### PR TITLE
feature/array_native

### DIFF
--- a/autoarray/structures/arrays/array_2d_util.py
+++ b/autoarray/structures/arrays/array_2d_util.py
@@ -34,7 +34,7 @@ def check_array_2d(array_2d: np.ndarray):
 
 
 def convert_array_2d(
-    array_2d: Union[np.ndarray, List], mask_2d: "Mask2D"
+    array_2d: Union[np.ndarray, List], mask_2d: "Mask2D", store_native : bool = False
 ) -> np.ndarray:
     """
     The `manual` classmethods in the `Array2D` object take as input a list or ndarray which is returned as an
@@ -55,9 +55,17 @@ def convert_array_2d(
         The input structure which is converted to an ndarray if it is a list.
     mask_2d
         The mask of the output Array2D.
+    store_native
+        If True, the array is stored in its native format [total_y_pixels, total_x_pixels]. The only use of
+        this is to avoid mapping large data arrays to and from the slim / native formats, which can be a
+        computational bottleneck.
     """
 
     array_2d = convert_array(array=array_2d)
+
+    if store_native:
+        array_2d *= np.invert(mask_2d)
+        return array_2d
 
     return convert_array_2d_to_slim(array_2d=array_2d, mask_2d=mask_2d)
 

--- a/autoarray/structures/arrays/uniform_2d.py
+++ b/autoarray/structures/arrays/uniform_2d.py
@@ -635,7 +635,7 @@ class Array2D(AbstractArray2D):
 
     @classmethod
     def manual_mask(
-        cls, array: Union[np.ndarray, List], mask: Mask2D, header: Header = None
+        cls, array: Union[np.ndarray, List], mask: Mask2D, header: Header = None, store_native : bool = False
     ) -> "Array2D":
         """
         Create an `Array2D` (see `AbstractArray2D.__new__`) by inputting the array values in 1D or 2D with its mask,
@@ -651,8 +651,12 @@ class Array2D(AbstractArray2D):
             lists.
         mask
             The mask whose masked pixels are used to setup the sub-pixel grid.
+        store_native
+            If True, the array is stored in its native format [total_y_pixels, total_x_pixels]. The only use of
+            this is to avoid mapping large data arrays to and from the slim / native formats, which can be a
+            computational bottleneck.
         """
-        array = array_2d_util.convert_array_2d(array_2d=array, mask_2d=mask)
+        array = array_2d_util.convert_array_2d(array_2d=array, mask_2d=mask, store_native=store_native)
         return Array2D(array=array, mask=mask, header=header)
 
     @classmethod

--- a/test_autoarray/structures/arrays/test_uniform_2d.py
+++ b/test_autoarray/structures/arrays/test_uniform_2d.py
@@ -121,6 +121,13 @@ class TestAPI:
             arr.native == np.array([[1.0, 2.0], [3.0, 4.0], [0.0, 0.0], [0.0, 0.0]])
         ).all()
 
+        mask = aa.Mask2D.manual(
+            mask=[[False, False], [True, False]], pixel_scales=1.0, origin=(0.0, 1.0),
+        )
+        arr = aa.Array2D.manual_mask(array=[[1.0, 2.0], [3.0, 4.0]], mask=mask, store_native=True)
+
+        assert (arr == np.array([[1.0, 2.0], [0.0, 4.0]])).all()
+
     def test__manual_native__exception_raised_if_input_array_is_2d_and_not_sub_shape_of_mask(
         self,
     ):


### PR DESCRIPTION
By default, when an `Array2D` is input into a `manual` method in its `native` format (e.g. a 2D ndarray), it is mapped to its `slim` representation (e.g. a 1D `ndarray` consisting of all unmasked values).

In most use cases this process is very fast. However, in PyAutoCTI, the large quantity of data means this can become a bottleneck in the `log_likelihood_function`.

This feature adds an optional input which keeps the data in its `native` format, avoiding the slow mapping to a `slim` format.