### PR TITLE
Feature/chi squared fast

### DIFF
--- a/autoarray/fit/fit_util.py
+++ b/autoarray/fit/fit_util.py
@@ -270,6 +270,33 @@ def chi_squared_with_mask_from(*, chi_squared_map: Structure, mask: Mask) -> flo
     return float(np.sum(chi_squared_map[np.asarray(mask) == 0]))
 
 
+def chi_squared_with_mask_fast_from(*, data: Structure, mask: Mask, model_data: Structure, noise_map: Structure) -> float:
+    """
+    Returns the chi-squared terms of each model data's fit to a masked dataset, by summing the masked
+    chi-squared-map of the fit.
+
+    The chi-squared values in masked pixels are omitted from the calculation.
+
+    Other methods in `fit_util` compute the `chi-squared` from the `residual_map` and `chi_squared_map`, which requires
+    that the `ndarrays` which are used to do this are created and stored in memory. For problems with large datasets
+    this can be computationally slow.
+
+    This function computes the `chi_squared` directly from the data, avoiding the need to store the data in memory
+    and offering faster tune times.
+
+    Parameters
+    ----------
+    chi_squared_map
+        The chi-squared-map of values of the model-data fit to the dataset.
+    mask
+        The mask applied to the chi-squared-map, where `False` entries are included in the calculation.
+    """
+
+    return float(np.sum(np.square(np.divide(np.subtract(
+        data, model_data, out=np.zeros_like(data), where=np.asarray(mask) == 0
+    ), noise_map))))
+
+
 def noise_normalization_with_mask_from(*, noise_map: Structure, mask: Mask) -> float:
     """
     Returns the noise-map normalization terms of masked noise-map, summing the noise_map value in every pixel as:

--- a/autoarray/fit/fit_util.py
+++ b/autoarray/fit/fit_util.py
@@ -270,7 +270,9 @@ def chi_squared_with_mask_from(*, chi_squared_map: Structure, mask: Mask) -> flo
     return float(np.sum(chi_squared_map[np.asarray(mask) == 0]))
 
 
-def chi_squared_with_mask_fast_from(*, data: Structure, mask: Mask, model_data: Structure, noise_map: Structure) -> float:
+def chi_squared_with_mask_fast_from(
+    *, data: Structure, mask: Mask, model_data: Structure, noise_map: Structure
+) -> float:
     """
     Returns the chi-squared terms of each model data's fit to a masked dataset, by summing the masked
     chi-squared-map of the fit.
@@ -292,9 +294,21 @@ def chi_squared_with_mask_fast_from(*, data: Structure, mask: Mask, model_data: 
         The mask applied to the chi-squared-map, where `False` entries are included in the calculation.
     """
 
-    return float(np.sum(np.square(np.divide(np.subtract(
-        data, model_data, out=np.zeros_like(data), where=np.asarray(mask) == 0
-    ), noise_map))))
+    return float(
+        np.sum(
+            np.square(
+                np.divide(
+                    np.subtract(
+                        data,
+                        model_data,
+                        out=np.zeros_like(data),
+                        where=np.asarray(mask) == 0,
+                    ),
+                    noise_map,
+                )
+            )
+        )
+    )
 
 
 def noise_normalization_with_mask_from(*, noise_map: Structure, mask: Mask) -> float:

--- a/autoarray/structures/arrays/array_2d_util.py
+++ b/autoarray/structures/arrays/array_2d_util.py
@@ -34,7 +34,7 @@ def check_array_2d(array_2d: np.ndarray):
 
 
 def convert_array_2d(
-    array_2d: Union[np.ndarray, List], mask_2d: "Mask2D", store_native : bool = False
+    array_2d: Union[np.ndarray, List], mask_2d: "Mask2D", store_native: bool = False
 ) -> np.ndarray:
     """
     The `manual` classmethods in the `Array2D` object take as input a list or ndarray which is returned as an

--- a/autoarray/structures/arrays/uniform_2d.py
+++ b/autoarray/structures/arrays/uniform_2d.py
@@ -635,7 +635,11 @@ class Array2D(AbstractArray2D):
 
     @classmethod
     def manual_mask(
-        cls, array: Union[np.ndarray, List], mask: Mask2D, header: Header = None, store_native : bool = False
+        cls,
+        array: Union[np.ndarray, List],
+        mask: Mask2D,
+        header: Header = None,
+        store_native: bool = False,
     ) -> "Array2D":
         """
         Create an `Array2D` (see `AbstractArray2D.__new__`) by inputting the array values in 1D or 2D with its mask,
@@ -656,7 +660,9 @@ class Array2D(AbstractArray2D):
             this is to avoid mapping large data arrays to and from the slim / native formats, which can be a
             computational bottleneck.
         """
-        array = array_2d_util.convert_array_2d(array_2d=array, mask_2d=mask, store_native=store_native)
+        array = array_2d_util.convert_array_2d(
+            array_2d=array, mask_2d=mask, store_native=store_native
+        )
         return Array2D(array=array, mask=mask, header=header)
 
     @classmethod

--- a/autoarray/structures/mock/mock_structure_decorators.py
+++ b/autoarray/structures/mock/mock_structure_decorators.py
@@ -60,7 +60,9 @@ def _cartesian_grid_via_radial_from(grid, radius):
 
 
 def ndarray_2d_from(profile, grid):
-    return _cartesian_grid_via_radial_from(grid=grid, radius=np.full(grid.shape[0], 2.0))
+    return _cartesian_grid_via_radial_from(
+        grid=grid, radius=np.full(grid.shape[0], 2.0)
+    )
 
 
 class MockGridLikeIteratorObj:
@@ -175,7 +177,9 @@ class MockGridLikeIteratorObj:
         Such functions are common in **PyAutoGalaxy** for light and mass profile objects.
         """
         return [
-            self._cartesian_grid_via_radial_from(grid=grid, radius=np.full(grid.shape[0], 2.0))
+            self._cartesian_grid_via_radial_from(
+                grid=grid, radius=np.full(grid.shape[0], 2.0)
+            )
         ]
 
     @structure_decorators.grid_2d_to_vector_yx
@@ -188,7 +192,9 @@ class MockGridLikeIteratorObj:
         Such functions are common in **PyAutoGalaxy** for light and mass profile objects.
         """
         return [
-            self._cartesian_grid_via_radial_from(grid=grid, radius=np.full(grid.shape[0], 2.0))
+            self._cartesian_grid_via_radial_from(
+                grid=grid, radius=np.full(grid.shape[0], 2.0)
+            )
         ]
 
 

--- a/test_autoarray/fit/test_fit_util.py
+++ b/test_autoarray/fit/test_fit_util.py
@@ -227,6 +227,55 @@ def test__chi_squared_with_noise_covariance_from():
     assert chi_squared == 43
 
 
+def test__chi_squared_with_mask_fast_from():
+
+    data = np.array([10.0, 10.0, 10.0, 10.0])
+    mask = np.array([True, False, False, True])
+    noise_map = np.array([1.0, 2.0, 3.0, 4.0])
+    model_data = np.array([11.0, 10.0, 9.0, 8.0])
+
+    residual_map = aa.util.fit.residual_map_with_mask_from(
+        data=data, mask=mask, model_data=model_data
+    )
+
+    chi_squared_map = aa.util.fit.chi_squared_map_with_mask_from(
+        residual_map=residual_map, mask=mask, noise_map=noise_map
+    )
+
+    chi_squared = aa.util.fit.chi_squared_with_mask_from(
+        mask=mask, chi_squared_map=chi_squared_map
+    )
+
+    chi_squared_fast = aa.util.fit.chi_squared_with_mask_fast_from(
+        data=data, noise_map=noise_map, mask=mask, model_data=model_data,
+    )
+
+    assert chi_squared == pytest.approx(chi_squared_fast, 1.0e-4)
+
+    data = np.array([[10.0, 10.0], [10.0, 10.0]])
+    mask = np.array([[True, False], [False, True]])
+    noise_map = np.array([[1.0, 2.0], [3.0, 4.0]])
+    model_data = np.array([[11.0, 10.0], [9.0, 8.0]])
+
+    residual_map = aa.util.fit.residual_map_with_mask_from(
+        data=data, mask=mask, model_data=model_data
+    )
+
+    chi_squared_map = aa.util.fit.chi_squared_map_with_mask_from(
+        residual_map=residual_map, mask=mask, noise_map=noise_map
+    )
+
+    chi_squared = aa.util.fit.chi_squared_with_mask_from(
+        mask=mask, chi_squared_map=chi_squared_map
+    )
+
+    chi_squared_fast = aa.util.fit.chi_squared_with_mask_fast_from(
+        data=data, noise_map=noise_map, mask=mask, model_data=model_data,
+    )
+
+    assert chi_squared == pytest.approx(chi_squared_fast, 1.0e-4)
+
+
 def test__log_likelihood_from():
 
     data = np.array([10.0, 10.0, 10.0, 10.0])

--- a/test_autoarray/fit/test_fit_util.py
+++ b/test_autoarray/fit/test_fit_util.py
@@ -247,7 +247,10 @@ def test__chi_squared_with_mask_fast_from():
     )
 
     chi_squared_fast = aa.util.fit.chi_squared_with_mask_fast_from(
-        data=data, noise_map=noise_map, mask=mask, model_data=model_data,
+        data=data,
+        noise_map=noise_map,
+        mask=mask,
+        model_data=model_data,
     )
 
     assert chi_squared == pytest.approx(chi_squared_fast, 1.0e-4)
@@ -270,7 +273,10 @@ def test__chi_squared_with_mask_fast_from():
     )
 
     chi_squared_fast = aa.util.fit.chi_squared_with_mask_fast_from(
-        data=data, noise_map=noise_map, mask=mask, model_data=model_data,
+        data=data,
+        noise_map=noise_map,
+        mask=mask,
+        model_data=model_data,
     )
 
     assert chi_squared == pytest.approx(chi_squared_fast, 1.0e-4)

--- a/test_autoarray/structures/arrays/test_uniform_2d.py
+++ b/test_autoarray/structures/arrays/test_uniform_2d.py
@@ -122,9 +122,13 @@ class TestAPI:
         ).all()
 
         mask = aa.Mask2D.manual(
-            mask=[[False, False], [True, False]], pixel_scales=1.0, origin=(0.0, 1.0),
+            mask=[[False, False], [True, False]],
+            pixel_scales=1.0,
+            origin=(0.0, 1.0),
         )
-        arr = aa.Array2D.manual_mask(array=[[1.0, 2.0], [3.0, 4.0]], mask=mask, store_native=True)
+        arr = aa.Array2D.manual_mask(
+            array=[[1.0, 2.0], [3.0, 4.0]], mask=mask, store_native=True
+        )
 
         assert (arr == np.array([[1.0, 2.0], [0.0, 4.0]])).all()
 


### PR DESCRIPTION
The `chi_squared` is a term in the log_likelihood of a fit, which is  (`data` - `model_data` / `noise_map`) ** 2

In most use cases, this is very fast (< 1.0e-4 seconds) and thus is done in a series of separate function calls for readability, which store different `ndarrays` in memory. 

However, in PyAutoCTI, the large quantity of data means this can take > 0.3s. A fast chi-squared calculation which performs the calculation on all memories at once is therefore implemented.