### PR TITLE
Feature/profile refactor

### DIFF
--- a/autoarray/__init__.py
+++ b/autoarray/__init__.py
@@ -52,7 +52,8 @@ from .structures.grids.two_d.grid_2d_irregular import Grid2DIrregular
 from .structures.grids.two_d.grid_2d_irregular import Grid2DIrregularUniform
 from .structures.grids.two_d.grid_2d_pixelization import Grid2DRectangular
 from .structures.grids.two_d.grid_2d_pixelization import Grid2DVoronoi
-from .structures.vector_fields.vector_field_irregular import VectorField2DIrregular
+from .structures.vector_fields.uniform import VectorField2D
+from .structures.vector_fields.irregular import VectorField2DIrregular
 from .structures.grids import grid_decorators as grid_dec
 from .layout.region import Region1D
 from .layout.region import Region2D

--- a/autoarray/__init__.py
+++ b/autoarray/__init__.py
@@ -52,8 +52,8 @@ from .structures.grids.two_d.grid_2d_irregular import Grid2DIrregular
 from .structures.grids.two_d.grid_2d_irregular import Grid2DIrregularUniform
 from .structures.grids.two_d.grid_2d_pixelization import Grid2DRectangular
 from .structures.grids.two_d.grid_2d_pixelization import Grid2DVoronoi
-from .structures.vector_fields.uniform import VectorField2D
-from .structures.vector_fields.irregular import VectorField2DIrregular
+from .structures.vectors.uniform import VectorYX2D
+from .structures.vectors.irregular import VectorYX2DIrregular
 from .structures.grids import grid_decorators as grid_dec
 from .layout.region import Region1D
 from .layout.region import Region2D

--- a/autoarray/dataset/imaging.py
+++ b/autoarray/dataset/imaging.py
@@ -164,7 +164,7 @@ class Imaging(AbstractDataset):
         return self.psf_unormalized
 
     @cached_property
-    def blurring_grid(self):
+    def blurring_grid(self) -> Grid2D:
         """
         Returns a blurring-grid from a mask and the 2D shape of the PSF kernel.
 

--- a/autoarray/mock/mock_grid.py
+++ b/autoarray/mock/mock_grid.py
@@ -126,6 +126,13 @@ class MockGridLikeIteratorObj:
             grid=grid, radius=np.full(grid.shape[0], 2.0)
         )
 
+    @grid_decorators.grid_2d_to_vector_yx
+    @grid_decorators.grid_2d_to_structure
+    def ndarray_yx_2d_from(self, grid):
+        return self.grid_to_grid_cartesian(
+            grid=grid, radius=np.full(grid.shape[0], 2.0)
+        )
+
     @grid_decorators.grid_2d_to_structure_list
     def ndarray_1d_list_from(self, grid):
         grid_radii = self.grid_to_grid_radii(grid=grid)
@@ -180,15 +187,10 @@ class MockGrid2DLikeObj:
     def ndarray_2d_from(self, grid):
         return np.multiply(2.0, grid)
 
+    @grid_decorators.grid_2d_to_vector_yx
     @grid_decorators.grid_2d_to_structure
-    def ndarray_3d_from(self, grid):
-
-        ndarray = np.zeros((grid.shape[0], grid.shape[1], 2))
-
-        ndarray[:, :, 0] = 2.0 * grid
-        ndarray[:, :, 1] = 2.0 * grid
-
-        return ndarray
+    def ndarray_yx_2d_from(self, grid):
+        return 2.0 * grid
 
     @grid_decorators.grid_2d_to_structure_list
     def ndarray_1d_list_from(self, grid):

--- a/autoarray/mock/mock_grid.py
+++ b/autoarray/mock/mock_grid.py
@@ -180,6 +180,16 @@ class MockGrid2DLikeObj:
     def ndarray_2d_from(self, grid):
         return np.multiply(2.0, grid)
 
+    @grid_decorators.grid_2d_to_structure
+    def ndarray_3d_from(self, grid):
+
+        ndarray = np.zeros((grid.shape[0], grid.shape[1], 2))
+
+        ndarray[:, :, 0] = 2.0 * grid
+        ndarray[:, :, 1] = 2.0 * grid
+
+        return ndarray
+
     @grid_decorators.grid_2d_to_structure_list
     def ndarray_1d_list_from(self, grid):
         return [np.ones(shape=grid.shape[0]), 2.0 * np.ones(shape=grid.shape[0])]

--- a/autoarray/mock/mock_grid.py
+++ b/autoarray/mock/mock_grid.py
@@ -111,7 +111,13 @@ class MockGridLikeIteratorObj:
         return np.multiply(radius[:, None], np.vstack((sin_theta, cos_theta)).T)
 
     @grid_decorators.grid_2d_to_structure
-    def ndarray_1d_from(self, grid):
+    def ndarray_1d_from(self, grid) -> np.ndarray:
+        """
+        Mock function mimicking the behaviour of a class function which given an input 1D grid, returns a 1D ndarray
+        of shape [total_masked_grid_pixels].
+
+        Such functions are common in **PyAutoGalaxy** for light and mass profile objects.
+        """
         grid_radii = self.grid_to_grid_radii(grid=grid)
         return np.exp(
             np.multiply(
@@ -122,6 +128,12 @@ class MockGridLikeIteratorObj:
 
     @grid_decorators.grid_2d_to_structure
     def ndarray_2d_from(self, grid):
+        """
+        Mock function mimicking the behaviour of a class function which given an input grid, returns a 2D ndarray
+        of shape [total_masked_grid_pixels, 2].
+
+        Such functions are common in **PyAutoGalaxy** for light and mass profile objects.
+        """
         return self.grid_to_grid_cartesian(
             grid=grid, radius=np.full(grid.shape[0], 2.0)
         )
@@ -129,12 +141,24 @@ class MockGridLikeIteratorObj:
     @grid_decorators.grid_2d_to_vector_yx
     @grid_decorators.grid_2d_to_structure
     def ndarray_yx_2d_from(self, grid):
+        """
+        Mock function mimicking the behaviour of a class function which given an input grid, returns a 2D ndarray
+        of shape [total_masked_grid_pixels] which represents a vector field.
+
+        Such functions are common in **PyAutoGalaxy** for light and mass profile objects.
+        """
         return self.grid_to_grid_cartesian(
             grid=grid, radius=np.full(grid.shape[0], 2.0)
         )
 
     @grid_decorators.grid_2d_to_structure_list
     def ndarray_1d_list_from(self, grid):
+        """
+        Mock function mimicking the behaviour of a class function which given an input 1D grid, returns a list of 1D
+        ndarrays of shape [total_masked_grid_pixels].
+
+        Such functions are common in **PyAutoGalaxy** for light and mass profile objects.
+        """
         grid_radii = self.grid_to_grid_radii(grid=grid)
         return [
             np.exp(
@@ -147,6 +171,12 @@ class MockGridLikeIteratorObj:
 
     @grid_decorators.grid_2d_to_structure_list
     def ndarray_2d_list_from(self, grid):
+        """
+        Mock function mimicking the behaviour of a class function which given an input grid, returns a 2D list of
+        ndarrays of shape [total_masked_grid_pixels, 2].
+
+        Such functions are common in **PyAutoGalaxy** for light and mass profile objects.
+        """
         return [
             self.grid_to_grid_cartesian(grid=grid, radius=np.full(grid.shape[0], 2.0))
         ]
@@ -154,6 +184,12 @@ class MockGridLikeIteratorObj:
     @grid_decorators.grid_2d_to_vector_yx
     @grid_decorators.grid_2d_to_structure_list
     def ndarray_yx_2d_list_from(self, grid):
+        """
+        Mock function mimicking the behaviour of a class function which given an input grid, returns a list of 2D
+        ndarrays of shape [total_masked_grid_pixels] which represents a vector field.
+
+        Such functions are common in **PyAutoGalaxy** for light and mass profile objects.
+        """
         return [
             self.grid_to_grid_cartesian(grid=grid, radius=np.full(grid.shape[0], 2.0))
         ]
@@ -188,28 +224,64 @@ class MockGrid2DLikeObj:
 
     @grid_decorators.grid_2d_to_structure
     def ndarray_1d_from(self, grid):
+        """
+        Mock function mimicking the behaviour of a class function which given an input 1D grid, returns a 1D ndarray
+        of shape [total_masked_grid_pixels].
+
+        Such functions are common in **PyAutoGalaxy** for light and mass profile objects.
+        """
         return np.ones(shape=grid.shape[0])
 
     @grid_decorators.grid_2d_to_structure
     def ndarray_2d_from(self, grid):
+        """
+        Mock function mimicking the behaviour of a class function which given an input grid, returns a 2D ndarray
+        of shape [total_masked_grid_pixels, 2].
+
+        Such functions are common in **PyAutoGalaxy** for light and mass profile objects.
+        """
         return np.multiply(2.0, grid)
 
     @grid_decorators.grid_2d_to_vector_yx
     @grid_decorators.grid_2d_to_structure
     def ndarray_yx_2d_from(self, grid):
+        """
+        Mock function mimicking the behaviour of a class function which given an input grid, returns a 2D ndarray
+        of shape [total_masked_grid_pixels] which represents a vector field.
+
+        Such functions are common in **PyAutoGalaxy** for light and mass profile objects.
+        """
         return 2.0 * grid
 
     @grid_decorators.grid_2d_to_structure_list
     def ndarray_1d_list_from(self, grid):
+        """
+        Mock function mimicking the behaviour of a class function which given an input 1D grid, returns a list of 1D
+        ndarrays of shape [total_masked_grid_pixels].
+
+        Such functions are common in **PyAutoGalaxy** for light and mass profile objects.
+        """
         return [np.ones(shape=grid.shape[0]), 2.0 * np.ones(shape=grid.shape[0])]
 
     @grid_decorators.grid_2d_to_structure_list
     def ndarray_2d_list_from(self, grid):
+        """
+        Mock function mimicking the behaviour of a class function which given an input grid, returns a 2D list of
+        ndarrays of shape [total_masked_grid_pixels, 2].
+
+        Such functions are common in **PyAutoGalaxy** for light and mass profile objects.
+        """
         return [np.multiply(1.0, grid), np.multiply(2.0, grid)]
 
     @grid_decorators.grid_2d_to_vector_yx
     @grid_decorators.grid_2d_to_structure_list
     def ndarray_yx_2d_list_from(self, grid):
+        """
+        Mock function mimicking the behaviour of a class function which given an input grid, returns a list of 2D
+        ndarrays of shape [total_masked_grid_pixels] which represents a vector field.
+
+        Such functions are common in **PyAutoGalaxy** for light and mass profile objects.
+        """
         return [np.multiply(1.0, grid), np.multiply(2.0, grid)]
 
 

--- a/autoarray/mock/mock_grid.py
+++ b/autoarray/mock/mock_grid.py
@@ -221,5 +221,5 @@ class MockGridRadialMinimum:
         return np.sqrt(np.add(np.square(grid[:, 0]), np.square(grid[:, 1])))
 
     @grid_decorators.relocate_to_radial_minimum
-    def deflections_2d_from(self, grid):
+    def deflections_yx_2d_from(self, grid):
         return grid

--- a/autoarray/mock/mock_grid.py
+++ b/autoarray/mock/mock_grid.py
@@ -151,6 +151,13 @@ class MockGridLikeIteratorObj:
             self.grid_to_grid_cartesian(grid=grid, radius=np.full(grid.shape[0], 2.0))
         ]
 
+    @grid_decorators.grid_2d_to_vector_yx
+    @grid_decorators.grid_2d_to_structure_list
+    def ndarray_yx_2d_list_from(self, grid):
+        return [
+            self.grid_to_grid_cartesian(grid=grid, radius=np.full(grid.shape[0], 2.0))
+        ]
+
 
 class MockGrid1DLikeObj:
     def __init__(self, centre=(0.0, 0.0), angle=0.0):
@@ -198,6 +205,11 @@ class MockGrid2DLikeObj:
 
     @grid_decorators.grid_2d_to_structure_list
     def ndarray_2d_list_from(self, grid):
+        return [np.multiply(1.0, grid), np.multiply(2.0, grid)]
+
+    @grid_decorators.grid_2d_to_vector_yx
+    @grid_decorators.grid_2d_to_structure_list
+    def ndarray_yx_2d_list_from(self, grid):
         return [np.multiply(1.0, grid), np.multiply(2.0, grid)]
 
 

--- a/autoarray/plot/__init__.py
+++ b/autoarray/plot/__init__.py
@@ -23,7 +23,7 @@ from autoarray.plot.wrap.wrap_2d import ArrayOverlay
 from autoarray.plot.wrap.wrap_2d import GridScatter
 from autoarray.plot.wrap.wrap_2d import GridPlot
 from autoarray.plot.wrap.wrap_2d import GridErrorbar
-from autoarray.plot.wrap.wrap_2d import VectorFieldQuiver
+from autoarray.plot.wrap.wrap_2d import VectorYXQuiver
 from autoarray.plot.wrap.wrap_2d import PatchOverlay
 from autoarray.plot.wrap.wrap_2d import VoronoiDrawer
 from autoarray.plot.wrap.wrap_2d import OriginScatter

--- a/autoarray/plot/mat_wrap/mat_plot.py
+++ b/autoarray/plot/mat_wrap/mat_plot.py
@@ -424,7 +424,7 @@ class MatPlot2D(AbstractMatPlot):
         grid_scatter: w2d.GridScatter = w2d.GridScatter(),
         grid_plot: w2d.GridPlot = w2d.GridPlot(),
         grid_errorbar: w2d.GridErrorbar = w2d.GridErrorbar(),
-        vector_field_quiver: w2d.VectorFieldQuiver = w2d.VectorFieldQuiver(),
+        vectors_quiver: w2d.VectorFieldQuiver = w2d.VectorFieldQuiver(),
         patch_overlay: w2d.PatchOverlay = w2d.PatchOverlay(),
         voronoi_drawer: w2d.VoronoiDrawer = w2d.VoronoiDrawer(),
         origin_scatter: w2d.OriginScatter = w2d.OriginScatter(),
@@ -494,7 +494,7 @@ class MatPlot2D(AbstractMatPlot):
             Scatters a `Grid2D` of (y,x) coordinates over the figure using `plt.scatter`.
         grid_plot
             Plots lines of data (e.g. a y versus x plot via `plt.plot`, vertical lines via `plt.avxline`, etc.)
-        vector_field_quiver
+        vectors_quiver
             Plots a `VectorField` object using the matplotlib function `plt.quiver`.
         patch_overlay
             Overlays matplotlib `patches.Patch` objects over the figure, such as an `Ellipse`.
@@ -547,7 +547,7 @@ class MatPlot2D(AbstractMatPlot):
         self.positions_scatter = positions_scatter
         self.index_scatter = index_scatter
         self.pixelization_grid_scatter = pixelization_grid_scatter
-        self.vector_field_quiver = vector_field_quiver
+        self.vectors_quiver = vectors_quiver
         self.patch_overlay = patch_overlay
         self.array_overlay = array_overlay
         self.voronoi_drawer = voronoi_drawer

--- a/autoarray/plot/mat_wrap/mat_plot.py
+++ b/autoarray/plot/mat_wrap/mat_plot.py
@@ -34,21 +34,21 @@ class AutoLabels:
 class AbstractMatPlot:
     def __init__(
         self,
-        units: wb.Units = wb.Units(),
-        figure: wb.Figure = wb.Figure(),
-        axis: wb.Axis = wb.Axis(),
-        cmap: wb.Cmap = wb.Cmap(),
-        colorbar: wb.Colorbar = wb.Colorbar(),
-        colorbar_tickparams: wb.ColorbarTickParams = wb.ColorbarTickParams(),
-        tickparams: wb.TickParams = wb.TickParams(),
-        yticks: wb.YTicks = wb.YTicks(),
-        xticks: wb.XTicks = wb.XTicks(),
-        title: wb.Title = wb.Title(),
-        ylabel: wb.YLabel = wb.YLabel(),
-        xlabel: wb.XLabel = wb.XLabel(),
-        text: wb.Text = wb.Text(),
-        legend: wb.Legend = wb.Legend(),
-        output: wb.Output = wb.Output(),
+        units: Optional[wb.Units] = None, 
+        figure: Optional[wb.Figure] = None, 
+        axis: Optional[wb.Axis] = None, 
+        cmap: Optional[wb.Cmap] = None, 
+        colorbar: Optional[wb.Colorbar] = None, 
+        colorbar_tickparams: Optional[wb.ColorbarTickParams] = None, 
+        tickparams: Optional[wb.TickParams] = None, 
+        yticks: Optional[wb.YTicks] = None, 
+        xticks: Optional[wb.XTicks] = None, 
+        title: Optional[wb.Title] = None, 
+        ylabel: Optional[wb.YLabel] = None,
+        xlabel: Optional[wb.XLabel] = None, 
+        text: Optional[wb.Text] = None, 
+        legend: Optional[wb.Legend] = None, 
+        output: Optional[wb.Output] = None, 
     ):
         """
         Visualizes data structures (e.g an `Array2D`, `Grid2D`, `VectorField`, etc.) using Matplotlib.
@@ -103,21 +103,26 @@ class AbstractMatPlot:
             Sets if the figure is displayed on the user's screen or output to `.png` using `plt.show` and `plt.savefig`
         """
 
-        self.units = units
-        self.figure = figure
-        self.axis = axis
-        self.cmap = cmap
-        self.colorbar = colorbar
-        self.colorbar_tickparams = colorbar_tickparams
-        self.tickparams = tickparams
-        self.title = title
-        self.yticks = yticks
-        self.xticks = xticks
-        self.ylabel = ylabel
-        self.xlabel = xlabel
-        self.text = text
-        self.legend = legend
-        self.output = output
+        self.units = units or wb.Units()
+        self.figure = figure or wb.Figure()
+        self.axis = axis or wb.Axis()
+    
+        self.cmap = cmap or wb.Cmap()
+    
+        self.colorbar = colorbar or wb.Colorbar()
+        self.colorbar_tickparams = colorbar_tickparams or wb.ColorbarTickParams()
+    
+        self.tickparams = tickparams or wb.TickParams()
+        self.yticks = yticks or wb.YTicks()
+        self.xticks = xticks or wb.XTicks()
+
+        self.title = title or wb.Title()
+        self.ylabel = ylabel or wb.YLabel()
+        self.xlabel = xlabel or wb.XLabel()
+    
+        self.text = text or wb.Text()
+        self.legend = legend or wb.Legend()
+        self.output = output or wb.Output()
 
         self.number_subplots = None
         self.subplot_shape = None
@@ -195,25 +200,25 @@ class AbstractMatPlot:
 class MatPlot1D(AbstractMatPlot):
     def __init__(
         self,
-        units: wb.Units = wb.Units(),
-        figure: wb.Figure = wb.Figure(),
-        axis: wb.Axis = wb.Axis(),
-        cmap: wb.Cmap = wb.Cmap(),
-        colorbar: wb.Colorbar = wb.Colorbar(),
-        colorbar_tickparams: wb.ColorbarTickParams = wb.ColorbarTickParams(),
-        tickparams: wb.TickParams = wb.TickParams(),
-        yticks: wb.YTicks = wb.YTicks(),
-        xticks: wb.XTicks = wb.XTicks(),
-        title: wb.Title = wb.Title(),
-        ylabel: wb.YLabel = wb.YLabel(),
-        xlabel: wb.XLabel = wb.XLabel(),
-        text: wb.Text = wb.Text(),
-        legend: wb.Legend = wb.Legend(),
-        output: wb.Output = wb.Output(),
-        yx_plot: w1d.YXPlot = w1d.YXPlot(),
-        vertical_line_axvline: w1d.AXVLine = w1d.AXVLine(),
-        yx_scatter: w1d.YXPlot = w1d.YXScatter(),
-        fill_between: w1d.FillBetween = w1d.FillBetween(),
+        units: Optional[wb.Units] = None, 
+        figure: Optional[wb.Figure] = None, 
+        axis: Optional[wb.Axis] = None, 
+        cmap: Optional[wb.Cmap] = None, 
+        colorbar: Optional[wb.Colorbar] = None, 
+        colorbar_tickparams: Optional[wb.ColorbarTickParams] = None, 
+        tickparams: Optional[wb.TickParams] = None, 
+        yticks: Optional[wb.YTicks] = None, 
+        xticks: Optional[wb.XTicks] = None, 
+        title: Optional[wb.Title] = None, 
+        ylabel: Optional[wb.YLabel] = None,
+        xlabel: Optional[wb.XLabel] = None, 
+        text: Optional[wb.Text] = None, 
+        legend: Optional[wb.Legend] = None, 
+        output: Optional[wb.Output] = None, 
+        yx_plot: Optional[w1d.YXPlot] = None, 
+        vertical_line_axvline: Optional[w1d.AXVLine] = None, 
+        yx_scatter: Optional[w1d.YXPlot] = None, 
+        fill_between: Optional[w1d.FillBetween] = None, 
     ):
         """
         Visualizes 1D data structures (e.g a `Line`, etc.) using Matplotlib.
@@ -285,10 +290,10 @@ class MatPlot1D(AbstractMatPlot):
             output=output,
         )
 
-        self.yx_plot = yx_plot
-        self.vertical_line_axvline = vertical_line_axvline
-        self.yx_scatter = yx_scatter
-        self.fill_between = fill_between
+        self.yx_plot = yx_plot or w1d.YXPlot()
+        self.vertical_line_axvline = vertical_line_axvline or w1d.AXVLine()
+        self.yx_scatter = yx_scatter or w1d.YXScatter()
+        self.fill_between = fill_between or w1d.FillBetween()
 
         self.is_for_multi_plot = False
         self.is_for_subplot = False
@@ -405,37 +410,37 @@ class MatPlot1D(AbstractMatPlot):
 class MatPlot2D(AbstractMatPlot):
     def __init__(
         self,
-        units: wb.Units = wb.Units(),
-        figure: wb.Figure = wb.Figure(),
-        axis: wb.Axis = wb.Axis(),
-        cmap: wb.Cmap = wb.Cmap(),
-        colorbar: wb.Colorbar = wb.Colorbar(),
-        colorbar_tickparams: wb.ColorbarTickParams = wb.ColorbarTickParams(),
-        tickparams: wb.TickParams = wb.TickParams(),
-        yticks: wb.YTicks = wb.YTicks(),
-        xticks: wb.XTicks = wb.XTicks(),
-        title: wb.Title = wb.Title(),
-        ylabel: wb.YLabel = wb.YLabel(),
-        xlabel: wb.XLabel = wb.XLabel(),
-        legend: wb.Legend = wb.Legend(),
-        text: wb.Text = wb.Text(),
-        output: wb.Output = wb.Output(),
-        array_overlay: w2d.ArrayOverlay = w2d.ArrayOverlay(),
-        grid_scatter: w2d.GridScatter = w2d.GridScatter(),
-        grid_plot: w2d.GridPlot = w2d.GridPlot(),
-        grid_errorbar: w2d.GridErrorbar = w2d.GridErrorbar(),
-        vectors_quiver: w2d.VectorFieldQuiver = w2d.VectorFieldQuiver(),
-        patch_overlay: w2d.PatchOverlay = w2d.PatchOverlay(),
-        voronoi_drawer: w2d.VoronoiDrawer = w2d.VoronoiDrawer(),
-        origin_scatter: w2d.OriginScatter = w2d.OriginScatter(),
-        mask_scatter: w2d.MaskScatter = w2d.MaskScatter(),
-        border_scatter: w2d.BorderScatter = w2d.BorderScatter(),
-        positions_scatter: w2d.PositionsScatter = w2d.PositionsScatter(),
-        index_scatter: w2d.IndexScatter = w2d.IndexScatter(),
-        pixelization_grid_scatter: w2d.PixelizationGridScatter = w2d.PixelizationGridScatter(),
-        parallel_overscan_plot: w2d.ParallelOverscanPlot = w2d.ParallelOverscanPlot(),
-        serial_prescan_plot: w2d.SerialPrescanPlot = w2d.SerialPrescanPlot(),
-        serial_overscan_plot: w2d.SerialOverscanPlot = w2d.SerialOverscanPlot(),
+        units: Optional[wb.Units] = None, 
+        figure: Optional[wb.Figure] = None, 
+        axis: Optional[wb.Axis] = None, 
+        cmap: Optional[wb.Cmap] = None, 
+        colorbar: Optional[wb.Colorbar] = None, 
+        colorbar_tickparams: Optional[wb.ColorbarTickParams] = None, 
+        tickparams: Optional[wb.TickParams] = None, 
+        yticks: Optional[wb.YTicks] = None, 
+        xticks: Optional[wb.XTicks] = None, 
+        title: Optional[wb.Title] = None, 
+        ylabel: Optional[wb.YLabel] = None,
+        xlabel: Optional[wb.XLabel] = None, 
+        text: Optional[wb.Text] = None, 
+        legend: Optional[wb.Legend] = None, 
+        output: Optional[wb.Output] = None, 
+        array_overlay: Optional[w2d.ArrayOverlay] = None, 
+        grid_scatter: Optional[w2d.GridScatter] = None, 
+        grid_plot: Optional[w2d.GridPlot] = None, 
+        grid_errorbar: Optional[w2d.GridErrorbar] = None, 
+        vector_yx_quiver: Optional[w2d.VectorYXQuiver] = None,
+        patch_overlay: Optional[w2d.PatchOverlay] = None, 
+        voronoi_drawer: Optional[w2d.VoronoiDrawer] = None, 
+        origin_scatter: Optional[w2d.OriginScatter] = None, 
+        mask_scatter: Optional[w2d.MaskScatter] = None, 
+        border_scatter: Optional[w2d.BorderScatter] = None, 
+        positions_scatter: Optional[w2d.PositionsScatter] = None, 
+        index_scatter: Optional[w2d.IndexScatter] = None, 
+        pixelization_grid_scatter: Optional[w2d.PixelizationGridScatter] = None, 
+        parallel_overscan_plot: Optional[w2d.ParallelOverscanPlot] = None, 
+        serial_prescan_plot: Optional[w2d.SerialPrescanPlot] = None, 
+        serial_overscan_plot: Optional[w2d.SerialOverscanPlot] = None, 
     ):
         """
         Visualizes 2D data structures (e.g an `Array2D`, `Grid2D`, `VectorField`, etc.) using Matplotlib.
@@ -494,7 +499,7 @@ class MatPlot2D(AbstractMatPlot):
             Scatters a `Grid2D` of (y,x) coordinates over the figure using `plt.scatter`.
         grid_plot
             Plots lines of data (e.g. a y versus x plot via `plt.plot`, vertical lines via `plt.avxline`, etc.)
-        vectors_quiver
+        vector_yx_quiver
             Plots a `VectorField` object using the matplotlib function `plt.quiver`.
         patch_overlay
             Overlays matplotlib `patches.Patch` objects over the figure, such as an `Ellipse`.
@@ -538,22 +543,28 @@ class MatPlot2D(AbstractMatPlot):
             output=output,
         )
 
-        self.origin_scatter = origin_scatter
-        self.mask_scatter = mask_scatter
-        self.border_scatter = border_scatter
-        self.grid_scatter = grid_scatter
-        self.grid_plot = grid_plot
-        self.grid_errorbar = grid_errorbar
-        self.positions_scatter = positions_scatter
-        self.index_scatter = index_scatter
-        self.pixelization_grid_scatter = pixelization_grid_scatter
-        self.vectors_quiver = vectors_quiver
-        self.patch_overlay = patch_overlay
-        self.array_overlay = array_overlay
-        self.voronoi_drawer = voronoi_drawer
-        self.parallel_overscan_plot = parallel_overscan_plot
-        self.serial_prescan_plot = serial_prescan_plot
-        self.serial_overscan_plot = serial_overscan_plot
+
+        self.array_overlay = array_overlay or w2d.ArrayOverlay()
+
+        self.grid_scatter = grid_scatter or w2d.GridScatter()
+        self.grid_plot = grid_plot or w2d.GridPlot()
+        self.grid_errorbar = grid_errorbar or w2d.GridErrorbar()
+
+        self.vector_yx_quiver = vector_yx_quiver or w2d.VectorYXQuiver()
+        self.patch_overlay = patch_overlay or w2d.PatchOverlay()
+
+        self.voronoi_drawer = voronoi_drawer or w2d.VoronoiDrawer()
+
+        self.origin_scatter = origin_scatter or w2d.OriginScatter()
+        self.mask_scatter = mask_scatter or w2d.MaskScatter()
+        self.border_scatter = border_scatter or w2d.BorderScatter()
+        self.positions_scatter = positions_scatter or w2d.PositionsScatter()
+        self.index_scatter = index_scatter or w2d.IndexScatter()
+        self.pixelization_grid_scatter = pixelization_grid_scatter or w2d.PixelizationGridScatter()
+
+        self.parallel_overscan_plot = parallel_overscan_plot or w2d.ParallelOverscanPlot()
+        self.serial_prescan_plot = serial_prescan_plot or w2d.SerialPrescanPlot()
+        self.serial_overscan_plot = serial_overscan_plot or w2d.SerialOverscanPlot()
 
         self.is_for_subplot = False
 

--- a/autoarray/plot/mat_wrap/visuals.py
+++ b/autoarray/plot/mat_wrap/visuals.py
@@ -10,9 +10,7 @@ from autoarray.structures.grids.two_d.grid_2d import Grid2D
 from autoarray.structures.grids.two_d.grid_2d_irregular import Grid2DIrregular
 from autoarray.mask.mask_1d import Mask1D
 from autoarray.mask.mask_2d import Mask2D
-from autoarray.structures.vector_fields.vector_field_irregular import (
-    VectorField2DIrregular,
-)
+from autoarray.structures.vector_fields.irregular import VectorField2DIrregular
 from autoarray.plot.mat_wrap.include import Include1D
 
 

--- a/autoarray/plot/mat_wrap/visuals.py
+++ b/autoarray/plot/mat_wrap/visuals.py
@@ -104,16 +104,16 @@ class Visuals1D(AbstractVisuals):
 class Visuals2D(AbstractVisuals):
     def __init__(
         self,
-        origin: Grid2D = None,
-        mask: Mask2D = None,
-        border: Grid2D = None,
-        lines: List[Array1D] = None,
-        positions: Union[Grid2DIrregular, List[Grid2DIrregular]] = None,
-        grid: Grid2D = None,
-        pixelization_grid: Grid2D = None,
-        vectors: VectorYX2DIrregular = None,
-        patches: List[ptch.Patch] = None,
-        array_overlay: Array2D = None,
+        origin: Optional[Grid2D] = None,
+        mask: Optional[Mask2D] = None,
+        border: Optional[Grid2D] = None,
+        lines: Optional[List[Array1D]] = None,
+        positions: Optional[Union[Grid2DIrregular, List[Grid2DIrregular]]] = None,
+        grid: Optional[Grid2D] = None,
+        pixelization_grid: Optional[Grid2D] = None,
+        vectors: Optional[VectorYX2DIrregular] = None,
+        patches: Optional[List[ptch.Patch]] = None,
+        array_overlay: Optional[Array2D] = None,
         parallel_overscan=None,
         serial_prescan=None,
         serial_overscan=None,
@@ -158,7 +158,7 @@ class Visuals2D(AbstractVisuals):
             plotter.positions_scatter.scatter_grid(grid=self.positions)
 
         if self.vectors is not None:
-            plotter.vectors_quiver.quiver_vectors(vectors=self.vectors)
+            plotter.vector_yx_quiver.quiver_vectors(vectors=self.vectors)
 
         if self.patches is not None:
             plotter.patch_overlay.overlay_patches(patches=self.patches)

--- a/autoarray/plot/mat_wrap/visuals.py
+++ b/autoarray/plot/mat_wrap/visuals.py
@@ -10,7 +10,7 @@ from autoarray.structures.grids.two_d.grid_2d import Grid2D
 from autoarray.structures.grids.two_d.grid_2d_irregular import Grid2DIrregular
 from autoarray.mask.mask_1d import Mask1D
 from autoarray.mask.mask_2d import Mask2D
-from autoarray.structures.vector_fields.irregular import VectorField2DIrregular
+from autoarray.structures.vectors.irregular import VectorYX2DIrregular
 from autoarray.plot.mat_wrap.include import Include1D
 
 
@@ -111,7 +111,7 @@ class Visuals2D(AbstractVisuals):
         positions: Union[Grid2DIrregular, List[Grid2DIrregular]] = None,
         grid: Grid2D = None,
         pixelization_grid: Grid2D = None,
-        vector_field: VectorField2DIrregular = None,
+        vectors: VectorYX2DIrregular = None,
         patches: List[ptch.Patch] = None,
         array_overlay: Array2D = None,
         parallel_overscan=None,
@@ -128,7 +128,7 @@ class Visuals2D(AbstractVisuals):
         self.positions = positions
         self.grid = grid
         self.pixelization_grid = pixelization_grid
-        self.vector_field = vector_field
+        self.vectors = vectors
         self.patches = patches
         self.array_overlay = array_overlay
         self.parallel_overscan = parallel_overscan
@@ -157,10 +157,8 @@ class Visuals2D(AbstractVisuals):
         if self.positions is not None:
             plotter.positions_scatter.scatter_grid(grid=self.positions)
 
-        if self.vector_field is not None:
-            plotter.vector_field_quiver.quiver_vector_field(
-                vector_field=self.vector_field
-            )
+        if self.vectors is not None:
+            plotter.vectors_quiver.quiver_vectors(vectors=self.vectors)
 
         if self.patches is not None:
             plotter.patch_overlay.overlay_patches(patches=self.patches)

--- a/autoarray/plot/wrap/__init__.py
+++ b/autoarray/plot/wrap/__init__.py
@@ -20,7 +20,7 @@ from .wrap_2d import (
     ArrayOverlay,
     GridScatter,
     GridPlot,
-    VectorFieldQuiver,
+    VectorYXQuiver,
     PatchOverlay,
     VoronoiDrawer,
     OriginScatter,

--- a/autoarray/plot/wrap/wrap_2d.py
+++ b/autoarray/plot/wrap/wrap_2d.py
@@ -434,7 +434,7 @@ class GridErrorbar(AbstractMatWrap2D):
         )
 
 
-class VectorFieldQuiver(AbstractMatWrap2D):
+class VectorYXQuiver(AbstractMatWrap2D):
     """
     Plots a `VectorField` data structure. A vector field is a set of 2D vectors on a grid of 2d (y,x) coordinates.
     These are plotted as arrows representing the (y,x) components of each vector at each (y,x) coordinate of it

--- a/autoarray/plot/wrap/wrap_2d.py
+++ b/autoarray/plot/wrap/wrap_2d.py
@@ -15,9 +15,7 @@ from autoarray.plot.wrap.wrap_base import AbstractMatWrap
 from autoarray.inversion.mappers.voronoi import MapperVoronoi
 from autoarray.structures.grids.two_d.grid_2d import Grid2D
 from autoarray.structures.grids.two_d.grid_2d_irregular import Grid2DIrregular
-from autoarray.structures.vector_fields.vector_field_irregular import (
-    VectorField2DIrregular,
-)
+from autoarray.structures.vector_fields.irregular import VectorField2DIrregular
 
 from autoarray import exc
 

--- a/autoarray/plot/wrap/wrap_2d.py
+++ b/autoarray/plot/wrap/wrap_2d.py
@@ -15,7 +15,7 @@ from autoarray.plot.wrap.wrap_base import AbstractMatWrap
 from autoarray.inversion.mappers.voronoi import MapperVoronoi
 from autoarray.structures.grids.two_d.grid_2d import Grid2D
 from autoarray.structures.grids.two_d.grid_2d_irregular import Grid2DIrregular
-from autoarray.structures.vector_fields.irregular import VectorField2DIrregular
+from autoarray.structures.vectors.irregular import VectorYX2DIrregular
 
 from autoarray import exc
 
@@ -445,21 +445,21 @@ class VectorFieldQuiver(AbstractMatWrap2D):
     https://matplotlib.org/3.3.2/api/_as_gen/matplotlib.pyplot.quiver.html
     """
 
-    def quiver_vector_field(self, vector_field: VectorField2DIrregular):
+    def quiver_vectors(self, vectors: VectorYX2DIrregular):
         """
          Plot a vector field using the matplotlib method `plt.quiver` such that each vector appears as an arrow whose
          direction depends on the y and x magnitudes of the vector.
 
          Parameters
          ----------
-         vector_field : VectorField2DIrregular
+         vectors : VectorYX2DIrregular
              The vector field that is plotted using `plt.quiver`.
          """
         plt.quiver(
-            vector_field.grid[:, 1],
-            vector_field.grid[:, 0],
-            vector_field[:, 1],
-            vector_field[:, 0],
+            vectors.grid[:, 1],
+            vectors.grid[:, 0],
+            vectors[:, 1],
+            vectors[:, 0],
             **self.config_dict,
         )
 

--- a/autoarray/preloads.py
+++ b/autoarray/preloads.py
@@ -18,7 +18,7 @@ class Preloads:
         self,
         w_tilde=None,
         use_w_tilde=None,
-        sparse_image_plane_grid_list_of_planes=None,
+        sparse_image_plane_grid_pg_list=None,
         relocated_grid=None,
         mapper_list=None,
         operated_mapping_matrix=None,
@@ -31,8 +31,8 @@ class Preloads:
         self.w_tilde = w_tilde
         self.use_w_tilde = use_w_tilde
 
-        self.sparse_image_plane_grid_list_of_planes = (
-            sparse_image_plane_grid_list_of_planes
+        self.sparse_image_plane_grid_pg_list = (
+            sparse_image_plane_grid_pg_list
         )
         self.relocated_grid = relocated_grid
         self.mapper_list = mapper_list
@@ -324,7 +324,7 @@ class Preloads:
 
         self.blurred_image = None
         self.traced_grids_of_planes_for_inversion = None
-        self.sparse_image_plane_grid_list_of_planes = None
+        self.sparse_image_plane_grid_pg_list = None
         self.relocated_grid = None
         self.mapper_list = None
         self.operated_mapping_matrix = None

--- a/autoarray/structures/arrays/two_d/array_2d.py
+++ b/autoarray/structures/arrays/two_d/array_2d.py
@@ -11,6 +11,8 @@ from autoarray.geometry import geometry_util
 from autoarray.structures.arrays.two_d import array_2d_util
 from autoarray.structures.grids.two_d import grid_2d_util
 
+from autoarray import type as ty
+
 logging.basicConfig()
 logger = logging.getLogger(__name__)
 

--- a/autoarray/structures/arrays/two_d/array_2d.py
+++ b/autoarray/structures/arrays/two_d/array_2d.py
@@ -575,3 +575,6 @@ class Array2D(AbstractArray2D):
             sub_size=sub_size,
             header=header,
         )
+
+    def apply_mask(self, mask: Mask2D):
+        return Array2D.manual_mask(array=self.native, mask=mask, header=self.header)

--- a/autoarray/structures/arrays/two_d/array_2d.py
+++ b/autoarray/structures/arrays/two_d/array_2d.py
@@ -27,7 +27,7 @@ class Array2D(AbstractArray2D):
         The array can be stored in 1D or 2D, as detailed below.
 
         Case 1: [sub-size=1, slim]:
-        -----------------------------------------
+        ---------------------------
 
         The Array2D is an ndarray of shape [total_unmasked_pixels].
 

--- a/autoarray/structures/grids/grid_decorators.py
+++ b/autoarray/structures/grids/grid_decorators.py
@@ -3,6 +3,7 @@ from functools import wraps
 from typing import List, Optional, Union
 
 from autoconf import conf
+from autoarray.mask.mask_2d import Mask2D
 from autoarray.structures.arrays.one_d.array_1d import Array1D
 from autoarray.structures.arrays.two_d.array_2d import Array2D
 from autoarray.structures.grids.one_d.abstract_grid_1d import AbstractGrid1D
@@ -377,8 +378,10 @@ def grid_2d_to_vector_yx(func):
 
         if isinstance(grid, Grid2DIrregular):
             return VectorYX2DIrregular(vectors=vector_yx_2d, grid=grid)
-        else:
+        try:
             return VectorYX2D(vectors=vector_yx_2d, grid=grid, mask=grid.mask)
+        except AttributeError:
+            return vector_yx_2d
 
     return wrapper
 

--- a/autoarray/structures/grids/grid_decorators.py
+++ b/autoarray/structures/grids/grid_decorators.py
@@ -15,6 +15,8 @@ from autoarray.structures.grids.two_d.grid_2d_irregular import Grid2DIrregular
 from autoarray.structures.grids.two_d.grid_2d_irregular import (
     Grid2DIrregularTransformed,
 )
+from autoarray.structures.vectors.uniform import VectorYX2D
+from autoarray.structures.vectors.irregular import VectorYX2DIrregular
 from autoarray.structures.arrays.values import ValuesIrregular
 
 from autoarray import exc
@@ -32,7 +34,7 @@ def grid_1d_to_structure(func):
 
     Returns
     -------
-        A function that can except cartesian or transformed coordinates
+        A function that can accept cartesian or transformed coordinates
     """
 
     @wraps(func)
@@ -124,7 +126,7 @@ def grid_1d_output_structure(func):
 
     Returns
     -------
-        A function that can except cartesian or transformed coordinates
+        A function that can accept cartesian or transformed coordinates
     """
 
     @wraps(func)
@@ -180,7 +182,7 @@ def grid_2d_to_structure(func):
 
     Returns
     -------
-        A function that can except cartesian or transformed coordinates
+        A function that can accept cartesian or transformed coordinates
     """
 
     @wraps(func)
@@ -257,7 +259,7 @@ def grid_2d_to_structure_list(func):
 
     Returns
     -------
-        A function that can except cartesian or transformed coordinates
+        A function that can accept cartesian or transformed coordinates
     """
 
     @wraps(func)
@@ -313,6 +315,142 @@ def grid_2d_to_structure_list(func):
     return wrapper
 
 
+def grid_2d_to_vector_yx(func):
+    """
+    Homogenize the inputs and outputs of functions that take 2D grids of (y,x) coordinates that return the results
+    as a NumPy array which represents a (y,x) 2D vectors.
+
+    Parameters
+    ----------
+    func
+        A function which computes (y,x) 2D vectors from a 2D grid of (y,x) coordinates.
+
+    Returns
+    -------
+        A function that can accept cartesian or transformed coordinates
+    """
+
+    @wraps(func)
+    def wrapper(
+        obj: object,
+        grid: Union[np.ndarray, Grid2D, Grid2DIterate, Grid2DIrregular, Grid1D],
+        *args,
+        **kwargs
+    ) -> Union[np.ndarray, Array2D, ValuesIrregular, Grid2D, Grid2DIrregular]:
+        """
+        This decorator homogenizes the input of a "grid_like" 2D vector_yx (`Grid2D`, `Grid2DIterate`,
+        `Grid2DIrregular` or `AbstractGrid1D`) into a function. It allows these classes to be
+        interchangeably input into a function, such that the grid is used to evaluate the function at every (y,x)
+        coordinates of the grid using specific functionality of the input grid.
+
+        The grid_like objects `Grid2D` and `Grid2DIrregular` are input into the function as a slimmed 2D NumPy array
+        of shape [total_coordinates, 2] where the second dimension stores the (y,x)  If a `Grid2DIterate` is
+        input, the function is evaluated using the appropriate `iterated_from` function.
+
+        The outputs of the function are converted from a 1D or 2D NumPy Array2D to an `Array2D`, `Grid2D`,
+        `ValuesIrregular` or `Grid2DIrregular` objects, whichever is applicable as follows:
+
+        - If the function returns (y,x) coordinates at every input point, the returned results are a `Grid2D`
+        or `Grid2DIrregular` vector_yx, the same vector_yx as the input.
+
+        - If the function returns scalar values at every input point and a `Grid2D` is input, the returned results are
+        an `Array2D` vector_yx which uses the same dimensions and mask as the `Grid2D`.
+
+        - If the function returns scalar values at every input point and `Grid2DIrregular` are input, the returned
+        results are a `ValuesIrregular` object with vector_yx resembling that of the `Grid2DIrregular`.
+
+        If the input array is not a `Grid2D` vector_yx (e.g. it is a 2D NumPy array) the output is a NumPy array.
+
+        Parameters
+        ----------
+        obj
+            An object whose function uses grid_like inputs to compute quantities at every coordinate on the grid.
+        grid : Grid2D or Grid2DIrregular
+            A grid_like object of (y,x) coordinates on which the function values are evaluated.
+
+        Returns
+        -------
+            The function values evaluated on the grid with the same vector_yx as the input grid_like object.
+        """
+
+        vector_yx_2d = func(obj, grid, *args, **kwargs)
+
+        if isinstance(grid, Grid2DIrregular):
+            return VectorYX2DIrregular(vectors=vector_yx_2d, grid=grid)
+        else:
+            return VectorYX2D(vectors=vector_yx_2d, grid=grid, mask=grid.mask)
+
+    return wrapper
+
+
+def grid_2d_to_vector_yx_list(func):
+    """
+    Homogenize the inputs and outputs of functions that take 2D grids of (y,x) coordinates and return the results as
+    a list of NumPy arrays.
+
+    Parameters
+    ----------
+    func
+        A function which computes a set of values from a 2D grid of (y,x) coordinates.
+
+    Returns
+    -------
+        A function that can accept cartesian or transformed coordinates
+    """
+
+    @wraps(func)
+    def wrapper(
+        obj: object,
+        grid: List[Union[np.ndarray, Grid2D, Grid2DIterate, Grid2DIrregular, Grid1D]],
+        *args,
+        **kwargs
+    ) -> List[Union[np.ndarray, Array2D, ValuesIrregular, Grid2D, Grid2DIrregular]]:
+        """
+        This decorator serves the same purpose as the `grid_2d_to_vector_yx` decorator, but it deals with functions
+        whose output is a list of results as opposed to a single NumPy array. It simply iterates over these lists to
+        perform the same conversions as `grid_2d_to_vector_yx`.
+
+        Parameters
+        ----------
+        obj
+            An object whose function uses grid_like inputs to compute quantities at every coordinate on the grid.
+        grid : Grid2D or Grid2DIrregular
+            A grid_like object of (y,x) coordinates on which the function values are evaluated.
+
+        Returns
+        -------
+            The function values evaluated on the grid with the same vector_yx as the input grid_like object in a list
+            of NumPy arrays.
+        """
+
+        if isinstance(grid, Grid2DIterate):
+            mask = grid.mask.mask_new_sub_size_from(
+                mask=grid.mask, sub_size=max(grid.sub_steps)
+            )
+            grid_compute = Grid2D.from_mask(mask=mask)
+            result_list = func(obj, grid_compute, *args, **kwargs)
+            result_list = [
+                grid_compute.vector_yx_2d_from(result=result) for result in result_list
+            ]
+            result_list = [result.binned for result in result_list]
+            return grid.grid.vector_yx_2d_list_from(result_list=result_list)
+        elif isinstance(grid, Grid2DIrregular):
+            result_list = func(obj, grid, *args, **kwargs)
+            return grid.vector_yx_2d_list_from(result_list=result_list)
+        elif isinstance(grid, Grid2D):
+            result_list = func(obj, grid, *args, **kwargs)
+            return grid.vector_yx_2d_list_from(result_list=result_list)
+        elif isinstance(grid, AbstractGrid1D):
+            grid_2d_radial = grid.project_to_radial_grid_2d()
+            result_list = func(obj, grid_2d_radial, *args, **kwargs)
+            return grid.vector_yx_2d_list_from(result_list=result_list)
+
+        if not isinstance(grid, Grid2DIrregular) and not isinstance(grid, Grid2D):
+            return func(obj, grid, *args, **kwargs)
+
+    return wrapper
+
+
 def transform(func):
     """
     Checks whether the input Grid2D of (y,x) coordinates have previously been transformed. If they have not \
@@ -325,7 +463,7 @@ def transform(func):
 
     Returns
     -------
-        A function that can except cartesian or transformed coordinates
+        A function that can accept cartesian or transformed coordinates
     """
 
     @wraps(func)
@@ -396,7 +534,7 @@ def relocate_to_radial_minimum(func):
 
     Returns
     -------
-        A function that can except cartesian or transformed coordinates
+        A function that can accept cartesian or transformed coordinates
     """
 
     @wraps(func)

--- a/autoarray/structures/grids/two_d/grid_2d.py
+++ b/autoarray/structures/grids/two_d/grid_2d.py
@@ -17,6 +17,7 @@ from autoarray.geometry import geometry_util
 from autoarray.mask.mask_2d import mask_2d_util
 from autoarray.structures.grids.two_d import sparse_util
 
+from autoarray import type as ty
 
 class Grid2D(AbstractGrid2D):
     def __new__(cls, grid: np.ndarray, mask: Mask2D, *args, **kwargs):
@@ -237,7 +238,7 @@ class Grid2D(AbstractGrid2D):
         cls,
         grid: Union[np.ndarray, List],
         shape_native: Tuple[int, int],
-        pixel_scales: Union[Tuple[float, float], float],
+        pixel_scales: ty.PixelScales,
         sub_size: int = 1,
         origin: Tuple[float, float] = (0.0, 0.0),
     ) -> "Grid2D":
@@ -284,7 +285,7 @@ class Grid2D(AbstractGrid2D):
     def manual_native(
         cls,
         grid: Union[np.ndarray, List],
-        pixel_scales: Union[Tuple[float, float], float],
+        pixel_scales: ty.PixelScales,
         sub_size: int = 1,
         origin: Tuple[float, float] = (0.0, 0.0),
     ) -> "Grid2D":
@@ -335,7 +336,7 @@ class Grid2D(AbstractGrid2D):
     def manual(
         cls,
         grid: Union[np.ndarray, List],
-        pixel_scales: Union[Tuple[float, float], float],
+        pixel_scales: ty.PixelScales,
         shape_native: Tuple[int, int] = None,
         sub_size: int = 1,
         origin: Tuple[float, float] = (0.0, 0.0),
@@ -403,7 +404,7 @@ class Grid2D(AbstractGrid2D):
         y: Union[np.ndarray, List],
         x: np.ndarray,
         shape_native: Tuple[int, int],
-        pixel_scales: Union[Tuple[float, float], float],
+        pixel_scales: ty.PixelScales,
         sub_size: int = 1,
         origin: Tuple[float, float] = (0.0, 0.0),
     ) -> "Grid2D":
@@ -453,7 +454,7 @@ class Grid2D(AbstractGrid2D):
         cls,
         y: Union[np.ndarray, List],
         x: Union[np.ndarray, List],
-        pixel_scales: Union[Tuple[float, float], float],
+        pixel_scales: ty.PixelScales,
         sub_size: int = 1,
         origin: Tuple[float, float] = (0.0, 0.0),
     ) -> "Grid2D":
@@ -623,7 +624,7 @@ class Grid2D(AbstractGrid2D):
     def from_fits(
         cls,
         file_path: str,
-        pixel_scales: Union[Tuple[float, float], float],
+        pixel_scales: ty.PixelScales,
         sub_size: int = 1,
         origin: Tuple[float, float] = (0.0, 0.0),
     ) -> "Grid2D":

--- a/autoarray/structures/grids/two_d/grid_2d_iterate.py
+++ b/autoarray/structures/grids/two_d/grid_2d_iterate.py
@@ -779,7 +779,7 @@ class Grid2DIterate(AbstractGrid2D):
         If the function return all zeros, the iteration is terminated early given that all levels of sub-gridding will
         return zeros. This occurs when a function is missing optional objects that contribute to the calculation.
 
-        An example use case of this function is when a "deflections_2d_from" methods in **PyAutoLens**'s `MassProfile`
+        An example use case of this function is when a "deflections_yx_2d_from" methods in **PyAutoLens**'s `MassProfile`
         module is computed, which by evaluating the function on a higher resolution sub-grid samples the analytic
         mass profile at more points and thus more precisely.
 

--- a/autoarray/structures/grids/two_d/grid_2d_iterate.py
+++ b/autoarray/structures/grids/two_d/grid_2d_iterate.py
@@ -14,6 +14,7 @@ from autoarray import numba_util
 from autoarray.geometry import geometry_util
 from autoarray.structures.grids.two_d import grid_2d_util
 
+from autoarray import type as ty
 
 def sub_steps_from(sub_steps):
 
@@ -124,7 +125,7 @@ class Grid2DIterate(AbstractGrid2D):
         cls,
         grid: Union[np.ndarray, List],
         shape_native: Tuple[int, int],
-        pixel_scales: Union[Tuple[float, float], float],
+        pixel_scales: ty.PixelScales,
         origin: Tuple[float, float] = (0.0, 0.0),
         fractional_accuracy: float = 0.9999,
         relative_accuracy: Optional[float] = None,
@@ -186,7 +187,7 @@ class Grid2DIterate(AbstractGrid2D):
     def uniform(
         cls,
         shape_native: Tuple[int, int],
-        pixel_scales: Union[Tuple[float, float], float],
+        pixel_scales: ty.PixelScales,
         origin: Tuple[float, float] = (0.0, 0.0),
         fractional_accuracy: float = 0.9999,
         relative_accuracy: Optional[float] = None,

--- a/autoarray/structures/grids/two_d/grid_2d_pixelization.py
+++ b/autoarray/structures/grids/two_d/grid_2d_pixelization.py
@@ -12,6 +12,7 @@ from autoarray import exc
 from autoarray.structures.grids.two_d import grid_2d_util
 from autoarray.inversion.pixelizations import pixelization_util
 
+from autoarray import type as ty
 
 class PixelNeighbors(np.ndarray):
     def __new__(cls, arr: np.ndarray, sizes: np.ndarray):
@@ -60,7 +61,7 @@ class Grid2DRectangular(AbstractStructure2D):
         cls,
         grid: np.ndarray,
         shape_native: Tuple[int, int],
-        pixel_scales: Union[Tuple[float, float], float],
+        pixel_scales: ty.PixelScales,
         origin: Tuple[float, float] = (0.0, 0.0),
         *args,
         **kwargs

--- a/autoarray/structures/vector_fields/abstract.py
+++ b/autoarray/structures/vector_fields/abstract.py
@@ -1,0 +1,135 @@
+import logging
+import numpy as np
+from typing import List, Tuple, Union
+
+from autoarray.structures.arrays.two_d.array_2d import Array2D
+from autoarray.structures.grids.two_d.grid_2d import Grid2D
+from autoarray.structures.arrays.values import ValuesIrregular
+
+from autoarray import exc
+from autoarray.structures.arrays.two_d import array_2d_util
+from autoarray.structures.grids.two_d import grid_2d_util
+
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+
+
+class AbstractVectorField2D(np.ndarray):
+    def __array_finalize__(self, obj):
+
+        if hasattr(obj, "mask"):
+            self.mask = obj.mask
+
+        if hasattr(obj, "grid"):
+            self.grid = obj.grid
+
+    @property
+    def slim(self) -> "VectorField2D":
+        """
+        Return a `VectorField2D` where the data is stored its `slim` representation, which is an ndarray of shape
+        [total_unmasked_pixels * sub_size**2, 2].
+
+        If it is already stored in its `slim` representation it is returned as it is. If not, it is  mapped from
+        `native` to `slim` and returned as a new `Array2D`.
+        """
+        if len(self.shape) == 2:
+            return self
+
+        vector_field_2d_slim = grid_2d_util.grid_2d_slim_from(
+            grid_2d_native=self, mask=self.mask, sub_size=self.mask.sub_size
+        )
+
+        grid_2d_slim = grid_2d_util.grid_2d_slim_from(
+            grid_2d_native=self.grid, mask=self.mask, sub_size=self.mask.sub_size
+        )
+
+        grid_2d_slim = Grid2D.manual_mask(grid=grid_2d_slim, mask=self.mask)
+
+        return self.__class__(
+            vectors=vector_field_2d_slim, grid=grid_2d_slim, mask=self.mask
+        )
+
+    @property
+    def native(self) -> "VectorField2D":
+        """
+        Return a `VectorField2D` where the data is stored in its `native` representation, which is an ndarray of shape
+        [sub_size*total_y_pixels, sub_size*total_x_pixels, 2].
+
+        If it is already stored in its `native` representation it is return as it is. If not, it is mapped from
+        `slim` to `native` and returned as a new `Grid2D`.
+        """
+
+        if len(self.shape) != 3:
+            return self
+
+        vector_field_2d_native = grid_2d_util.grid_2d_native_from(
+            grid_2d_slim=self, mask_2d=self.mask, sub_size=self.mask.sub_size
+        )
+
+        grid_2d_native = grid_2d_util.grid_2d_native_from(
+            grid_2d_slim=self.grid, mask_2d=self.mask, sub_size=self.mask.sub_size
+        )
+
+        grid_2d_native = Grid2D.manual_mask(grid=grid_2d_native, mask=self.mask)
+
+        return self.__class__(
+            vectors=vector_field_2d_native, grid=grid_2d_native, mask=self.mask
+        )
+
+    @property
+    def binned(self) -> "VectorField2D":
+        """
+        Convenience method to access the binned-up vectors as a Vector2D stored in its `slim` or `native` format.
+
+        The binning up process converts a grid from (y,x) values where each value is a coordinate on the sub-grid to
+        (y,x) values where each coordinate is at the centre of its mask (e.g. a grid with a sub_size of 1). This is
+        performed by taking the mean of all (y,x) values in each sub pixel.
+
+        If the grid is stored in 1D it is return as is. If it is stored in 2D, it must first be mapped from 2D to 1D.
+        """
+
+        vector_2d_slim_binned_y = np.multiply(
+            self.mask.sub_fraction,
+            self.slim[:, 0].reshape(-1, self.mask.sub_length).sum(axis=1),
+        )
+
+        vector_2d_slim_binned_x = np.multiply(
+            self.mask.sub_fraction,
+            self.slim[:, 1].reshape(-1, self.mask.sub_length).sum(axis=1),
+        )
+
+        grid_2d_slim_binned_y = np.multiply(
+            self.mask.sub_fraction,
+            self.grid.slim[:, 0].reshape(-1, self.mask.sub_length).sum(axis=1),
+        )
+
+        grid_2d_slim_binned_x = np.multiply(
+            self.mask.sub_fraction,
+            self.grid.slim[:, 1].reshape(-1, self.mask.sub_length).sum(axis=1),
+        )
+
+        return self.__class__(
+            vectors=np.stack(
+                (vector_2d_slim_binned_y, vector_2d_slim_binned_x), axis=-1
+            ),
+            grid=np.stack((grid_2d_slim_binned_y, grid_2d_slim_binned_x), axis=-1),
+            mask=self.mask.mask_sub_1,
+        )
+
+    @property
+    def average_magnitude(self) -> float:
+        """
+        The average magnitude of the vector field, where averaging is performed on the (vector_y, vector_x) components.
+        """
+        return np.sqrt(np.mean(self.slim[:, 0]) ** 2 + np.mean(self.slim[:, 1]) ** 2)
+
+    @property
+    def average_phi(self) -> float:
+        """
+        The average angle of the vector field, where averaging is performed on the (vector_y, vector_x) components.
+        """
+        return (
+            0.5
+            * np.arctan2(np.mean(self.slim[:, 0]), np.mean(self.slim[:, 1]))
+            * (180 / np.pi)
+        )

--- a/autoarray/structures/vector_fields/abstract.py
+++ b/autoarray/structures/vector_fields/abstract.py
@@ -1,20 +1,16 @@
 import logging
 import numpy as np
-from typing import List, Tuple, Union
 
-from autoarray.structures.arrays.two_d.array_2d import Array2D
+from autoarray.structures.abstract_structure import AbstractStructure2D
+
 from autoarray.structures.grids.two_d.grid_2d import Grid2D
-from autoarray.structures.arrays.values import ValuesIrregular
-
-from autoarray import exc
-from autoarray.structures.arrays.two_d import array_2d_util
 from autoarray.structures.grids.two_d import grid_2d_util
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 
-class AbstractVectorField2D(np.ndarray):
+class AbstractVectorField2D(AbstractStructure2D):
     def __array_finalize__(self, obj):
 
         if hasattr(obj, "mask"):
@@ -59,7 +55,7 @@ class AbstractVectorField2D(np.ndarray):
         `slim` to `native` and returned as a new `Grid2D`.
         """
 
-        if len(self.shape) != 3:
+        if len(self.shape) != 2:
             return self
 
         vector_field_2d_native = grid_2d_util.grid_2d_native_from(
@@ -98,21 +94,11 @@ class AbstractVectorField2D(np.ndarray):
             self.slim[:, 1].reshape(-1, self.mask.sub_length).sum(axis=1),
         )
 
-        grid_2d_slim_binned_y = np.multiply(
-            self.mask.sub_fraction,
-            self.grid.slim[:, 0].reshape(-1, self.mask.sub_length).sum(axis=1),
-        )
-
-        grid_2d_slim_binned_x = np.multiply(
-            self.mask.sub_fraction,
-            self.grid.slim[:, 1].reshape(-1, self.mask.sub_length).sum(axis=1),
-        )
-
         return self.__class__(
             vectors=np.stack(
                 (vector_2d_slim_binned_y, vector_2d_slim_binned_x), axis=-1
             ),
-            grid=np.stack((grid_2d_slim_binned_y, grid_2d_slim_binned_x), axis=-1),
+            grid=self.grid.binned,
             mask=self.mask.mask_sub_1,
         )
 

--- a/autoarray/structures/vector_fields/irregular.py
+++ b/autoarray/structures/vector_fields/irregular.py
@@ -1,8 +1,8 @@
 import logging
-from matplotlib.patches import Ellipse
 import numpy as np
-import typing
+from typing import List, Tuple, Union
 
+from autoarray.structures.vector_fields.abstract import AbstractVectorField2D
 from autoarray.structures.grids.two_d.grid_2d_irregular import Grid2DIrregular
 from autoarray.structures.arrays.values import ValuesIrregular
 
@@ -12,12 +12,16 @@ logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 
-class VectorField2DIrregular(np.ndarray):
+class VectorField2DIrregular(AbstractVectorField2D):
     def __new__(
-        cls, vectors: np.ndarray or [(float, float)], grid: Grid2DIrregular or list
+        cls,
+        vectors: Union[
+            np.ndarray, List[np.ndarray], List[List], List[Tuple[float, float]]
+        ],
+        grid: Union[Grid2DIrregular, List],
     ):
         """
-        A collection of (y,x) vectors which are located on an irregular grid of (y,x) coordinates.
+        A collection of (y,x) vectors which are located on a irregular 2D grid of (y,x) coordinates.
 
         The (y,x) vectors are stored as a 2D NumPy array of shape [total_vectors, 2]. This array can be mapped to a
         list of tuples structure.
@@ -34,9 +38,9 @@ class VectorField2DIrregular(np.ndarray):
 
         Parameters
         ----------
-        vectors or [(float, float)]
+        vectors
             The 2D (y,x) vectors on an irregular grid that represent the vector-field.
-        grid : Grid2DIrregular
+        grid
             The irregular grid of (y,x) coordinates where each vector is located.
         """
 
@@ -57,60 +61,6 @@ class VectorField2DIrregular(np.ndarray):
             self.grid = obj.grid
 
     @property
-    def ellipticities(self) -> ValuesIrregular:
-        """
-        If we treat this vector field as a set of weak lensing shear measurements, the galaxy ellipticity each vector
-        corresponds too.
-        """
-        return ValuesIrregular(values=np.sqrt(self[:, 0] ** 2 + self[:, 1] ** 2.0))
-
-    @property
-    def semi_major_axes(self) -> ValuesIrregular:
-        """
-        If we treat this vector field as a set of weak lensing shear measurements, the semi-major axis of each
-        galaxy ellipticity that each vector corresponds too.
-        """
-        return ValuesIrregular(values=3 * (1 + self.ellipticities))
-
-    @property
-    def semi_minor_axes(self) -> ValuesIrregular:
-        """
-        If we treat this vector field as a set of weak lensing shear measurements, the semi-minor axis of each
-        galaxy ellipticity that each vector corresponds too.
-        """
-        return ValuesIrregular(values=3 * (1 - self.ellipticities))
-
-    @property
-    def phis(self) -> ValuesIrregular:
-        """
-        If we treat this vector field as a set of weak lensing shear measurements, the position angle defined
-        counter clockwise from the positive x-axis of each galaxy ellipticity that each vector corresponds too.
-        """
-        return ValuesIrregular(
-            values=np.arctan2(self[:, 0], self[:, 1]) * 180.0 / np.pi / 2.0
-        )
-
-    @property
-    def elliptical_patches(self) -> typing.List[Ellipse]:
-        """
-        If we treat this vector field as a set of weak lensing shear measurements, the elliptical patch representing
-        each galaxy ellipticity. This patch is used for visualizing an ellipse of each galaxy in an image.
-        """
-
-        return [
-            Ellipse(
-                xy=(x, y), width=semi_major_axis, height=semi_minor_axis, angle=angle
-            )
-            for x, y, semi_major_axis, semi_minor_axis, angle in zip(
-                self.grid[:, 1],
-                self.grid[:, 0],
-                self.semi_major_axes,
-                self.semi_minor_axes,
-                self.phis,
-            )
-        ]
-
-    @property
     def slim(self) -> np.ndarray:
         """
         The vector-field in its 1D representation, an ndarray of shape [total_vectors, 2].
@@ -118,12 +68,19 @@ class VectorField2DIrregular(np.ndarray):
         return self
 
     @property
-    def in_list(self) -> typing.List[typing.Tuple]:
+    def in_list(self) -> List[Tuple]:
         """
         The vector-field in its list representation, as list of (y,x) vector tuples in a structure
         [(vector_0_y, vector_0_x), ...].
         """
         return [tuple(vector) for vector in self.slim]
+
+    @property
+    def magnitudes(self) -> ValuesIrregular:
+        """
+        Returns the magnitude of every vector which are computed as sqrt(y**2 + x**2).
+        """
+        return ValuesIrregular(values=np.sqrt(self[:, 0] ** 2.0 + self[:, 1] ** 2.0))
 
     @property
     def average_magnitude(self) -> float:
@@ -142,7 +99,7 @@ class VectorField2DIrregular(np.ndarray):
         )
 
     def vectors_within_radius(
-        self, radius: float, centre: typing.Tuple[float, float] = (0.0, 0.0)
+        self, radius: float, centre: Tuple[float, float] = (0.0, 0.0)
     ) -> "VectorField2DIrregular":
         """
         Returns a new `VectorField2DIrregular` object which has had all vectors outside of a circle of input radius
@@ -177,7 +134,7 @@ class VectorField2DIrregular(np.ndarray):
         self,
         inner_radius: float,
         outer_radius: float,
-        centre: typing.Tuple[float, float] = (0.0, 0.0),
+        centre: Tuple[float, float] = (0.0, 0.0),
     ) -> "VectorField2DIrregular":
         """
         Returns a new `VectorFieldIrregular` object which has had all vectors outside of a circle of input radius

--- a/autoarray/structures/vector_fields/uniform.py
+++ b/autoarray/structures/vector_fields/uniform.py
@@ -1,0 +1,233 @@
+import logging
+import numpy as np
+from typing import List, Tuple, Union
+
+from autoarray.structures.arrays.two_d.array_2d import Array2D
+from autoarray.structures.grids.two_d.grid_2d import Grid2D
+from autoarray.structures.vector_fields.abstract import AbstractVectorField2D
+from autoarray.structures.arrays.values import ValuesIrregular
+
+from autoarray import exc
+from autoarray.structures.arrays.two_d import array_2d_util
+from autoarray.structures.grids.two_d import grid_2d_util
+
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+
+
+class VectorField2D(AbstractVectorField2D):
+    def __new__(
+        cls,
+        vectors: Union[np.ndarray, List[Tuple[float, float]]],
+        grid: Union[Grid2D, List],
+        mask,
+    ):
+        """
+        A collection of (y,x) vectors which are located on a regular 2D grid of (y,x) coordinates.
+
+        The vectors are paired to a uniform 2D mask of pixels and sub-pixels. Each vector corresponds to a value at 
+        the centre of a sub-pixel in an unmasked pixel.
+
+        The `VectorField2D` is ordered such that pixels begin from the top-row of the corresponding mask and go right 
+        and down. The positive y-axis is upwards and positive x-axis to the right.
+
+        The (y,x) vectors are stored as a NumPy array which has the `slim` and `native shapes described below. 
+        Irrespective of this shape, the last dimension of the data structure storing the vectors is always shape 2, 
+        corresponding to the y and x vectors. [total_vectors, 2].
+
+        Calculations should use the NumPy array structure wherever possible for efficient calculations.
+
+        The vectors input to this function can have any of the following forms (they will be converted to the 1D NumPy
+        array structure and can be converted back using the object's properties):
+
+        [[vector_0_y, vector_0_x], [vector_1_y, vector_1_x]]
+        [(vector_0_y, vector_0_x), (vector_1_y, vector_1_x)]
+
+        If your vector field lies on a 2D irregular grid of data the `VectorFieldIrregular2D` data structure should be 
+        used.
+
+        Case 1: [sub-size=1, slim]:
+        ---------------------------
+
+        The Vector2D is an ndarray of shape [total_unmasked_pixels, 2].
+
+        The first element of the ndarray corresponds to the pixel index, for example:
+
+        - vector[3, 0:2] = the 4th unmasked pixel's y and x values.
+        - vector[6, 0:2] = the 7th unmasked pixel's y and x values.
+
+        Below is a visual illustration of a vector, where a total of 10 pixels are unmasked and are included in
+        the vector.
+
+        IxIxIxIxIxIxIxIxIxIxI
+        IxIxIxIxIxIxIxIxIxIxI     This is an example `Mask2D`, where:
+        IxIxIxIxIxIxIxIxIxIxI
+        IxIxIxIxIoIoIxIxIxIxI     x = `True` (Pixel is masked and excluded from the vector)
+        IxIxIxIoIoIoIoIxIxIxI     o = `False` (Pixel is not masked and included in the vector)
+        IxIxIxIoIoIoIoIxIxIxI
+        IxIxIxIxIxIxIxIxIxIxI
+        IxIxIxIxIxIxIxIxIxIxI
+        IxIxIxIxIxIxIxIxIxIxI
+        IxIxIxIxIxIxIxIxIxIxI
+
+        The mask pixel index's will come out like this (and the direction of scaled values is highlighted
+        around the mask).
+
+        pixel_scales = 1.0"
+
+        <--- -ve  x  +ve -->
+                                                        y      x
+        IxIxIxIxIxIxIxIxIxIxI  ^   vector[0, :] = 0
+        IxIxIxIxIxIxIxIxIxIxI  I   vector[1, :] = 1
+        IxIxIxIxIxIxIxIxIxIxI  I   vector[2, :] = 2
+        IxIxIxIxI0I1IxIxIxIxI +ve  vector[3, :] = 3
+        IxIxIxI2I3I4I5IxIxIxI  y   vector[4, :] = 4
+        IxIxIxI6I7I8I9IxIxIxI -ve  vector[5, :] = 5
+        IxIxIxIxIxIxIxIxIxIxI  I   vector[6, :] = 6
+        IxIxIxIxIxIxIxIxIxIxI  I   vector[7, :] = 7
+        IxIxIxIxIxIxIxIxIxIxI \/   vector[8, :] = 8
+        IxIxIxIxIxIxIxIxIxIxI      vector[9, :] = 9
+
+        Case 2: [sub-size>1, slim]:
+        ------------------
+
+        If the masks's sub size is > 1, the vector is defined as a sub-vector where each entry corresponds to the 
+        values at the centre of each sub-pixel of an unmasked pixel.
+
+        The sub-vector indexes are ordered such that pixels begin from the first (top-left) sub-pixel in the first
+        unmasked pixel. Indexes then go over the sub-pixels in each unmasked pixel, for every unmasked pixel.
+        Therefore, the sub-vector is an ndarray of shape [total_unmasked_pixels*(sub_array_shape)**2, 2]. For example:
+
+        - vector[9, 0:2] - using a 2x2 sub-vector, gives the 3rd unmasked pixel's 2nd sub-pixel y and x values.
+        - vector[9, 0:2] - using a 3x3 sub-vector, gives the 2nd unmasked pixel's 1st sub-pixel y and x values.
+        - vector[27, 0:2] - using a 3x3 sub-vector, gives the 4th unmasked pixel's 1st sub-pixel y and x values.
+
+        Below is a visual illustration of a sub vector. Indexing of each sub-pixel goes from the top-left corner. In
+        contrast to the vector above, our illustration below restricts the mask to just 2 pixels, to keep the
+        illustration brief.
+
+        IxIxIxIxIxIxIxIxIxIxI
+        IxIxIxIxIxIxIxIxIxIxI     This is an example `Mask2D`, where:
+        IxIxIxIxIxIxIxIxIxIxI
+        IxIxIxIxIxIxIxIxIxIxI     x = `True` (Pixel is masked and excluded from lens)
+        IxIxIxIxIoIoIxIxIxIxI     o = `False` (Pixel is not masked and included in lens)
+        IxIxIxIxIxIxIxIxIxIxI
+        IxIxIxIxIxIxIxIxIxIxI
+        IxIxIxIxIxIxIxIxIxIxI
+        IxIxIxIxIxIxIxIxIxIxI
+        IxIxIxIxIxIxIxIxIxIxI
+
+        Our vector with a sub-size looks like it did before:
+
+        pixel_scales = 1.0"
+
+        <--- -ve  x  +ve -->
+
+        IxIxIxIxIxIxIxIxIxIxI  ^
+        IxIxIxIxIxIxIxIxIxIxI  I
+        IxIxIxIxIxIxIxIxIxIxI  I
+        IxIxIxIxIxIxIxIxIxIxI +ve
+        IxIxIxI0I1IxIxIxIxIxI  y
+        IxIxIxIxIxIxIxIxIxIxI -ve
+        IxIxIxIxIxIxIxIxIxIxI  I
+        IxIxIxIxIxIxIxIxIxIxI  I
+        IxIxIxIxIxIxIxIxIxIxI \/
+        IxIxIxIxIxIxIxIxIxIxI
+
+        However, if the sub-size is 2,each unmasked pixel has a set of sub-pixels with values. For example, for pixel 0,
+        if `sub_size=2`, it has 4 values on a 2x2 sub-vector:
+
+        Pixel 0 - (2x2):
+
+               vector[0, 0:2] = y and x values of first sub-pixel in pixel 0.
+        I0I1I  vector[1, 0:2] = y and x values of first sub-pixel in pixel 1.
+        I2I3I  vector[2, 0:2] = y and x values of first sub-pixel in pixel 2.
+               vector[3, 0:2] = y and x values of first sub-pixel in pixel 3.
+
+        If we used a sub_size of 3, for the first pixel we we would create a 3x3 sub-vector:
+
+
+                 vector[0] = y and x values of first sub-pixel in pixel 0.
+                 vector[1] = y and x values of first sub-pixel in pixel 1.
+                 vector[2] = y and x values of first sub-pixel in pixel 2.
+        I0I1I2I  vector[3] = y and x values of first sub-pixel in pixel 3.
+        I3I4I5I  vector[4] = y and x values of first sub-pixel in pixel 4.
+        I6I7I8I  vector[5] = y and x values of first sub-pixel in pixel 5.
+                 vector[6] = y and x values of first sub-pixel in pixel 6.
+                 vector[7] = y and x values of first sub-pixel in pixel 7.
+                 vector[8] = y and x values of first sub-pixel in pixel 8.
+
+        Case 3: [sub_size=1, native]
+        ----------------------------
+
+        The Vector2D has the same properties as Case 1, but is stored as an an ndarray of shape
+        [total_y_values, total_x_values, 2].
+
+        All masked entries on the vector have values of 0.0.
+
+        For the following example mask:
+
+        IxIxIxIxIxIxIxIxIxIxI
+        IxIxIxIxIxIxIxIxIxIxI     This is an example `Mask2D`, where:
+        IxIxIxIxIxIxIxIxIxIxI
+        IxIxIxIxIoIoIxIxIxIxI     x = `True` (Pixel is masked and excluded from the vector)
+        IxIxIxIoIoIoIoIxIxIxI     o = `False` (Pixel is not masked and included in the vector)
+        IxIxIxIoIoIoIoIxIxIxI
+        IxIxIxIxIxIxIxIxIxIxI
+        IxIxIxIxIxIxIxIxIxIxI
+        IxIxIxIxIxIxIxIxIxIxI
+        IxIxIxIxIxIxIxIxIxIxI
+
+        - vector[0,0, 0:2] = [0.0, 0.0] (it is masked, thus zero)
+        - vector[0,0, 0:2] = [0.0, 0.0] (it is masked, thus zero)
+        - vector[3,3, 0:2] = [0.0, 0.0] (it is masked, thus zero)
+        - vector[3,3, 0:2] = [0.0, 0.0] (it is masked, thus zero)
+        - vector[3,4, 0:2] = [0, 0]
+        - vector[3,4, 0:2] = [-1, -1]
+
+        Case 4: [sub_size>, native]
+        ---------------------------
+
+        The properties of this vector can be derived by combining Case's 2 and 3 above, whereby the vector is stored as
+        an ndarray of shape [total_y_values*sub_size, total_x_values*sub_size, 2].
+
+        All sub-pixels in masked pixels have values 0.0.
+
+        Parameters
+        ----------
+        vectors
+            The 2D (y,x) vectors on a regular grid that represent the vector-field.
+        grid
+            The regular grid of (y,x) coordinates where each vector is located.
+        mask
+            The 2D mask associated with the array, defining the pixels each array value is paired with and
+            originates from.            
+        """
+
+        if len(vectors) == 0:
+            return []
+
+        if type(vectors) is list:
+            vectors = np.asarray(vectors)
+
+        obj = vectors.view(cls)
+        obj.grid = Grid2D(grid=grid, mask=mask)
+
+        return obj
+
+    def __array_finalize__(self, obj):
+
+        if hasattr(obj, "mask"):
+            self.mask = obj.mask
+
+        if hasattr(obj, "grid"):
+            self.grid = obj.grid
+
+    @property
+    def magnitudes(self) -> Array2D:
+        """
+        Returns the magnitude of every vector which are computed as sqrt(y**2 + x**2).
+        """
+        return Array2D(
+            array=np.sqrt(self[:, 0] ** 2.0 + self[:, 1] ** 2.0), mask=self.mask
+        )

--- a/autoarray/structures/vectors/abstract.py
+++ b/autoarray/structures/vectors/abstract.py
@@ -10,7 +10,7 @@ logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 
-class AbstractVectorField2D(AbstractStructure2D):
+class AbstractVectorYX2D(AbstractStructure2D):
     def __array_finalize__(self, obj):
 
         if hasattr(obj, "mask"):
@@ -20,9 +20,9 @@ class AbstractVectorField2D(AbstractStructure2D):
             self.grid = obj.grid
 
     @property
-    def slim(self) -> "VectorField2D":
+    def slim(self) -> "VectorYX2D":
         """
-        Return a `VectorField2D` where the data is stored its `slim` representation, which is an ndarray of shape
+        Return a `VectorYX2D` where the data is stored its `slim` representation, which is an ndarray of shape
         [total_unmasked_pixels * sub_size**2, 2].
 
         If it is already stored in its `slim` representation it is returned as it is. If not, it is  mapped from
@@ -31,7 +31,7 @@ class AbstractVectorField2D(AbstractStructure2D):
         if len(self.shape) == 2:
             return self
 
-        vector_field_2d_slim = grid_2d_util.grid_2d_slim_from(
+        vectors_2d_slim = grid_2d_util.grid_2d_slim_from(
             grid_2d_native=self, mask=self.mask, sub_size=self.mask.sub_size
         )
 
@@ -42,13 +42,13 @@ class AbstractVectorField2D(AbstractStructure2D):
         grid_2d_slim = Grid2D.manual_mask(grid=grid_2d_slim, mask=self.mask)
 
         return self.__class__(
-            vectors=vector_field_2d_slim, grid=grid_2d_slim, mask=self.mask
+            vectors=vectors_2d_slim, grid=grid_2d_slim, mask=self.mask
         )
 
     @property
-    def native(self) -> "VectorField2D":
+    def native(self) -> "VectorYX2D":
         """
-        Return a `VectorField2D` where the data is stored in its `native` representation, which is an ndarray of shape
+        Return a `VectorYX2D` where the data is stored in its `native` representation, which is an ndarray of shape
         [sub_size*total_y_pixels, sub_size*total_x_pixels, 2].
 
         If it is already stored in its `native` representation it is return as it is. If not, it is mapped from
@@ -58,7 +58,7 @@ class AbstractVectorField2D(AbstractStructure2D):
         if len(self.shape) != 2:
             return self
 
-        vector_field_2d_native = grid_2d_util.grid_2d_native_from(
+        vectors_2d_native = grid_2d_util.grid_2d_native_from(
             grid_2d_slim=self, mask_2d=self.mask, sub_size=self.mask.sub_size
         )
 
@@ -69,11 +69,11 @@ class AbstractVectorField2D(AbstractStructure2D):
         grid_2d_native = Grid2D.manual_mask(grid=grid_2d_native, mask=self.mask)
 
         return self.__class__(
-            vectors=vector_field_2d_native, grid=grid_2d_native, mask=self.mask
+            vectors=vectors_2d_native, grid=grid_2d_native, mask=self.mask
         )
 
     @property
-    def binned(self) -> "VectorField2D":
+    def binned(self) -> "VectorYX2D":
         """
         Convenience method to access the binned-up vectors as a Vector2D stored in its `slim` or `native` format.
 

--- a/autoarray/structures/vectors/irregular.py
+++ b/autoarray/structures/vectors/irregular.py
@@ -2,7 +2,7 @@ import logging
 import numpy as np
 from typing import List, Tuple, Union
 
-from autoarray.structures.vector_fields.abstract import AbstractVectorField2D
+from autoarray.structures.vectors.abstract import AbstractVectorYX2D
 from autoarray.structures.grids.two_d.grid_2d_irregular import Grid2DIrregular
 from autoarray.structures.arrays.values import ValuesIrregular
 
@@ -12,7 +12,7 @@ logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 
-class VectorField2DIrregular(AbstractVectorField2D):
+class VectorYX2DIrregular(AbstractVectorYX2D):
     def __new__(
         cls,
         vectors: Union[
@@ -100,9 +100,9 @@ class VectorField2DIrregular(AbstractVectorField2D):
 
     def vectors_within_radius(
         self, radius: float, centre: Tuple[float, float] = (0.0, 0.0)
-    ) -> "VectorField2DIrregular":
+    ) -> "VectorYX2DIrregular":
         """
-        Returns a new `VectorField2DIrregular` object which has had all vectors outside of a circle of input radius
+        Returns a new `VectorYX2DIrregular` object which has had all vectors outside of a circle of input radius
         around an  input (y,x) centre removed.
 
         Parameters
@@ -114,7 +114,7 @@ class VectorField2DIrregular(AbstractVectorField2D):
 
         Returns
         -------
-        VectorField2DIrregular
+        VectorYX2DIrregular
             The vector field where all vectors outside of the input radius are removed.
 
         """
@@ -126,7 +126,7 @@ class VectorField2DIrregular(AbstractVectorField2D):
                 "The input radius removed all vectors / points on the grid."
             )
 
-        return VectorField2DIrregular(
+        return VectorYX2DIrregular(
             vectors=self[mask], grid=Grid2DIrregular(self.grid[mask])
         )
 
@@ -135,7 +135,7 @@ class VectorField2DIrregular(AbstractVectorField2D):
         inner_radius: float,
         outer_radius: float,
         centre: Tuple[float, float] = (0.0, 0.0),
-    ) -> "VectorField2DIrregular":
+    ) -> "VectorYX2DIrregular":
         """
         Returns a new `VectorFieldIrregular` object which has had all vectors outside of a circle of input radius
         around an  input (y,x) centre removed.
@@ -161,6 +161,6 @@ class VectorField2DIrregular(AbstractVectorField2D):
                 "The input radius removed all vectors / points on the grid."
             )
 
-        return VectorField2DIrregular(
+        return VectorYX2DIrregular(
             vectors=self[mask], grid=Grid2DIrregular(self.grid[mask])
         )

--- a/autoarray/structures/vectors/uniform.py
+++ b/autoarray/structures/vectors/uniform.py
@@ -278,7 +278,7 @@ class VectorYX2D(AbstractVectorYX2D):
 
         vectors = abstract_grid_2d.convert_grid_2d(grid_2d=vectors, mask_2d=mask)
 
-        return VectorYX2D(vectors=vectors, grid=grid, mask=mask)
+        return cls(vectors=vectors, grid=grid, mask=mask)
 
     @classmethod
     def manual_native(

--- a/autoarray/structures/vectors/uniform.py
+++ b/autoarray/structures/vectors/uniform.py
@@ -4,7 +4,7 @@ from typing import List, Tuple, Union
 
 from autoarray.structures.arrays.two_d.array_2d import Array2D
 from autoarray.structures.grids.two_d.grid_2d import Grid2D
-from autoarray.structures.vector_fields.abstract import AbstractVectorField2D
+from autoarray.structures.vectors.abstract import AbstractVectorYX2D
 
 from autoarray.mask.mask_2d import Mask2D
 from autoarray.structures.grids import abstract_grid
@@ -15,7 +15,7 @@ logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 
-class VectorField2D(AbstractVectorField2D):
+class VectorYX2D(AbstractVectorYX2D):
     def __new__(
         cls,
         vectors: Union[np.ndarray, List[Tuple[float, float]]],
@@ -28,7 +28,7 @@ class VectorField2D(AbstractVectorField2D):
         The vectors are paired to a uniform 2D mask of pixels and sub-pixels. Each vector corresponds to a value at 
         the centre of a sub-pixel in an unmasked pixel.
 
-        The `VectorField2D` is ordered such that pixels begin from the top-row of the corresponding mask and go right 
+        The `VectorYX2D` is ordered such that pixels begin from the top-row of the corresponding mask and go right
         and down. The positive y-axis is upwards and positive x-axis to the right.
 
         The (y,x) vectors are stored as a NumPy array which has the `slim` and `native shapes described below. 
@@ -232,14 +232,14 @@ class VectorField2D(AbstractVectorField2D):
         pixel_scales: Union[Tuple[float, float], float],
         sub_size: int = 1,
         origin: Tuple[float, float] = (0.0, 0.0),
-    ) -> "VectorField2D":
+    ) -> "VectorYX2D":
         """
-        Create a VectorField2D (see *VectorField2D.__new__*) by inputting the vector in 1D, for example:
+        Create a VectorYX2D (see *VectorYX2D.__new__*) by inputting the vector in 1D, for example:
 
         vectors=np.array([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [4.0, 4.0]])
         vectors=[[1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [4.0, 4.0]]
 
-        The `VectorField2D` object assumes a uniform `Grid2D` which is computed from the input `shape_native`,
+        The `VectorYX2D` object assumes a uniform `Grid2D` which is computed from the input `shape_native`,
         `pixel_scales` and `origin`.
 
         From 1D input the method cannot determine the 2D shape of the grid and its mask, thus the `shape_native` must be
@@ -278,7 +278,7 @@ class VectorField2D(AbstractVectorField2D):
 
         vectors = abstract_grid_2d.convert_grid_2d(grid_2d=vectors, mask_2d=mask)
 
-        return VectorField2D(vectors=vectors, grid=grid, mask=mask)
+        return VectorYX2D(vectors=vectors, grid=grid, mask=mask)
 
     @classmethod
     def manual_native(
@@ -287,9 +287,9 @@ class VectorField2D(AbstractVectorField2D):
         pixel_scales: Union[Tuple[float, float], float],
         sub_size: int = 1,
         origin: Tuple[float, float] = (0.0, 0.0),
-    ) -> "VectorField2D":
+    ) -> "VectorYX2D":
         """
-        Create a VectorField2D (see *VectorField2D.__new__*) by inputting the grid coordinates in 2D, for example:
+        Create a VectorYX2D (see *VectorYX2D.__new__*) by inputting the grid coordinates in 2D, for example:
 
         vectors=np.ndarray([[[1.0, 1.0], [2.0, 2.0]],
                          [[3.0, 3.0], [4.0, 4.0]]])
@@ -297,7 +297,7 @@ class VectorField2D(AbstractVectorField2D):
         vectors=[[[1.0, 1.0], [2.0, 2.0]],
                 [[3.0, 3.0], [4.0, 4.0]]]
 
-        The `VectorField2D` object assumes a uniform `Grid2D` which is computed from the mask's `shape_native`,
+        The `VectorYX2D` object assumes a uniform `Grid2D` which is computed from the mask's `shape_native`,
         `pixel_scales` and `origin`.
 
         The 2D shape of the grid and its mask are determined from the input grid and the mask is setup as an
@@ -342,7 +342,7 @@ class VectorField2D(AbstractVectorField2D):
 
         vectors = abstract_grid_2d.convert_grid_2d(grid_2d=vectors, mask_2d=mask)
 
-        return VectorField2D(vectors=vectors, grid=grid, mask=mask)
+        return VectorYX2D(vectors=vectors, grid=grid, mask=mask)
 
     @property
     def magnitudes(self) -> Array2D:

--- a/autoarray/structures/vectors/uniform.py
+++ b/autoarray/structures/vectors/uniform.py
@@ -11,6 +11,8 @@ from autoarray.structures.grids import abstract_grid
 from autoarray.structures.grids.two_d import abstract_grid_2d
 from autoarray.geometry import geometry_util
 
+from autoarray import type as ty
+
 logging.basicConfig()
 logger = logging.getLogger(__name__)
 
@@ -229,7 +231,7 @@ class VectorYX2D(AbstractVectorYX2D):
         cls,
         vectors: Union[np.ndarray, List[List], List[Tuple]],
         shape_native: Tuple[int, int],
-        pixel_scales: Union[Tuple[float, float], float],
+        pixel_scales: ty.PixelScales,
         sub_size: int = 1,
         origin: Tuple[float, float] = (0.0, 0.0),
     ) -> "VectorYX2D":
@@ -284,7 +286,7 @@ class VectorYX2D(AbstractVectorYX2D):
     def manual_native(
         cls,
         vectors: Union[np.ndarray, List],
-        pixel_scales: Union[Tuple[float, float], float],
+        pixel_scales: ty.PixelScales,
         sub_size: int = 1,
         origin: Tuple[float, float] = (0.0, 0.0),
     ) -> "VectorYX2D":

--- a/autoarray/type.py
+++ b/autoarray/type.py
@@ -1,5 +1,7 @@
 import numpy as np
-from typing import Union
+from typing import Tuple, Union
+
+PixelScales = Union[Tuple[float, float], float]
 
 # from autoarray.structures.grids.one_d import grid_1d as g1d
 from autoarray.structures.grids.two_d.grid_2d import Grid2D
@@ -8,3 +10,8 @@ from autoarray.structures.grids.two_d.grid_2d_irregular import Grid2DIrregular
 
 Grid1D2DLike = Union[np.ndarray, "Grid1D", Grid2D, Grid2DIterate, Grid2DIrregular]
 Grid2DLike = Union[np.ndarray, Grid2D, Grid2DIterate, Grid2DIrregular]
+
+from autoarray.operators.transformer import TransformerDFT
+from autoarray.operators.transformer import TransformerNUFFT
+
+Transformer = Union[TransformerDFT, TransformerNUFFT]

--- a/test_autoarray/plot/mat_wrap/test_get_visuals.py
+++ b/test_autoarray/plot/mat_wrap/test_get_visuals.py
@@ -42,7 +42,7 @@ def test__via_array_1d_from(array_1d_7):
 
 def test__via_mask_from(mask_2d_7x7):
 
-    visuals_2d = aplt.Visuals2D(origin=(1.0, 1.0), vector_field=2)
+    visuals_2d = aplt.Visuals2D(origin=(1.0, 1.0), vectors=2)
     include_2d = aplt.Include2D(origin=True, mask=True, border=True)
 
     get_visuals = GetVisuals2D(include=include_2d, visuals=visuals_2d)
@@ -52,7 +52,7 @@ def test__via_mask_from(mask_2d_7x7):
     assert visuals_2d_via.origin == (1.0, 1.0)
     assert (visuals_2d_via.mask == mask_2d_7x7).all()
     assert (visuals_2d_via.border == mask_2d_7x7.border_grid_sub_1.binned).all()
-    assert visuals_2d_via.vector_field == 2
+    assert visuals_2d_via.vectors == 2
 
     include_2d = aplt.Include2D(origin=False, mask=False, border=False)
 
@@ -63,7 +63,7 @@ def test__via_mask_from(mask_2d_7x7):
     assert visuals_2d_via.origin == (1.0, 1.0)
     assert visuals_2d_via.mask == None
     assert visuals_2d_via.border == None
-    assert visuals_2d_via.vector_field == 2
+    assert visuals_2d_via.vectors == 2
 
 
 def test__via_grid_from(grid_2d_7x7):
@@ -176,7 +176,7 @@ def test__via_mapper_for_source_from(rectangular_mapper_7x7_3x3):
 
 def test__via_fit_imaging_from(fit_imaging_7x7):
 
-    visuals_2d = aplt.Visuals2D(origin=(1.0, 1.0), vector_field=2)
+    visuals_2d = aplt.Visuals2D(origin=(1.0, 1.0), vectors=2)
     include_2d = aplt.Include2D(origin=True, mask=True, border=True)
 
     get_visuals = GetVisuals2D(include=include_2d, visuals=visuals_2d)
@@ -188,7 +188,7 @@ def test__via_fit_imaging_from(fit_imaging_7x7):
     assert (
         visuals_2d_via.border == fit_imaging_7x7.mask.border_grid_sub_1.binned
     ).all()
-    assert visuals_2d_via.vector_field == 2
+    assert visuals_2d_via.vectors == 2
 
     include_2d = aplt.Include2D(origin=False, mask=False, border=False)
 
@@ -199,4 +199,4 @@ def test__via_fit_imaging_from(fit_imaging_7x7):
     assert visuals_2d_via.origin == (1.0, 1.0)
     assert visuals_2d_via.mask == None
     assert visuals_2d_via.border == None
-    assert visuals_2d_via.vector_field == 2
+    assert visuals_2d_via.vectors == 2

--- a/test_autoarray/plot/mat_wrap/wrap/test_wrap_2d.py
+++ b/test_autoarray/plot/mat_wrap/wrap/test_wrap_2d.py
@@ -283,25 +283,25 @@ class TestGridErrorbar:
 class TestVectorFieldQuiver:
     def test__from_config_or_via_manual_input(self):
 
-        vector_field_quiver = aplt.VectorFieldQuiver()
+        vectors_quiver = aplt.VectorFieldQuiver()
 
-        assert vector_field_quiver.config_dict["headlength"] == 0
+        assert vectors_quiver.config_dict["headlength"] == 0
 
-        vector_field_quiver = aplt.VectorFieldQuiver(headlength=1)
+        vectors_quiver = aplt.VectorFieldQuiver(headlength=1)
 
-        assert vector_field_quiver.config_dict["headlength"] == 1
+        assert vectors_quiver.config_dict["headlength"] == 1
 
-        vector_field_quiver = aplt.VectorFieldQuiver()
-        vector_field_quiver.is_for_subplot = True
+        vectors_quiver = aplt.VectorFieldQuiver()
+        vectors_quiver.is_for_subplot = True
 
-        assert vector_field_quiver.config_dict["headlength"] == 0.1
+        assert vectors_quiver.config_dict["headlength"] == 0.1
 
-        vector_field_quiver = aplt.VectorFieldQuiver(headlength=12)
-        vector_field_quiver.is_for_subplot = True
+        vectors_quiver = aplt.VectorFieldQuiver(headlength=12)
+        vectors_quiver.is_for_subplot = True
 
-        assert vector_field_quiver.config_dict["headlength"] == 12
+        assert vectors_quiver.config_dict["headlength"] == 12
 
-    def test__quiver_vector_field(self):
+    def test__quiver_vectors(self):
 
         quiver = aplt.VectorFieldQuiver(
             headlength=5,
@@ -313,11 +313,11 @@ class TestVectorFieldQuiver:
             alpha=1.0,
         )
 
-        vector_field = aa.VectorField2DIrregular(
+        vectors = aa.VectorYX2DIrregular(
             vectors=[(1.0, 2.0), (2.0, 1.0)], grid=[(-1.0, 0.0), (-2.0, 0.0)]
         )
 
-        quiver.quiver_vector_field(vector_field=vector_field)
+        quiver.quiver_vectors(vectors=vectors)
 
 
 class TestPatcher:

--- a/test_autoarray/plot/mat_wrap/wrap/test_wrap_2d.py
+++ b/test_autoarray/plot/mat_wrap/wrap/test_wrap_2d.py
@@ -280,30 +280,30 @@ class TestGridErrorbar:
         )
 
 
-class TestVectorFieldQuiver:
+class TestVectorYXQuiver:
     def test__from_config_or_via_manual_input(self):
 
-        vectors_quiver = aplt.VectorFieldQuiver()
+        vector_yx_quiver = aplt.VectorYXQuiver()
 
-        assert vectors_quiver.config_dict["headlength"] == 0
+        assert vector_yx_quiver.config_dict["headlength"] == 0
 
-        vectors_quiver = aplt.VectorFieldQuiver(headlength=1)
+        vector_yx_quiver = aplt.VectorYXQuiver(headlength=1)
 
-        assert vectors_quiver.config_dict["headlength"] == 1
+        assert vector_yx_quiver.config_dict["headlength"] == 1
 
-        vectors_quiver = aplt.VectorFieldQuiver()
-        vectors_quiver.is_for_subplot = True
+        vector_yx_quiver = aplt.VectorYXQuiver()
+        vector_yx_quiver.is_for_subplot = True
 
-        assert vectors_quiver.config_dict["headlength"] == 0.1
+        assert vector_yx_quiver.config_dict["headlength"] == 0.1
 
-        vectors_quiver = aplt.VectorFieldQuiver(headlength=12)
-        vectors_quiver.is_for_subplot = True
+        vector_yx_quiver = aplt.VectorYXQuiver(headlength=12)
+        vector_yx_quiver.is_for_subplot = True
 
-        assert vectors_quiver.config_dict["headlength"] == 12
+        assert vector_yx_quiver.config_dict["headlength"] == 12
 
     def test__quiver_vectors(self):
 
-        quiver = aplt.VectorFieldQuiver(
+        quiver = aplt.VectorYXQuiver(
             headlength=5,
             pivot="middle",
             linewidth=3,

--- a/test_autoarray/structures/arrays/two_d/test_array_2d.py
+++ b/test_autoarray/structures/arrays/two_d/test_array_2d.py
@@ -109,6 +109,19 @@ class TestAPI:
         assert arr.origin == (0.0, 0.0)
         assert arr.mask.sub_size == 2
 
+        mask = aa.Mask2D.manual(mask=[[False], [True]], pixel_scales=2.0, sub_size=2)
+        arr = aa.Array2D.manual_slim(
+            array=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+            shape_native=(2, 1),
+            pixel_scales=2.0,
+            sub_size=2,
+        )
+        arr = arr.apply_mask(mask=mask)
+
+        assert (
+            arr.native == np.array([[1.0, 2.0], [3.0, 4.0], [0.0, 0.0], [0.0, 0.0]])
+        ).all()
+
     def test__manual_native__exception_raised_if_input_array_is_2d_and_not_sub_shape_of_mask(
         self,
     ):

--- a/test_autoarray/structures/grids/test_decorators.py
+++ b/test_autoarray/structures/grids/test_decorators.py
@@ -581,3 +581,97 @@ class TestGrid2DToVectorYX:
 
         assert vectors_output.native[1, 1, 1] != values_sub_4.binned.native[1, 1, 1]
         assert vectors_output.native[2, 2, 1] == values_sub_4.binned.native[2, 2, 1]
+
+
+class TestGrid2DToVectorYXList:
+    def test__grid_2d_in__output_is_list__list_of_same_format(self):
+
+        mask = aa.Mask2D.manual(
+            mask=[
+                [True, True, True, True],
+                [True, False, False, True],
+                [True, False, False, True],
+                [True, True, True, True],
+            ],
+            pixel_scales=(1.0, 1.0),
+            sub_size=1,
+        )
+
+        grid_2d = aa.Grid2D.from_mask(mask=mask)
+
+        grid_like_object = MockGrid2DLikeObj()
+
+        vectors_output = grid_like_object.ndarray_yx_2d_list_from(grid=grid_2d)
+
+        assert isinstance(vectors_output[0], aa.VectorYX2D)
+        assert (
+            vectors_output[0].native
+            == np.array(
+                [
+                    [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+                    [[0.0, 0.0], [0.5, -0.5], [0.5, 0.5], [0.0, 0.0]],
+                    [[0.0, 0.0], [-0.5, -0.5], [-0.5, 0.5], [0.0, 0.0]],
+                    [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+                ]
+            )
+        ).all()
+
+        assert isinstance(vectors_output[1], aa.VectorYX2D)
+        assert (
+            vectors_output[1].native
+            == np.array(
+                [
+                    [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+                    [[0.0, 0.0], [1.0, -1.0], [1.0, 1.0], [0.0, 0.0]],
+                    [[0.0, 0.0], [-1.0, -1.0], [-1.0, 1.0], [0.0, 0.0]],
+                    [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+                ]
+            )
+        ).all()
+
+    def test__grid_2d_irregular_in__output_is_list__list_of_same_format(self):
+
+        grid_like_object = MockGrid2DLikeObj()
+
+        grid_2d = aa.Grid2DIrregular(grid=[(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)])
+
+        vectors_output = grid_like_object.ndarray_yx_2d_list_from(grid=grid_2d)
+
+        assert isinstance(vectors_output[0], aa.VectorYX2DIrregular)
+        assert vectors_output[0].in_list == [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)]
+
+        assert isinstance(vectors_output[1], aa.VectorYX2DIrregular)
+        assert vectors_output[1].in_list == [(2.0, 4.0), (6.0, 8.0), (10.0, 12.0)]
+
+    def test__grid_2d_iterate_in__output_is_list_of_grids__use_maximum_sub_size_in_all_pixels(
+        self
+    ):
+
+        mask = aa.Mask2D.manual(
+            mask=[
+                [True, True, True, True, True],
+                [True, False, False, False, True],
+                [True, False, False, False, True],
+                [True, False, False, False, True],
+                [True, True, True, True, True],
+            ],
+            pixel_scales=(1.0, 1.0),
+            origin=(0.001, 0.001),
+        )
+
+        grid_2d = aa.Grid2DIterate.from_mask(
+            mask=mask, fractional_accuracy=0.05, sub_steps=[2, 3]
+        )
+
+        grid_like_obj = MockGridLikeIteratorObj()
+
+        vectors_output = grid_like_obj.ndarray_yx_2d_list_from(grid=grid_2d)
+
+        mask_sub_3 = mask.mask_new_sub_size_from(mask=mask, sub_size=3)
+        grid_sub_3 = aa.Grid2D.from_mask(mask=mask_sub_3)
+        values_sub_3 = ndarray_2d_from(grid=grid_sub_3, profile=None)
+        values_sub_3 = grid_sub_3.structure_2d_from(result=values_sub_3)
+
+        assert isinstance(vectors_output[0], aa.VectorYX2D)
+        assert (vectors_output[0][0] == values_sub_3.binned[0]).all()
+        assert (vectors_output[0][1] == values_sub_3.binned[1]).all()

--- a/test_autoarray/structures/grids/test_decorators.py
+++ b/test_autoarray/structures/grids/test_decorators.py
@@ -88,36 +88,6 @@ class TestGrid2DToStructure:
             np.array([[[0.0, 0.0], [0.0, -1.0], [0.0, 1.0], [0.0, 0.0]]]), 1.0e-4
         )
 
-    def test__grid_1d_in__output_is_list__list_of_same_format(self):
-
-        mask = aa.Mask1D.manual(
-            mask=[True, False, False, True], pixel_scales=(1.0,), sub_size=1
-        )
-
-        grid_1d = aa.Grid1D.from_mask(mask=mask)
-
-        grid_like_object = MockGrid2DLikeObj()
-
-        array_output = grid_like_object.ndarray_1d_list_from(grid=grid_1d)
-
-        assert isinstance(array_output[0], aa.Array1D)
-        assert (array_output[0].native == np.array([[0.0, 1.0, 1.0, 0.0]])).all()
-
-        assert isinstance(array_output[1], aa.Array1D)
-        assert (array_output[1].native == np.array([[0.0, 2.0, 2.0, 0.0]])).all()
-
-        grid_output = grid_like_object.ndarray_2d_list_from(grid=grid_1d)
-
-        assert isinstance(grid_output[0], aa.Grid2D)
-        assert grid_output[0].native == pytest.approx(
-            np.array([[[0.0, 0.0], [0.0, -0.5], [0.0, 0.5], [0.0, 0.0]]]), 1.0e-4
-        )
-
-        assert isinstance(grid_output[1], aa.Grid2D)
-        assert grid_output[1].native == pytest.approx(
-            np.array([[[0.0, 0.0], [0.0, -1.0], [0.0, 1.0], [0.0, 0.0]]]), 1.0e-4
-        )
-
     def test__grid_2d_in__output_values_same_format(self):
 
         mask = aa.Mask2D.manual(
@@ -165,94 +135,6 @@ class TestGrid2DToStructure:
             )
         ).all()
 
-        # vectors_output = grid_like_object.ndarray_3d_from(grid=grid_2d)
-        #
-        # assert isinstance(grid_output, aa.VectorYX2D)
-        # assert (
-        #     grid_output.native
-        #     == np.array(
-        #         [
-        #             [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
-        #             [[0.0, 0.0], [1.0, -1.0], [1.0, 1.0], [0.0, 0.0]],
-        #             [[0.0, 0.0], [-1.0, -1.0], [-1.0, 1.0], [0.0, 0.0]],
-        #             [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
-        #         ]
-        #     )
-        # ).all()
-
-    def test__grid_2d_in__output_is_list__list_of_same_format(self):
-
-        mask = aa.Mask2D.manual(
-            mask=[
-                [True, True, True, True],
-                [True, False, False, True],
-                [True, False, False, True],
-                [True, True, True, True],
-            ],
-            pixel_scales=(1.0, 1.0),
-            sub_size=1,
-        )
-
-        grid_2d = aa.Grid2D.from_mask(mask=mask)
-
-        grid_like_object = MockGrid2DLikeObj()
-
-        array_output = grid_like_object.ndarray_1d_list_from(grid=grid_2d)
-
-        assert isinstance(array_output[0], aa.Array2D)
-        assert (
-            array_output[0].native
-            == np.array(
-                [
-                    [0.0, 0.0, 0.0, 0.0],
-                    [0.0, 1.0, 1.0, 0.0],
-                    [0.0, 1.0, 1.0, 0.0],
-                    [0.0, 0.0, 0.0, 0.0],
-                ]
-            )
-        ).all()
-
-        assert isinstance(array_output[1], aa.Array2D)
-        assert (
-            array_output[1].native
-            == np.array(
-                [
-                    [0.0, 0.0, 0.0, 0.0],
-                    [0.0, 2.0, 2.0, 0.0],
-                    [0.0, 2.0, 2.0, 0.0],
-                    [0.0, 0.0, 0.0, 0.0],
-                ]
-            )
-        ).all()
-
-        grid_output = grid_like_object.ndarray_2d_list_from(grid=grid_2d)
-
-        assert isinstance(grid_output[0], aa.Grid2D)
-        assert (
-            grid_output[0].native
-            == np.array(
-                [
-                    [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
-                    [[0.0, 0.0], [0.5, -0.5], [0.5, 0.5], [0.0, 0.0]],
-                    [[0.0, 0.0], [-0.5, -0.5], [-0.5, 0.5], [0.0, 0.0]],
-                    [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
-                ]
-            )
-        ).all()
-
-        assert isinstance(grid_output[1], aa.Grid2D)
-        assert (
-            grid_output[1].native
-            == np.array(
-                [
-                    [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
-                    [[0.0, 0.0], [1.0, -1.0], [1.0, 1.0], [0.0, 0.0]],
-                    [[0.0, 0.0], [-1.0, -1.0], [-1.0, 1.0], [0.0, 0.0]],
-                    [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
-                ]
-            )
-        ).all()
-
     def test__grid_2d_irregular_in__output_values_same_format(self):
 
         grid_like_object = MockGrid2DLikeObj()
@@ -266,22 +148,6 @@ class TestGrid2DToStructure:
         grid_output = grid_like_object.ndarray_2d_from(grid=grid_2d)
 
         assert grid_output.in_list == [(2.0, 4.0), (6.0, 8.0), (10.0, 12.0)]
-
-    def test__grid_2d_irregular_in__output_is_list__list_of_same_format(self):
-
-        grid_like_object = MockGrid2DLikeObj()
-
-        grid_2d = aa.Grid2DIrregular(grid=[(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)])
-
-        grid_output = grid_like_object.ndarray_1d_list_from(grid=grid_2d)
-
-        assert grid_output[0].in_list == [1.0, 1.0, 1.0]
-        assert grid_output[1].in_list == [2.0, 2.0, 2.0]
-
-        grid_output = grid_like_object.ndarray_2d_list_from(grid=grid_2d)
-
-        assert grid_output[0].in_list == [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)]
-        assert grid_output[1].in_list == [(2.0, 4.0), (6.0, 8.0), (10.0, 12.0)]
 
     def test__grid_2d_iterate_in__output_values__use_iterated_array_function(self):
 
@@ -350,37 +216,6 @@ class TestGrid2DToStructure:
 
         assert values.native[1, 1] != values_sub_4.binned.native[1, 1]
         assert values.native[2, 2] == values_sub_4.binned.native[2, 2]
-
-    def test__grid_2d_iterate_in__output_is_list_of_arrays__use_maximum_sub_size_in_all_pixels(
-        self
-    ):
-
-        mask = aa.Mask2D.manual(
-            mask=[
-                [True, True, True, True, True],
-                [True, False, False, False, True],
-                [True, False, False, False, True],
-                [True, False, False, False, True],
-                [True, True, True, True, True],
-            ],
-            pixel_scales=(1.0, 1.0),
-            origin=(0.001, 0.001),
-        )
-
-        grid_2d = aa.Grid2DIterate.from_mask(
-            mask=mask, fractional_accuracy=0.05, sub_steps=[2, 3]
-        )
-
-        grid_like_obj = MockGridLikeIteratorObj()
-
-        values = grid_like_obj.ndarray_1d_list_from(grid=grid_2d)
-
-        mask_sub_3 = mask.mask_new_sub_size_from(mask=mask, sub_size=3)
-        grid_sub_3 = aa.Grid2D.from_mask(mask=mask_sub_3)
-        values_sub_3 = ndarray_1d_from(grid=grid_sub_3, profile=None)
-        values_sub_3 = grid_sub_3.structure_2d_from(result=values_sub_3)
-
-        assert (values[0] == values_sub_3.binned).all()
 
     def test__grid_2d_iterate_in__output_values__use_iterated_grid_function(self):
 
@@ -456,6 +291,158 @@ class TestGrid2DToStructure:
         assert values.native[1, 1, 1] != values_sub_4.binned.native[1, 1, 1]
         assert values.native[2, 2, 1] == values_sub_4.binned.native[2, 2, 1]
 
+
+class TestGrid2DToStructreList:
+    def test__grid_1d_in__output_is_list__list_of_same_format(self):
+
+        mask = aa.Mask1D.manual(
+            mask=[True, False, False, True], pixel_scales=(1.0,), sub_size=1
+        )
+
+        grid_1d = aa.Grid1D.from_mask(mask=mask)
+
+        grid_like_object = MockGrid2DLikeObj()
+
+        array_output = grid_like_object.ndarray_1d_list_from(grid=grid_1d)
+
+        assert isinstance(array_output[0], aa.Array1D)
+        assert (array_output[0].native == np.array([[0.0, 1.0, 1.0, 0.0]])).all()
+
+        assert isinstance(array_output[1], aa.Array1D)
+        assert (array_output[1].native == np.array([[0.0, 2.0, 2.0, 0.0]])).all()
+
+        grid_output = grid_like_object.ndarray_2d_list_from(grid=grid_1d)
+
+        assert isinstance(grid_output[0], aa.Grid2D)
+        assert grid_output[0].native == pytest.approx(
+            np.array([[[0.0, 0.0], [0.0, -0.5], [0.0, 0.5], [0.0, 0.0]]]), 1.0e-4
+        )
+
+        assert isinstance(grid_output[1], aa.Grid2D)
+        assert grid_output[1].native == pytest.approx(
+            np.array([[[0.0, 0.0], [0.0, -1.0], [0.0, 1.0], [0.0, 0.0]]]), 1.0e-4
+        )
+
+    def test__grid_2d_in__output_is_list__list_of_same_format(self):
+
+        mask = aa.Mask2D.manual(
+            mask=[
+                [True, True, True, True],
+                [True, False, False, True],
+                [True, False, False, True],
+                [True, True, True, True],
+            ],
+            pixel_scales=(1.0, 1.0),
+            sub_size=1,
+        )
+
+        grid_2d = aa.Grid2D.from_mask(mask=mask)
+
+        grid_like_object = MockGrid2DLikeObj()
+
+        array_output = grid_like_object.ndarray_1d_list_from(grid=grid_2d)
+
+        assert isinstance(array_output[0], aa.Array2D)
+        assert (
+            array_output[0].native
+            == np.array(
+                [
+                    [0.0, 0.0, 0.0, 0.0],
+                    [0.0, 1.0, 1.0, 0.0],
+                    [0.0, 1.0, 1.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0],
+                ]
+            )
+        ).all()
+
+        assert isinstance(array_output[1], aa.Array2D)
+        assert (
+            array_output[1].native
+            == np.array(
+                [
+                    [0.0, 0.0, 0.0, 0.0],
+                    [0.0, 2.0, 2.0, 0.0],
+                    [0.0, 2.0, 2.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0],
+                ]
+            )
+        ).all()
+
+        grid_output = grid_like_object.ndarray_2d_list_from(grid=grid_2d)
+
+        assert isinstance(grid_output[0], aa.Grid2D)
+        assert (
+            grid_output[0].native
+            == np.array(
+                [
+                    [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+                    [[0.0, 0.0], [0.5, -0.5], [0.5, 0.5], [0.0, 0.0]],
+                    [[0.0, 0.0], [-0.5, -0.5], [-0.5, 0.5], [0.0, 0.0]],
+                    [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+                ]
+            )
+        ).all()
+
+        assert isinstance(grid_output[1], aa.Grid2D)
+        assert (
+            grid_output[1].native
+            == np.array(
+                [
+                    [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+                    [[0.0, 0.0], [1.0, -1.0], [1.0, 1.0], [0.0, 0.0]],
+                    [[0.0, 0.0], [-1.0, -1.0], [-1.0, 1.0], [0.0, 0.0]],
+                    [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+                ]
+            )
+        ).all()
+
+    def test__grid_2d_irregular_in__output_is_list__list_of_same_format(self):
+
+        grid_like_object = MockGrid2DLikeObj()
+
+        grid_2d = aa.Grid2DIrregular(grid=[(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)])
+
+        grid_output = grid_like_object.ndarray_1d_list_from(grid=grid_2d)
+
+        assert grid_output[0].in_list == [1.0, 1.0, 1.0]
+        assert grid_output[1].in_list == [2.0, 2.0, 2.0]
+
+        grid_output = grid_like_object.ndarray_2d_list_from(grid=grid_2d)
+
+        assert grid_output[0].in_list == [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)]
+        assert grid_output[1].in_list == [(2.0, 4.0), (6.0, 8.0), (10.0, 12.0)]
+
+    def test__grid_2d_iterate_in__output_is_list_of_arrays__use_maximum_sub_size_in_all_pixels(
+        self
+    ):
+
+        mask = aa.Mask2D.manual(
+            mask=[
+                [True, True, True, True, True],
+                [True, False, False, False, True],
+                [True, False, False, False, True],
+                [True, False, False, False, True],
+                [True, True, True, True, True],
+            ],
+            pixel_scales=(1.0, 1.0),
+            origin=(0.001, 0.001),
+        )
+
+        grid_2d = aa.Grid2DIterate.from_mask(
+            mask=mask, fractional_accuracy=0.05, sub_steps=[2, 3]
+        )
+
+        grid_like_obj = MockGridLikeIteratorObj()
+
+        values = grid_like_obj.ndarray_1d_list_from(grid=grid_2d)
+
+        mask_sub_3 = mask.mask_new_sub_size_from(mask=mask, sub_size=3)
+        grid_sub_3 = aa.Grid2D.from_mask(mask=mask_sub_3)
+        values_sub_3 = ndarray_1d_from(grid=grid_sub_3, profile=None)
+        values_sub_3 = grid_sub_3.structure_2d_from(result=values_sub_3)
+
+        assert (values[0] == values_sub_3.binned).all()
+
     def test__grid_2d_iterate_in__output_is_list_of_grids__use_maximum_sub_size_in_all_pixels(
         self
     ):
@@ -487,3 +474,110 @@ class TestGrid2DToStructure:
 
         assert (values[0][0] == values_sub_3.binned[0]).all()
         assert (values[0][1] == values_sub_3.binned[1]).all()
+
+
+class TestGrid2DToVectorYX:
+    def test__grid_2d_in__output_values_same_format(self):
+
+        mask = aa.Mask2D.manual(
+            mask=[
+                [True, True, True, True],
+                [True, False, False, True],
+                [True, False, False, True],
+                [True, True, True, True],
+            ],
+            pixel_scales=(1.0, 1.0),
+            sub_size=1,
+        )
+
+        grid_2d = aa.Grid2D.from_mask(mask=mask)
+
+        grid_like_object = MockGrid2DLikeObj()
+
+        vectors_output = grid_like_object.ndarray_yx_2d_from(grid=grid_2d)
+
+        assert isinstance(vectors_output, aa.VectorYX2D)
+        assert (
+            vectors_output.native
+            == np.array(
+                [
+                    [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+                    [[0.0, 0.0], [1.0, -1.0], [1.0, 1.0], [0.0, 0.0]],
+                    [[0.0, 0.0], [-1.0, -1.0], [-1.0, 1.0], [0.0, 0.0]],
+                    [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+                ]
+            )
+        ).all()
+
+    def test__grid_2d_irregular_in__output_values_same_format(self):
+
+        grid_like_object = MockGrid2DLikeObj()
+
+        grid_2d = aa.Grid2DIrregular(grid=[(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)])
+
+        vectors_output = grid_like_object.ndarray_yx_2d_from(grid=grid_2d)
+
+        assert isinstance(vectors_output, aa.VectorYX2DIrregular)
+        assert vectors_output.in_list == [(2.0, 4.0), (6.0, 8.0), (10.0, 12.0)]
+
+    def test__grid_2d_iterate_in__output_values__use_iterated_grid_function(self):
+
+        mask = aa.Mask2D.manual(
+            mask=[
+                [True, True, True, True, True],
+                [True, False, False, False, True],
+                [True, False, False, False, True],
+                [True, False, False, False, True],
+                [True, True, True, True, True],
+            ],
+            pixel_scales=(1.0, 1.0),
+            origin=(0.001, 0.001),
+        )
+
+        grid_2d = aa.Grid2DIterate.from_mask(
+            mask=mask, fractional_accuracy=0.000001, sub_steps=[2, 4, 8, 16, 32]
+        )
+
+        grid_like_obj = MockGridLikeIteratorObj()
+
+        vectors_output = grid_like_obj.ndarray_yx_2d_from(grid=grid_2d)
+
+        mask_sub_2 = mask.mask_new_sub_size_from(mask=mask, sub_size=2)
+        grid_sub_2 = aa.Grid2D.from_mask(mask=mask_sub_2)
+        values_sub_2 = ndarray_2d_from(grid=grid_sub_2, profile=None)
+        values_sub_2 = grid_sub_2.structure_2d_from(result=values_sub_2)
+
+        assert isinstance(vectors_output, aa.VectorYX2D)
+        assert (vectors_output == values_sub_2.binned).all()
+
+        grid_2d = aa.Grid2DIterate.from_mask(
+            mask=mask, fractional_accuracy=0.5, sub_steps=[2, 4]
+        )
+
+        iterate_obj = MockGridLikeIteratorObj()
+
+        vectors_output = iterate_obj.ndarray_yx_2d_from(grid=grid_2d)
+
+        mask_sub_2 = mask.mask_new_sub_size_from(mask=mask, sub_size=2)
+        grid_sub_2 = aa.Grid2D.from_mask(mask=mask_sub_2)
+        values_sub_2 = ndarray_2d_from(grid=grid_sub_2, profile=None)
+        values_sub_2 = grid_sub_2.structure_2d_from(result=values_sub_2)
+
+        mask_sub_4 = mask.mask_new_sub_size_from(mask=mask, sub_size=4)
+        grid_sub_4 = aa.Grid2D.from_mask(mask=mask_sub_4)
+        values_sub_4 = ndarray_2d_from(grid=grid_sub_4, profile=None)
+        values_sub_4 = grid_sub_4.structure_2d_from(result=values_sub_4)
+
+        assert isinstance(vectors_output, aa.VectorYX2D)
+
+        assert vectors_output.native[1, 1, 0] == values_sub_2.binned.native[1, 1, 0]
+        assert vectors_output.native[2, 2, 0] != values_sub_2.binned.native[2, 2, 0]
+
+        assert vectors_output.native[1, 1, 0] != values_sub_4.binned.native[1, 1, 0]
+        assert vectors_output.native[2, 2, 0] == values_sub_4.binned.native[2, 2, 0]
+
+        assert vectors_output.native[1, 1, 1] == values_sub_2.binned.native[1, 1, 1]
+        assert vectors_output.native[2, 2, 1] != values_sub_2.binned.native[2, 2, 1]
+
+        assert vectors_output.native[1, 1, 1] != values_sub_4.binned.native[1, 1, 1]
+        assert vectors_output.native[2, 2, 1] == values_sub_4.binned.native[2, 2, 1]

--- a/test_autoarray/structures/grids/test_decorators.py
+++ b/test_autoarray/structures/grids/test_decorators.py
@@ -165,6 +165,21 @@ class TestGrid2DToStructure:
             )
         ).all()
 
+        # vectors_output = grid_like_object.ndarray_3d_from(grid=grid_2d)
+        #
+        # assert isinstance(grid_output, aa.VectorYX2D)
+        # assert (
+        #     grid_output.native
+        #     == np.array(
+        #         [
+        #             [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+        #             [[0.0, 0.0], [1.0, -1.0], [1.0, 1.0], [0.0, 0.0]],
+        #             [[0.0, 0.0], [-1.0, -1.0], [-1.0, 1.0], [0.0, 0.0]],
+        #             [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+        #         ]
+        #     )
+        # ).all()
+
     def test__grid_2d_in__output_is_list__list_of_same_format(self):
 
         mask = aa.Mask2D.manual(

--- a/test_autoarray/structures/grids/two_d/test_abstract_grid_2d.py
+++ b/test_autoarray/structures/grids/two_d/test_abstract_grid_2d.py
@@ -415,7 +415,7 @@ class TestGridRadialMinimum:
         grid = np.array([[2.5, 0.0], [4.0, 0.0], [6.0, 0.0]])
         mock_profile = MockGridRadialMinimum()
 
-        deflections = mock_profile.deflections_2d_from(grid=grid)
+        deflections = mock_profile.deflections_yx_2d_from(grid=grid)
         assert (deflections == grid).all()
 
     def test__mock_profile__grid_radial_minimum_is_above_some_radial_coordinates__moves_them_grid_radial_minimum(
@@ -424,7 +424,7 @@ class TestGridRadialMinimum:
         grid = np.array([[2.0, 0.0], [1.0, 0.0], [6.0, 0.0]])
         mock_profile = MockGridRadialMinimum()
 
-        deflections = mock_profile.deflections_2d_from(grid=grid)
+        deflections = mock_profile.deflections_yx_2d_from(grid=grid)
 
         assert (deflections == np.array([[2.5, 0.0], [2.5, 0.0], [6.0, 0.0]])).all()
 
@@ -439,7 +439,7 @@ class TestGridRadialMinimum:
 
         mock_profile = MockGridRadialMinimum()
 
-        deflections = mock_profile.deflections_2d_from(grid=grid)
+        deflections = mock_profile.deflections_yx_2d_from(grid=grid)
 
         assert deflections == pytest.approx(
             np.array(

--- a/test_autoarray/structures/vector_fields/test_vector_field_irregular.py
+++ b/test_autoarray/structures/vector_fields/test_vector_field_irregular.py
@@ -77,38 +77,6 @@ def test__input_grids_as_different_types__all_converted_to_grid_irregular_correc
     assert (vector_field.grid == np.array([[1.0, -1.0], [1.0, 1.0]])).all()
 
 
-def test__elliptical_properties_and_patches():
-
-    vector_field = aa.VectorField2DIrregular(
-        vectors=[(0.0, 1.0), (1.0, 0.0), (1.0, 1.0)],
-        grid=[[1.0, -1.0], [1.0, 1.0], [0.0, 0.0]],
-    )
-
-    assert isinstance(vector_field.ellipticities, aa.ValuesIrregular)
-    assert vector_field.ellipticities.in_list == [1.0, 1.0, np.sqrt(2.0)]
-
-    assert isinstance(vector_field.semi_major_axes, aa.ValuesIrregular)
-    assert vector_field.semi_major_axes.in_list == pytest.approx(
-        [6.0, 6.0, 7.242640], 1.0e-4
-    )
-
-    assert isinstance(vector_field.semi_minor_axes, aa.ValuesIrregular)
-    assert vector_field.semi_minor_axes.in_list == pytest.approx(
-        [0.0, 0.0, -1.242640], 1.0e-4
-    )
-
-    assert isinstance(vector_field.phis, aa.ValuesIrregular)
-    assert vector_field.phis.in_list == pytest.approx([0.0, 45.0, 22.5], 1.0e-4)
-
-    assert isinstance(vector_field.elliptical_patches[0], Ellipse)
-    assert vector_field.elliptical_patches[1].center == pytest.approx(
-        (1.0, 1.0), 1.0e-4
-    )
-    assert vector_field.elliptical_patches[1].width == pytest.approx(6.0, 1.0e-4)
-    assert vector_field.elliptical_patches[1].height == pytest.approx(0.0, 1.0e-4)
-    assert vector_field.elliptical_patches[1].angle == pytest.approx(45.0, 1.0e-4)
-
-
 def test__vectors_from_grid_within_radius():
 
     vector_field = aa.VectorField2DIrregular(

--- a/test_autoarray/structures/vector_fields/test_vector_field_irregular.py
+++ b/test_autoarray/structures/vector_fields/test_vector_field_irregular.py
@@ -16,96 +16,90 @@ def test__input_vectors_as_different_types__all_converted_to_ndarray_correctly()
 
     # Input tuples
 
-    vector_field = aa.VectorField2DIrregular(
+    vectors = aa.VectorYX2DIrregular(
         vectors=[(1.0, -1.0), (1.0, 1.0)], grid=[[1.0, -1.0], [1.0, 1.0]]
     )
 
-    assert type(vector_field) == aa.VectorField2DIrregular
-    assert (vector_field == np.array([[1.0, -1.0], [1.0, 1.0]])).all()
-    assert vector_field.in_list == [(1.0, -1.0), (1.0, 1.0)]
+    assert type(vectors) == aa.VectorYX2DIrregular
+    assert (vectors == np.array([[1.0, -1.0], [1.0, 1.0]])).all()
+    assert vectors.in_list == [(1.0, -1.0), (1.0, 1.0)]
 
     # Input np array
 
-    vector_field = aa.VectorField2DIrregular(
+    vectors = aa.VectorYX2DIrregular(
         vectors=[np.array([1.0, -1.0]), np.array([1.0, 1.0])],
         grid=[[1.0, -1.0], [1.0, 1.0]],
     )
 
-    assert type(vector_field) == aa.VectorField2DIrregular
-    assert (vector_field == np.array([[1.0, -1.0], [1.0, 1.0]])).all()
-    assert vector_field.in_list == [(1.0, -1.0), (1.0, 1.0)]
+    assert type(vectors) == aa.VectorYX2DIrregular
+    assert (vectors == np.array([[1.0, -1.0], [1.0, 1.0]])).all()
+    assert vectors.in_list == [(1.0, -1.0), (1.0, 1.0)]
 
     # Input list
 
-    vector_field = aa.VectorField2DIrregular(
+    vectors = aa.VectorYX2DIrregular(
         vectors=[[1.0, -1.0], [1.0, 1.0]], grid=[[1.0, -1.0], [1.0, 1.0]]
     )
 
-    assert type(vector_field) == aa.VectorField2DIrregular
-    assert (vector_field == np.array([[1.0, -1.0], [1.0, 1.0]])).all()
-    assert vector_field.in_list == [(1.0, -1.0), (1.0, 1.0)]
+    assert type(vectors) == aa.VectorYX2DIrregular
+    assert (vectors == np.array([[1.0, -1.0], [1.0, 1.0]])).all()
+    assert vectors.in_list == [(1.0, -1.0), (1.0, 1.0)]
 
 
 def test__input_grids_as_different_types__all_converted_to_grid_irregular_correctly():
 
     # Input tuples
 
-    vector_field = aa.VectorField2DIrregular(
+    vectors = aa.VectorYX2DIrregular(
         vectors=[(1.0, -1.0), (1.0, 1.0)],
         grid=aa.Grid2DIrregular([[1.0, -1.0], [1.0, 1.0]]),
     )
 
-    assert type(vector_field.grid) == aa.Grid2DIrregular
-    assert (vector_field.grid == np.array([[1.0, -1.0], [1.0, 1.0]])).all()
+    assert type(vectors.grid) == aa.Grid2DIrregular
+    assert (vectors.grid == np.array([[1.0, -1.0], [1.0, 1.0]])).all()
 
     # Input np array
 
-    vector_field = aa.VectorField2DIrregular(
+    vectors = aa.VectorYX2DIrregular(
         vectors=[(1.0, -1.0), (1.0, 1.0)], grid=[[1.0, -1.0], [1.0, 1.0]]
     )
 
-    assert type(vector_field.grid) == aa.Grid2DIrregular
-    assert (vector_field.grid == np.array([[1.0, -1.0], [1.0, 1.0]])).all()
+    assert type(vectors.grid) == aa.Grid2DIrregular
+    assert (vectors.grid == np.array([[1.0, -1.0], [1.0, 1.0]])).all()
 
     # Input list
 
-    vector_field = aa.VectorField2DIrregular(
+    vectors = aa.VectorYX2DIrregular(
         vectors=[(1.0, -1.0), (1.0, 1.0)], grid=[(1.0, -1.0), (1.0, 1.0)]
     )
 
-    assert type(vector_field.grid) == aa.Grid2DIrregular
-    assert (vector_field.grid == np.array([[1.0, -1.0], [1.0, 1.0]])).all()
+    assert type(vectors.grid) == aa.Grid2DIrregular
+    assert (vectors.grid == np.array([[1.0, -1.0], [1.0, 1.0]])).all()
 
 
 def test__vectors_from_grid_within_radius():
 
-    vector_field = aa.VectorField2DIrregular(
+    vectors = aa.VectorYX2DIrregular(
         vectors=[(1.0, 1.0), (2.0, 2.0)], grid=[[0.0, 1.0], [0.0, 2.0]]
     )
 
-    vector_field_masked = vector_field.vectors_within_radius(
-        radius=3.0, centre=(0.0, 0.0)
-    )
+    vectors_masked = vectors.vectors_within_radius(radius=3.0, centre=(0.0, 0.0))
 
-    assert type(vector_field_masked) == aa.VectorField2DIrregular
-    assert vector_field_masked.in_list == [(1.0, 1.0), (2.0, 2.0)]
-    assert vector_field_masked.grid.in_list == [(0.0, 1.0), (0.0, 2.0)]
+    assert type(vectors_masked) == aa.VectorYX2DIrregular
+    assert vectors_masked.in_list == [(1.0, 1.0), (2.0, 2.0)]
+    assert vectors_masked.grid.in_list == [(0.0, 1.0), (0.0, 2.0)]
 
-    vector_field_masked = vector_field.vectors_within_radius(
-        radius=1.5, centre=(0.0, 0.0)
-    )
+    vectors_masked = vectors.vectors_within_radius(radius=1.5, centre=(0.0, 0.0))
 
-    assert type(vector_field_masked) == aa.VectorField2DIrregular
-    assert vector_field_masked.in_list == [(1.0, 1.0)]
-    assert vector_field_masked.grid.in_list == [(0.0, 1.0)]
+    assert type(vectors_masked) == aa.VectorYX2DIrregular
+    assert vectors_masked.in_list == [(1.0, 1.0)]
+    assert vectors_masked.grid.in_list == [(0.0, 1.0)]
 
-    vector_field_masked = vector_field.vectors_within_radius(
-        radius=0.5, centre=(0.0, 2.0)
-    )
+    vectors_masked = vectors.vectors_within_radius(radius=0.5, centre=(0.0, 2.0))
 
-    assert type(vector_field_masked) == aa.VectorField2DIrregular
-    assert vector_field_masked.in_list == [(2.0, 2.0)]
-    assert vector_field_masked.grid.in_list == [(0.0, 2.0)]
+    assert type(vectors_masked) == aa.VectorYX2DIrregular
+    assert vectors_masked.in_list == [(2.0, 2.0)]
+    assert vectors_masked.grid.in_list == [(0.0, 2.0)]
 
     with pytest.raises(exc.VectorFieldException):
-        vector_field.vectors_within_radius(radius=0.0, centre=(0.0, 0.0))
+        vectors.vectors_within_radius(radius=0.0, centre=(0.0, 0.0))

--- a/test_autoarray/structures/vector_fields/test_vector_field_uniform.py
+++ b/test_autoarray/structures/vector_fields/test_vector_field_uniform.py
@@ -1,0 +1,76 @@
+from os import path
+import numpy as np
+import pytest
+
+from autoconf import conf
+import autoarray as aa
+from autoarray import exc
+
+test_grid_dir = path.join("{}".format(path.dirname(path.realpath(__file__))), "files")
+
+
+class TestAPI:
+    def test__manual(self):
+
+        vectors = aa.VectorField2D.manual_native(
+            vectors=[[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]],
+            pixel_scales=1.0,
+            sub_size=1,
+        )
+
+        assert type(vectors) == aa.VectorField2D
+        assert (
+            vectors == np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]])
+        ).all()
+        assert (
+            vectors.native
+            == np.array([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]])
+        ).all()
+        assert (
+            vectors.slim == np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]])
+        ).all()
+        assert (
+            vectors.binned.native
+            == np.array([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]])
+        ).all()
+        assert (
+            vectors.binned == np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]])
+        ).all()
+        assert (
+            vectors.grid.native
+            == np.array([[[0.5, -0.5], [0.5, 0.5]], [[-0.5, -0.5], [-0.5, 0.5]]])
+        ).all()
+        assert vectors.pixel_scales == (1.0, 1.0)
+        assert vectors.origin == (0.0, 0.0)
+        assert vectors.sub_size == 1
+
+        vectors = aa.VectorField2D.manual_slim(
+            vectors=[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]],
+            shape_native=(1, 1),
+            pixel_scales=1.0,
+            sub_size=2,
+            origin=(0.0, 1.0),
+        )
+
+        assert type(vectors) == aa.VectorField2D
+        assert (
+            vectors == np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]])
+        ).all()
+        assert (
+            vectors.native
+            == np.array([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]])
+        ).all()
+        assert (
+            vectors.slim == np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]])
+        ).all()
+
+        assert (vectors.binned.native == np.array([[[4.0, 5.0]]])).all()
+        print(vectors.grid)
+        assert (vectors.binned.slim == np.array([[4.0, 5.0]])).all()
+        assert (
+            vectors.grid.native
+            == np.array([[[0.25, 0.75], [0.25, 1.25]], [[-0.25, 0.75], [-0.25, 1.25]]])
+        ).all()
+        assert vectors.pixel_scales == (1.0, 1.0)
+        assert vectors.origin == (0.0, 1.0)
+        assert vectors.sub_size == 2

--- a/test_autoarray/structures/vector_fields/test_vector_field_uniform.py
+++ b/test_autoarray/structures/vector_fields/test_vector_field_uniform.py
@@ -12,13 +12,13 @@ test_grid_dir = path.join("{}".format(path.dirname(path.realpath(__file__))), "f
 class TestAPI:
     def test__manual(self):
 
-        vectors = aa.VectorField2D.manual_native(
+        vectors = aa.VectorYX2D.manual_native(
             vectors=[[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]],
             pixel_scales=1.0,
             sub_size=1,
         )
 
-        assert type(vectors) == aa.VectorField2D
+        assert type(vectors) == aa.VectorYX2D
         assert (
             vectors == np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]])
         ).all()
@@ -44,7 +44,7 @@ class TestAPI:
         assert vectors.origin == (0.0, 0.0)
         assert vectors.sub_size == 1
 
-        vectors = aa.VectorField2D.manual_slim(
+        vectors = aa.VectorYX2D.manual_slim(
             vectors=[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]],
             shape_native=(1, 1),
             pixel_scales=1.0,
@@ -52,7 +52,7 @@ class TestAPI:
             origin=(0.0, 1.0),
         )
 
-        assert type(vectors) == aa.VectorField2D
+        assert type(vectors) == aa.VectorYX2D
         assert (
             vectors == np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]])
         ).all()


### PR DESCRIPTION
This PR refactors the PyAutoGalaxy profile module, in particular moving calculations which use the `image_2d` of a light profile (e.g. computing its blurred image via the PSF) to a class `CalcImage` and moving all calculations which use the `deflections_2d` of a mass profile (e.g. computes the magnification from these values) to a class `CalcLens`.

In PyAutoArray, I have add a `VectorField2D` class whcih stores vectors of data, primarily deflection angles and a shear field. This does not change the way profiles / calculations are performed.