### PR TITLE
Feature/preload linear light

### DIFF
--- a/autoarray/inversion/inversion/imaging/abstract.py
+++ b/autoarray/inversion/inversion/imaging/abstract.py
@@ -158,6 +158,9 @@ class AbstractInversionImaging(AbstractInversion):
         convolved with the kernel.
         """
 
+        if self.preloads.linear_func_weighted_mapping_vectors_dict is not None:
+            return self.preloads.linear_func_weighted_mapping_vectors_dict
+
         linear_func_weighted_mapping_vectors_dict = {}
 
         for (

--- a/autoarray/inversion/inversion/imaging/abstract.py
+++ b/autoarray/inversion/inversion/imaging/abstract.py
@@ -190,6 +190,9 @@ class AbstractInversionImaging(AbstractInversion):
         divided by the noise squared convolved with the kernel).
         """
 
+        if self.preloads.linear_func_curvature_vectors_dict is not None:
+            return self.preloads.linear_func_curvature_vectors_dict
+
         linear_func_curvature_vectors_dict = {}
 
         for (

--- a/autoarray/inversion/inversion/imaging/abstract.py
+++ b/autoarray/inversion/inversion/imaging/abstract.py
@@ -110,6 +110,18 @@ class AbstractInversionImaging(AbstractInversion):
             for linear_obj in self.linear_obj_list
         ]
 
+    def _linear_func_preload_dict_map(self, linear_func_preload_dict: Dict) -> Dict:
+
+        linear_func_dict = {}
+
+        for linear_func, values in zip(
+            self.cls_list_from(cls=AbstractLinearObjFuncList),
+            linear_func_preload_dict.values(),
+        ):
+            linear_func_dict[linear_func] = values
+
+        return linear_func_dict
+
     @cached_property
     @profile_func
     def linear_func_operated_mapping_matrix_dict(self) -> Dict:
@@ -128,7 +140,9 @@ class AbstractInversionImaging(AbstractInversion):
         """
 
         if self.preloads.linear_func_operated_mapping_matrix_dict is not None:
-            return self.preloads.linear_func_operated_mapping_matrix_dict
+            return self._linear_func_preload_dict_map(
+                linear_func_preload_dict=self.preloads.linear_func_operated_mapping_matrix_dict
+            )
 
         linear_func_operated_mapping_matrix_dict = {}
 
@@ -163,7 +177,9 @@ class AbstractInversionImaging(AbstractInversion):
         """
 
         if self.preloads.linear_func_weighted_mapping_vectors_dict is not None:
-            return self.preloads.linear_func_weighted_mapping_vectors_dict
+            return self._linear_func_preload_dict_map(
+                linear_func_preload_dict=self.preloads.linear_func_weighted_mapping_vectors_dict
+            )
 
         linear_func_weighted_mapping_vectors_dict = {}
 
@@ -195,7 +211,9 @@ class AbstractInversionImaging(AbstractInversion):
         """
 
         if self.preloads.linear_func_curvature_vectors_dict is not None:
-            return self.preloads.linear_func_curvature_vectors_dict
+            return self._linear_func_preload_dict_map(
+                linear_func_preload_dict=self.preloads.linear_func_curvature_vectors_dict
+            )
 
         linear_func_curvature_vectors_dict = {}
 

--- a/autoarray/inversion/inversion/imaging/abstract.py
+++ b/autoarray/inversion/inversion/imaging/abstract.py
@@ -187,17 +187,17 @@ class AbstractInversionImaging(AbstractInversion):
         divided by the noise squared convolved with the kernel).
         """
 
-        linear_func_operated_noise_vectors_dict = {}
+        linear_func_curvature_vectors_dict = {}
 
         for (
             linear_func,
             operated_mapping_matrix,
         ) in self.linear_func_operated_mapping_matrix_dict.items():
 
-            linear_func_operated_noise_vectors_dict[
+            linear_func_curvature_vectors_dict[
                 linear_func
             ] = self.convolver.convolve_mapping_matrix(
                 mapping_matrix=operated_mapping_matrix / self.noise_map[:, None] ** 2
             )
 
-        return linear_func_operated_noise_vectors_dict
+        return linear_func_curvature_vectors_dict

--- a/autoarray/inversion/inversion/imaging/abstract.py
+++ b/autoarray/inversion/inversion/imaging/abstract.py
@@ -126,6 +126,10 @@ class AbstractInversionImaging(AbstractInversion):
         -------
         A dictionary mapping every linear function object to its operated mapping matrix.
         """
+
+        if self.preloads.linear_func_operated_mapping_matrix_dict is not None:
+            return self.preloads.linear_func_operated_mapping_matrix_dict
+
         linear_func_operated_mapping_matrix_dict = {}
 
         for linear_func in self.cls_list_from(cls=AbstractLinearObjFuncList):

--- a/autoarray/inversion/inversion/imaging/w_tilde.py
+++ b/autoarray/inversion/inversion/imaging/w_tilde.py
@@ -249,6 +249,9 @@ class InversionImagingWTilde(AbstractInversionImaging):
         by computing each one (and their off-diagonal matrices) and combining them via the `block_diag` method.
         """
 
+        if self.preloads.curvature_matrix_mapper_diag is not None:
+            return self.preloads.curvature_matrix_mapper_diag
+
         curvature_matrix = np.zeros((self.total_params, self.total_params))
 
         mapper_list = self.cls_list_from(cls=AbstractMapper)

--- a/autoarray/inversion/inversion/imaging/w_tilde.py
+++ b/autoarray/inversion/inversion/imaging/w_tilde.py
@@ -240,29 +240,7 @@ class InversionImagingWTilde(AbstractInversionImaging):
 
     @property
     @profile_func
-    def _curvature_matrix_x1_mapper(self) -> np.ndarray:
-        """
-        Returns the `curvature_matrix`, a 2D matrix which uses the mappings between the data and the linear objects to
-        construct the simultaneous linear equations. The object is described in full in the method `curvature_matrix`.
-
-        This method computes the `curvature_matrix` when there is a single mapper object in the `Inversion`,
-        which circumvents `block_diag` for speed up.
-        """
-        return inversion_imaging_util.curvature_matrix_via_w_tilde_curvature_preload_imaging_from(
-            curvature_preload=self.w_tilde.curvature_preload,
-            curvature_indexes=self.w_tilde.indexes,
-            curvature_lengths=self.w_tilde.lengths,
-            data_to_pix_unique=self.linear_obj_list[
-                0
-            ].unique_mappings.data_to_pix_unique,
-            data_weights=self.linear_obj_list[0].unique_mappings.data_weights,
-            pix_lengths=self.linear_obj_list[0].unique_mappings.pix_lengths,
-            pix_pixels=self.linear_obj_list[0].params,
-        )
-
-    @property
-    @profile_func
-    def _curvature_matrix_multi_mapper(self) -> np.ndarray:
+    def _curvature_matrix_mapper_diag(self) -> np.ndarray:
         """
         Returns the `curvature_matrix`, a 2D matrix which uses the mappings between the data and the linear objects to
         construct the simultaneous linear equations. The object is described in full in the method `curvature_matrix`.
@@ -298,20 +276,6 @@ class InversionImagingWTilde(AbstractInversionImaging):
 
             if self.total(cls=AbstractMapper) == 1:
                 return curvature_matrix
-
-            for j in range(i + 1, len(mapper_list)):
-
-                mapper_j = mapper_list[j]
-                mapper_param_range_j = mapper_param_range_list[j]
-
-                off_diag = self._curvature_matrix_off_diag_from(
-                    mapper_0=mapper_i, mapper_1=mapper_j
-                )
-
-                curvature_matrix[
-                    mapper_param_range_i[0] : mapper_param_range_i[1],
-                    mapper_param_range_j[0] : mapper_param_range_j[1],
-                ] = off_diag
 
         curvature_matrix = inversion_util.curvature_matrix_mirrored_from(
             curvature_matrix=curvature_matrix
@@ -362,6 +326,62 @@ class InversionImagingWTilde(AbstractInversionImaging):
         )
 
         return curvature_matrix_off_diag_0 + curvature_matrix_off_diag_1.T
+
+    @property
+    @profile_func
+    def _curvature_matrix_x1_mapper(self) -> np.ndarray:
+        """
+        Returns the `curvature_matrix`, a 2D matrix which uses the mappings between the data and the linear objects to
+        construct the simultaneous linear equations. The object is described in full in the method `curvature_matrix`.
+
+        This method computes the `curvature_matrix` when there is a single mapper object in the `Inversion`,
+        which circumvents `block_diag` for speed up.
+        """
+        return self._curvature_matrix_mapper_diag
+
+    @property
+    @profile_func
+    def _curvature_matrix_multi_mapper(self) -> np.ndarray:
+        """
+        Returns the `curvature_matrix`, a 2D matrix which uses the mappings between the data and the linear objects to
+        construct the simultaneous linear equations. The object is described in full in the method `curvature_matrix`.
+
+        This method computes the `curvature_matrix` when there are multiple mapper objects in the `Inversion`,
+        by computing each one (and their off-diagonal matrices) and combining them via the `block_diag` method.
+        """
+
+        curvature_matrix = self._curvature_matrix_mapper_diag
+
+        if self.total(cls=AbstractMapper) == 1:
+            return curvature_matrix
+
+        mapper_list = self.cls_list_from(cls=AbstractMapper)
+        mapper_param_range_list = self.param_range_list_from(cls=AbstractMapper)
+
+        for i in range(len(mapper_list)):
+
+            mapper_i = mapper_list[i]
+            mapper_param_range_i = mapper_param_range_list[i]
+
+            for j in range(i + 1, len(mapper_list)):
+
+                mapper_j = mapper_list[j]
+                mapper_param_range_j = mapper_param_range_list[j]
+
+                off_diag = self._curvature_matrix_off_diag_from(
+                    mapper_0=mapper_i, mapper_1=mapper_j
+                )
+
+                curvature_matrix[
+                    mapper_param_range_i[0] : mapper_param_range_i[1],
+                    mapper_param_range_j[0] : mapper_param_range_j[1],
+                ] = off_diag
+
+        curvature_matrix = inversion_util.curvature_matrix_mirrored_from(
+            curvature_matrix=curvature_matrix
+        )
+
+        return curvature_matrix
 
     @property
     @profile_func

--- a/autoarray/inversion/inversion/imaging/w_tilde.py
+++ b/autoarray/inversion/inversion/imaging/w_tilde.py
@@ -242,11 +242,12 @@ class InversionImagingWTilde(AbstractInversionImaging):
     @profile_func
     def _curvature_matrix_mapper_diag(self) -> np.ndarray:
         """
-        Returns the `curvature_matrix`, a 2D matrix which uses the mappings between the data and the linear objects to
-        construct the simultaneous linear equations. The object is described in full in the method `curvature_matrix`.
+        Returns the diagonal regions of the `curvature_matrix`, a 2D matrix which uses the mappings between the data
+        and the linear objects to construct the simultaneous linear equations. The object is described in full in
+        the method `curvature_matrix`.
 
-        This method computes the `curvature_matrix` when there are multiple mapper objects in the `Inversion`,
-        by computing each one (and their off-diagonal matrices) and combining them via the `block_diag` method.
+        This method computes the diagonal entries of all mapper objects in the `curvature_matrix`. It is separate from
+        other calculations to enable preloading of this calculation.
         """
 
         if self.preloads.curvature_matrix_mapper_diag is not None:

--- a/autoarray/inversion/mock/mock_inversion.py
+++ b/autoarray/inversion/mock/mock_inversion.py
@@ -15,6 +15,7 @@ class MockInversion(AbstractInversion):
         operated_mapping_matrix=None,
         data_vector=None,
         curvature_matrix=None,
+        curvature_matrix_mapper_diag=None,
         regularization_matrix=None,
         curvature_reg_matrix=None,
         reconstruction: np.ndarray = None,
@@ -44,6 +45,7 @@ class MockInversion(AbstractInversion):
         self._data_vector = data_vector
         self._regularization_matrix = regularization_matrix
         self._curvature_matrix = curvature_matrix
+        self._curvature_matrix_mapper_diag = curvature_matrix_mapper_diag
         self._curvature_reg_matrix = curvature_reg_matrix
         self._reconstruction = reconstruction
         self._reconstruction_dict = reconstruction_dict
@@ -89,6 +91,14 @@ class MockInversion(AbstractInversion):
             return super().curvature_matrix
 
         return self._curvature_matrix
+
+    @property
+    def curvature_matrix_mapper_diag(self):
+
+        if self._curvature_matrix_mapper_diag is None:
+            return super()._curvature_matrix_mapper_diag
+
+        return self._curvature_matrix_mapper_diag
 
     @property
     def curvature_reg_matrix(self):

--- a/autoarray/inversion/mock/mock_inversion_imaging.py
+++ b/autoarray/inversion/mock/mock_inversion_imaging.py
@@ -15,6 +15,7 @@ class MockInversionImaging(InversionImagingMapping):
         convolver=None,
         linear_obj_list=None,
         operated_mapping_matrix=None,
+        linear_func_operated_mapping_matrix_dict=None,
         linear_func_weighted_mapping_vectors_dict=None,
         linear_func_curvature_vectors_dict=None,
         curvature_matrix_preload=None,
@@ -34,6 +35,9 @@ class MockInversionImaging(InversionImagingMapping):
 
         self._operated_mapping_matrix = operated_mapping_matrix
 
+        self._linear_func_operated_mapping_matrix_dict = (
+            linear_func_operated_mapping_matrix_dict
+        )
         self._linear_func_weighted_mapping_vectors_dict = (
             linear_func_weighted_mapping_vectors_dict
         )
@@ -47,6 +51,13 @@ class MockInversionImaging(InversionImagingMapping):
             return super().operated_mapping_matrix
 
         return self._operated_mapping_matrix
+
+    @property
+    def linear_func_operated_mapping_matrix_dict(self) -> Dict:
+        if self._linear_func_operated_mapping_matrix_dict is None:
+            return super().linear_func_operated_mapping_matrix_dict
+
+        return self._linear_func_operated_mapping_matrix_dict
 
     @property
     def linear_func_weighted_mapping_vectors_dict(self) -> Dict:

--- a/autoarray/inversion/mock/mock_inversion_imaging.py
+++ b/autoarray/inversion/mock/mock_inversion_imaging.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from autoarray.inversion.inversion.imaging.mapping import InversionImagingMapping
+from autoarray.inversion.inversion.imaging.w_tilde import InversionImagingWTilde
 from autoarray.inversion.inversion.settings import SettingsInversion
 from autoarray.preloads import Preloads
 
@@ -53,3 +54,42 @@ class MockInversionImaging(InversionImagingMapping):
             return super().curvature_matrix_counts
 
         return self._curvature_matrix_counts
+
+
+class MockWTildeImaging:
+    def check_noise_map(self, noise_map):
+
+        pass
+
+
+class MockInversionImagingWTilde(InversionImagingWTilde):
+    def __init__(
+        self,
+        data=None,
+        noise_map=None,
+        convolver=None,
+        w_tilde=None,
+        linear_obj_list=None,
+        curvature_matrix_mapper_diag=None,
+        settings: SettingsInversion = SettingsInversion(),
+        preloads: Preloads = Preloads(),
+    ):
+
+        super().__init__(
+            data=data,
+            noise_map=noise_map,
+            convolver=convolver,
+            w_tilde=w_tilde or MockWTildeImaging(),
+            linear_obj_list=linear_obj_list,
+            settings=settings,
+            preloads=preloads,
+        )
+
+        self.__curvature_matrix_mapper_diag = curvature_matrix_mapper_diag
+
+    @property
+    def curvature_matrix_mapper_diag(self):
+        if self.__curvature_matrix_mapper_diag is None:
+            return super()._curvature_matrix_mapper_diag
+
+        return self.__curvature_matrix_mapper_diag

--- a/autoarray/inversion/mock/mock_inversion_imaging.py
+++ b/autoarray/inversion/mock/mock_inversion_imaging.py
@@ -1,4 +1,5 @@
 import numpy as np
+from typing import Dict
 
 from autoarray.inversion.inversion.imaging.mapping import InversionImagingMapping
 from autoarray.inversion.inversion.imaging.w_tilde import InversionImagingWTilde
@@ -14,6 +15,8 @@ class MockInversionImaging(InversionImagingMapping):
         convolver=None,
         linear_obj_list=None,
         operated_mapping_matrix=None,
+        linear_func_weighted_mapping_vectors_dict=None,
+        linear_func_curvature_vectors_dict=None,
         curvature_matrix_preload=None,
         curvature_matrix_counts=None,
         settings: SettingsInversion = SettingsInversion(),
@@ -31,6 +34,10 @@ class MockInversionImaging(InversionImagingMapping):
 
         self._operated_mapping_matrix = operated_mapping_matrix
 
+        self._linear_func_weighted_mapping_vectors_dict = (
+            linear_func_weighted_mapping_vectors_dict
+        )
+        self._linear_func_curvature_vectors_dict = linear_func_curvature_vectors_dict
         self._curvature_matrix_preload = curvature_matrix_preload
         self._curvature_matrix_counts = curvature_matrix_counts
 
@@ -40,6 +47,20 @@ class MockInversionImaging(InversionImagingMapping):
             return super().operated_mapping_matrix
 
         return self._operated_mapping_matrix
+
+    @property
+    def linear_func_weighted_mapping_vectors_dict(self) -> Dict:
+        if self._linear_func_weighted_mapping_vectors_dict is None:
+            return super().linear_func_weighted_mapping_vectors_dict
+
+        return self._linear_func_weighted_mapping_vectors_dict
+
+    @property
+    def linear_func_curvature_vectors_dict(self) -> Dict:
+        if self._linear_func_curvature_vectors_dict is None:
+            return super().linear_func_curvature_vectors_dict
+
+        return self._linear_func_curvature_vectors_dict
 
     @property
     def curvature_matrix_preload(self):

--- a/autoarray/mock.py
+++ b/autoarray/mock.py
@@ -7,6 +7,7 @@ from autoarray.inversion.mock.mock_linear_obj import MockLinearObj
 from autoarray.inversion.mock.mock_linear_obj_func_list import MockLinearObjFuncList
 from autoarray.inversion.mock.mock_inversion import MockInversion
 from autoarray.inversion.mock.mock_inversion_imaging import MockInversionImaging
+from autoarray.inversion.mock.mock_inversion_imaging import MockInversionImagingWTilde
 from autoarray.inversion.mock.mock_inversion_interferometer import (
     MockInversionInterferometer,
 )

--- a/autoarray/preloads.py
+++ b/autoarray/preloads.py
@@ -321,7 +321,7 @@ class Preloads:
 
                 return
 
-            if (
+            elif (
                 np.max(
                     abs(
                         inversion_0._curvature_matrix_mapper_diag

--- a/autoarray/preloads.py
+++ b/autoarray/preloads.py
@@ -303,6 +303,7 @@ class Preloads:
         """
 
         self.linear_func_weighted_mapping_vectors_dict = None
+        self.linear_func_curvature_vectors_dict = None
 
         inversion_0 = fit_0.inversion
         inversion_1 = fit_1.inversion
@@ -310,7 +311,7 @@ class Preloads:
         if inversion_0 is None:
             return
 
-        if inversion_0.total(cls=AbstractLinearObjFuncList) == 0:
+        if not inversion_0.has(cls=AbstractLinearObjFuncList):
             return
 
         should_preload = False

--- a/autoarray/preloads.py
+++ b/autoarray/preloads.py
@@ -24,6 +24,7 @@ class Preloads:
         relocated_grid=None,
         mapper_list=None,
         operated_mapping_matrix=None,
+        linear_func_operated_mapping_matrix_dict=None,
         linear_func_weighted_mapping_vectors_dict=None,
         linear_func_curvature_vectors_dict=None,
         curvature_matrix_preload=None,
@@ -43,6 +44,9 @@ class Preloads:
         self.relocated_grid = relocated_grid
         self.mapper_list = mapper_list
         self.operated_mapping_matrix = operated_mapping_matrix
+        self.linear_func_operated_mapping_matrix_dict = (
+            linear_func_operated_mapping_matrix_dict
+        )
         self.linear_func_weighted_mapping_vectors_dict = (
             linear_func_weighted_mapping_vectors_dict
         )
@@ -302,6 +306,7 @@ class Preloads:
             The second fit corresponding to a model with a different set of unit-values.
         """
 
+        self.linear_func_operated_mapping_matrix_dict = None
         self.linear_func_weighted_mapping_vectors_dict = None
         self.linear_func_curvature_vectors_dict = None
 
@@ -313,6 +318,30 @@ class Preloads:
 
         if not inversion_0.has(cls=AbstractLinearObjFuncList):
             return
+
+        should_preload = False
+
+        for operated_mapping_matrix_0, operated_mapping_matrix_1 in zip(
+            inversion_0.linear_func_operated_mapping_matrix_dict.values(),
+            inversion_1.linear_func_operated_mapping_matrix_dict.values(),
+        ):
+
+            if (
+                np.max(abs(operated_mapping_matrix_0 - operated_mapping_matrix_1))
+                < 1e-8
+            ):
+
+                should_preload = True
+
+        if should_preload:
+
+            self.linear_func_operated_mapping_matrix_dict = (
+                inversion_0.linear_func_operated_mapping_matrix_dict
+            )
+
+            logger.info(
+                "PRELOADS - Inversion linear light profile operated mapping matrix preloaded for this model-fit."
+            )
 
         should_preload = False
 

--- a/autoarray/preloads.py
+++ b/autoarray/preloads.py
@@ -277,8 +277,12 @@ class Preloads:
     def set_curvature_matrix(self, fit_0, fit_1):
         """
         If the `MassProfile`'s and `Mesh`'s in a model are fixed, the mapping of image-pixels to the
-        source-pixels does not change during the model-fit and therefore its associated cruvature matrix is also
+        source-pixels does not change during the model-fit and therefore its associated curvature matrix is also
         fixed, meaning the curvature matrix preloaded.
+
+        If linear ``LightProfiles``'s are included, the regions of the curvature matrix associatd with these
+        objects vary but the diagonals of the mapper do not change. In this case, the `curvature_matrix_mapper_diag`
+        is preloaded.
 
         This function compares the curvature matrix of two fit's corresponding to two model instances, and preloads
         this value if it is the same for both fits.
@@ -292,6 +296,7 @@ class Preloads:
         fit_1
             The second fit corresponding to a model with a different set of unit-values.
         """
+
         self.curvature_matrix = None
         self.curvature_matrix_mapper_diag = None
 
@@ -316,27 +321,23 @@ class Preloads:
 
                 return
 
-            if hasattr(inversion_0, "_curvature_matrix_mapper_diag"):
-
-                if (
-                    np.max(
-                        abs(
-                            inversion_0._curvature_matrix_mapper_diag
-                            - inversion_1._curvature_matrix_mapper_diag
-                        )
-                    )
-                    < 1e-8
-                ):
-
-                    self.curvature_matrix_mapper_diag = (
+            if (
+                np.max(
+                    abs(
                         inversion_0._curvature_matrix_mapper_diag
+                        - inversion_1._curvature_matrix_mapper_diag
                     )
+                )
+                < 1e-8
+            ):
 
-                    logger.info(
-                        "PRELOADS - Inversion Curvature Matrix Mapper Diag preloaded for this model-fit."
-                    )
+                self.curvature_matrix_mapper_diag = (
+                    inversion_0._curvature_matrix_mapper_diag
+                )
 
-                    return
+                logger.info(
+                    "PRELOADS - Inversion Curvature Matrix Mapper Diag preloaded for this model-fit."
+                )
 
     def set_regularization_matrix_and_term(self, fit_0, fit_1):
         """
@@ -448,6 +449,9 @@ class Preloads:
             f"Curvature Matrix Sparse = {self.curvature_matrix_preload is not None}\n"
         ]
         line += [f"Curvature Matrix = {self.curvature_matrix is not None}\n"]
+        line += [
+            f"Curvature Matrix Mapper Diag = {self.curvature_matrix_mapper_diag is not None}\n"
+        ]
         line += [f"Regularization Matrix = {self.regularization_matrix is not None}\n"]
         line += [
             f"Log Det Regularization Matrix Term = {self.log_det_regularization_matrix_term is not None}\n"

--- a/autoarray/preloads.py
+++ b/autoarray/preloads.py
@@ -25,6 +25,7 @@ class Preloads:
         curvature_matrix_preload=None,
         curvature_matrix_counts=None,
         curvature_matrix=None,
+        curvature_matrix_mapper_diag=None,
         regularization_matrix=None,
         log_det_regularization_matrix_term=None,
         traced_sparse_grids_list_of_planes=None,
@@ -41,6 +42,7 @@ class Preloads:
         self.curvature_matrix_preload = curvature_matrix_preload
         self.curvature_matrix_counts = curvature_matrix_counts
         self.curvature_matrix = curvature_matrix
+        self.curvature_matrix_mapper_diag = curvature_matrix_mapper_diag
         self.regularization_matrix = regularization_matrix
         self.log_det_regularization_matrix_term = log_det_regularization_matrix_term
 
@@ -291,6 +293,7 @@ class Preloads:
             The second fit corresponding to a model with a different set of unit-values.
         """
         self.curvature_matrix = None
+        self.curvature_matrix_mapper_diag = None
 
         inversion_0 = fit_0.inversion
         inversion_1 = fit_1.inversion
@@ -310,6 +313,30 @@ class Preloads:
                 logger.info(
                     "PRELOADS - Inversion Curvature Matrix preloaded for this model-fit."
                 )
+
+                return
+
+            if hasattr(inversion_0, "_curvature_matrix_mapper_diag"):
+
+                if (
+                    np.max(
+                        abs(
+                            inversion_0._curvature_matrix_mapper_diag
+                            - inversion_1._curvature_matrix_mapper_diag
+                        )
+                    )
+                    < 1e-8
+                ):
+
+                    self.curvature_matrix_mapper_diag = (
+                        inversion_0._curvature_matrix_mapper_diag
+                    )
+
+                    logger.info(
+                        "PRELOADS - Inversion Curvature Matrix Mapper Diag preloaded for this model-fit."
+                    )
+
+                    return
 
     def set_regularization_matrix_and_term(self, fit_0, fit_1):
         """

--- a/autoarray/preloads.py
+++ b/autoarray/preloads.py
@@ -2,7 +2,9 @@ import logging
 import numpy as np
 from typing import List
 
+
 from autoarray.inversion.inversion.imaging.abstract import AbstractInversionImaging
+from autoarray.inversion.linear_obj.func_list import AbstractLinearObjFuncList
 from autoarray.inversion.pixelization.mappers.abstract import AbstractMapper
 
 from autoarray import exc
@@ -22,6 +24,8 @@ class Preloads:
         relocated_grid=None,
         mapper_list=None,
         operated_mapping_matrix=None,
+        linear_func_weighted_mapping_vectors_dict=None,
+        linear_func_curvature_vectors_dict=None,
         curvature_matrix_preload=None,
         curvature_matrix_counts=None,
         curvature_matrix=None,
@@ -39,6 +43,10 @@ class Preloads:
         self.relocated_grid = relocated_grid
         self.mapper_list = mapper_list
         self.operated_mapping_matrix = operated_mapping_matrix
+        self.linear_func_weighted_mapping_vectors_dict = (
+            linear_func_weighted_mapping_vectors_dict
+        )
+        self.linear_func_curvature_vectors_dict = linear_func_curvature_vectors_dict
         self.curvature_matrix_preload = curvature_matrix_preload
         self.curvature_matrix_counts = curvature_matrix_counts
         self.curvature_matrix = curvature_matrix
@@ -273,6 +281,64 @@ class Preloads:
                 logger.info(
                     "PRELOADS - Inversion linear algebra quantities preloaded for this model-fit."
                 )
+
+    def set_linear_func_inversion_dicts(self, fit_0, fit_1):
+        """
+        If the `MassProfile`'s and `Mesh`'s in a model are fixed, the mapping of image-pixels to the
+        source-pixels does not change during the model-fit and matrices used to perform the linear algebra in an
+        inversion can be preloaded, which help efficiently construct the curvature matrix.
+
+        This function compares the operated mapping matrix of two fit's corresponding to two model instances, and
+        preloads the mapper if the mapping matrix of both fits are the same.
+
+        The preload is typically used in searches where only light profiles vary (e.g. when only the lens's light is
+        being fitted for).
+
+        Parameters
+        ----------
+        fit_0
+            The first fit corresponding to a model with a specific set of unit-values.
+        fit_1
+            The second fit corresponding to a model with a different set of unit-values.
+        """
+
+        self.linear_func_weighted_mapping_vectors_dict = None
+
+        inversion_0 = fit_0.inversion
+        inversion_1 = fit_1.inversion
+
+        if inversion_0 is None:
+            return
+
+        if inversion_0.total(cls=AbstractLinearObjFuncList) == 0:
+            return
+
+        should_preload = False
+
+        for weighted_mapping_vectors_0, weighted_mapping_vectors_1 in zip(
+            inversion_0.linear_func_weighted_mapping_vectors_dict.values(),
+            inversion_1.linear_func_weighted_mapping_vectors_dict.values(),
+        ):
+
+            if (
+                np.max(abs(weighted_mapping_vectors_0 - weighted_mapping_vectors_1))
+                < 1e-8
+            ):
+
+                should_preload = True
+
+        if should_preload:
+
+            self.linear_func_weighted_mapping_vectors_dict = (
+                inversion_0.linear_func_weighted_mapping_vectors_dict
+            )
+            self.linear_func_curvature_vectors_dict = (
+                inversion_0.linear_func_curvature_vectors_dict
+            )
+
+            logger.info(
+                "PRELOADS - Inversion linear light profile quantities preloaded for this model-fit."
+            )
 
     def set_curvature_matrix(self, fit_0, fit_1):
         """

--- a/test_autoarray/inversion/inversion/test_abstract.py
+++ b/test_autoarray/inversion/inversion/test_abstract.py
@@ -295,6 +295,22 @@ def test__preloads__operated_mapping_matrix_and_curvature_matrix_preload():
     assert inversion.curvature_matrix[0, 0] == 36.0
 
 
+def test__linear_func_weighted_mapping_vectors_dict():
+
+    dict_0 = {"key0": np.array([1.0, 2.0])}
+
+    preloads = aa.Preloads(linear_func_weighted_mapping_vectors_dict=dict_0)
+
+    # noinspection PyTypeChecker
+    inversion = aa.m.MockInversionImagingWTilde(
+        noise_map=np.ones(9), linear_obj_list=aa.m.MockMapper(), preloads=preloads
+    )
+
+    assert inversion.linear_func_weighted_mapping_vectors_dict["key0"] == pytest.approx(
+        dict_0["key0"], 1.0e-4
+    )
+
+
 def test__curvature_matrix_mapper_diag_preload():
 
     curvature_matrix_mapper_diag = 2.0 * np.ones((9, 3))

--- a/test_autoarray/inversion/inversion/test_abstract.py
+++ b/test_autoarray/inversion/inversion/test_abstract.py
@@ -295,6 +295,22 @@ def test__preloads__operated_mapping_matrix_and_curvature_matrix_preload():
     assert inversion.curvature_matrix[0, 0] == 36.0
 
 
+def test__linear_func_operated_mapping_matrix_dict():
+
+    dict_0 = {"key0": np.array([1.0, 2.0])}
+
+    preloads = aa.Preloads(linear_func_operated_mapping_matrix_dict=dict_0)
+
+    # noinspection PyTypeChecker
+    inversion = aa.m.MockInversionImagingWTilde(
+        noise_map=np.ones(9), linear_obj_list=aa.m.MockMapper(), preloads=preloads
+    )
+
+    assert inversion.linear_func_operated_mapping_matrix_dict["key0"] == pytest.approx(
+        dict_0["key0"], 1.0e-4
+    )
+
+
 def test__linear_func_weighted_mapping_vectors_dict():
 
     dict_0 = {"key0": np.array([1.0, 2.0])}

--- a/test_autoarray/inversion/inversion/test_abstract.py
+++ b/test_autoarray/inversion/inversion/test_abstract.py
@@ -303,10 +303,10 @@ def test__linear_func_operated_mapping_matrix_dict():
 
     # noinspection PyTypeChecker
     inversion = aa.m.MockInversionImagingWTilde(
-        noise_map=np.ones(9), linear_obj_list=aa.m.MockMapper(), preloads=preloads
+        noise_map=np.ones(9), linear_obj_list=[aa.m.MockLinearObjFuncList()], preloads=preloads
     )
 
-    assert inversion.linear_func_operated_mapping_matrix_dict["key0"] == pytest.approx(
+    assert list(inversion.linear_func_operated_mapping_matrix_dict.values())[0] == pytest.approx(
         dict_0["key0"], 1.0e-4
     )
 
@@ -319,10 +319,10 @@ def test__linear_func_weighted_mapping_vectors_dict():
 
     # noinspection PyTypeChecker
     inversion = aa.m.MockInversionImagingWTilde(
-        noise_map=np.ones(9), linear_obj_list=aa.m.MockMapper(), preloads=preloads
+        noise_map=np.ones(9), linear_obj_list=[aa.m.MockLinearObjFuncList()], preloads=preloads
     )
 
-    assert inversion.linear_func_weighted_mapping_vectors_dict["key0"] == pytest.approx(
+    assert list(inversion.linear_func_weighted_mapping_vectors_dict.values())[0] == pytest.approx(
         dict_0["key0"], 1.0e-4
     )
 
@@ -335,10 +335,10 @@ def test__linear_func_curvature_vectors_dict():
 
     # noinspection PyTypeChecker
     inversion = aa.m.MockInversionImagingWTilde(
-        noise_map=np.ones(9), linear_obj_list=aa.m.MockMapper(), preloads=preloads
+        noise_map=np.ones(9), linear_obj_list=[aa.m.MockLinearObjFuncList()], preloads=preloads
     )
 
-    assert inversion.linear_func_curvature_vectors_dict["key0"] == pytest.approx(
+    assert list(inversion.linear_func_curvature_vectors_dict.values())[0] == pytest.approx(
         dict_0["key0"], 1.0e-4
     )
 

--- a/test_autoarray/inversion/inversion/test_abstract.py
+++ b/test_autoarray/inversion/inversion/test_abstract.py
@@ -311,6 +311,22 @@ def test__linear_func_weighted_mapping_vectors_dict():
     )
 
 
+def test__linear_func_curvature_vectors_dict():
+
+    dict_0 = {"key0": np.array([1.0, 2.0])}
+
+    preloads = aa.Preloads(linear_func_curvature_vectors_dict=dict_0)
+
+    # noinspection PyTypeChecker
+    inversion = aa.m.MockInversionImagingWTilde(
+        noise_map=np.ones(9), linear_obj_list=aa.m.MockMapper(), preloads=preloads
+    )
+
+    assert inversion.linear_func_curvature_vectors_dict["key0"] == pytest.approx(
+        dict_0["key0"], 1.0e-4
+    )
+
+
 def test__curvature_matrix_mapper_diag_preload():
 
     curvature_matrix_mapper_diag = 2.0 * np.ones((9, 3))

--- a/test_autoarray/inversion/inversion/test_abstract.py
+++ b/test_autoarray/inversion/inversion/test_abstract.py
@@ -295,6 +295,22 @@ def test__preloads__operated_mapping_matrix_and_curvature_matrix_preload():
     assert inversion.curvature_matrix[0, 0] == 36.0
 
 
+def test__curvature_matrix_mapper_diag_preload():
+
+    curvature_matrix_mapper_diag = 2.0 * np.ones((9, 3))
+
+    preloads = aa.Preloads(curvature_matrix_mapper_diag=curvature_matrix_mapper_diag)
+
+    # noinspection PyTypeChecker
+    inversion = aa.m.MockInversionImagingWTilde(
+        noise_map=np.ones(9), linear_obj_list=aa.m.MockMapper(), preloads=preloads
+    )
+
+    assert inversion._curvature_matrix_mapper_diag == pytest.approx(
+        curvature_matrix_mapper_diag, 1.0e-4
+    )
+
+
 def test__preload_of_regularization_matrix__overwrites_calculation():
 
     inversion = aa.m.MockInversion(

--- a/test_autoarray/inversion/inversion/test_factory.py
+++ b/test_autoarray/inversion/inversion/test_factory.py
@@ -340,6 +340,9 @@ def test__inversion_imaging__compare_mapping_and_w_tilde_values(
         settings=aa.SettingsInversion(use_w_tilde=False),
     )
 
+    assert inversion_w_tilde._curvature_matrix_mapper_diag == pytest.approx(
+        inversion_mapping._curvature_matrix_mapper_diag, 1.0e-4
+    )
     assert inversion_w_tilde.reconstruction == pytest.approx(
         inversion_mapping.reconstruction, 1.0e-4
     )

--- a/test_autoarray/test_preloads.py
+++ b/test_autoarray/test_preloads.py
@@ -283,7 +283,7 @@ def test__set_curvature_matrix():
     fit_0 = aa.m.MockFitImaging(inversion=None)
     fit_1 = aa.m.MockFitImaging(inversion=None)
 
-    preloads = aa.Preloads(curvature_matrix=1)
+    preloads = aa.Preloads(curvature_matrix=1, curvature_matrix_mapper_diag=1)
     preloads.set_curvature_matrix(fit_0=fit_0, fit_1=fit_1)
 
     assert preloads.curvature_matrix is None
@@ -295,10 +295,14 @@ def test__set_curvature_matrix():
     curvature_matrix_1 = np.array([[0.0, 0.0, 1.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
 
     fit_0 = aa.m.MockFitImaging(
-        inversion=aa.m.MockInversion(curvature_matrix=curvature_matrix_0)
+        inversion=aa.m.MockInversion(
+            curvature_matrix=curvature_matrix_0, curvature_matrix_mapper_diag=1
+        )
     )
     fit_1 = aa.m.MockFitImaging(
-        inversion=aa.m.MockInversion(curvature_matrix=curvature_matrix_1)
+        inversion=aa.m.MockInversion(
+            curvature_matrix=curvature_matrix_1, curvature_matrix_mapper_diag=1
+        )
     )
 
     preloads = aa.Preloads(curvature_matrix=1)
@@ -311,10 +315,14 @@ def test__set_curvature_matrix():
     preloads = aa.Preloads(curvature_matrix=2)
 
     fit_0 = aa.m.MockFitImaging(
-        inversion=aa.m.MockInversion(curvature_matrix=curvature_matrix_0)
+        inversion=aa.m.MockInversion(
+            curvature_matrix=curvature_matrix_0, curvature_matrix_mapper_diag=1
+        )
     )
     fit_1 = aa.m.MockFitImaging(
-        inversion=aa.m.MockInversion(curvature_matrix=curvature_matrix_0)
+        inversion=aa.m.MockInversion(
+            curvature_matrix=curvature_matrix_0, curvature_matrix_mapper_diag=1
+        )
     )
 
     preloads.set_curvature_matrix(fit_0=fit_0, fit_1=fit_1)

--- a/test_autoarray/test_preloads.py
+++ b/test_autoarray/test_preloads.py
@@ -284,11 +284,13 @@ def test__set_linear_func_inversion_dicts():
     fit_1 = aa.m.MockFitImaging(inversion=None)
 
     preloads = aa.Preloads(
+        linear_func_operated_mapping_matrix_dict=0,
         linear_func_weighted_mapping_vectors_dict=1,
         linear_func_curvature_vectors_dict=2,
     )
     preloads.set_linear_func_inversion_dicts(fit_0=fit_0, fit_1=fit_1)
 
+    assert preloads.linear_func_operated_mapping_matrix_dict is None
     assert preloads.linear_func_weighted_mapping_vectors_dict is None
     assert preloads.linear_func_curvature_vectors_dict is None
 
@@ -299,11 +301,13 @@ def test__set_linear_func_inversion_dicts():
 
     inversion_0 = aa.m.MockInversionImaging(
         linear_obj_list=[aa.m.MockLinearObjFuncList()],
+        linear_func_operated_mapping_matrix_dict=dict_0,
         linear_func_weighted_mapping_vectors_dict=dict_0,
         linear_func_curvature_vectors_dict=dict_0,
     )
     inversion_1 = aa.m.MockInversionImaging(
         linear_obj_list=[aa.m.MockLinearObjFuncList()],
+        linear_func_operated_mapping_matrix_dict=dict_1,
         linear_func_weighted_mapping_vectors_dict=dict_1,
         linear_func_curvature_vectors_dict=dict_0,
     )
@@ -317,6 +321,7 @@ def test__set_linear_func_inversion_dicts():
     )
     preloads.set_linear_func_inversion_dicts(fit_0=fit_0, fit_1=fit_1)
 
+    assert preloads.linear_func_operated_mapping_matrix_dict is None
     assert preloads.linear_func_weighted_mapping_vectors_dict is None
     assert preloads.linear_func_curvature_vectors_dict is None
 
@@ -324,11 +329,13 @@ def test__set_linear_func_inversion_dicts():
 
     inversion_0 = aa.m.MockInversionImaging(
         linear_obj_list=[aa.m.MockLinearObjFuncList()],
+        linear_func_operated_mapping_matrix_dict=dict_0,
         linear_func_weighted_mapping_vectors_dict=dict_0,
         linear_func_curvature_vectors_dict=dict_0,
     )
     inversion_1 = aa.m.MockInversionImaging(
         linear_obj_list=[aa.m.MockLinearObjFuncList()],
+        linear_func_operated_mapping_matrix_dict=dict_0,
         linear_func_weighted_mapping_vectors_dict=dict_0,
         linear_func_curvature_vectors_dict=dict_0,
     )
@@ -342,6 +349,9 @@ def test__set_linear_func_inversion_dicts():
     )
     preloads.set_linear_func_inversion_dicts(fit_0=fit_0, fit_1=fit_1)
 
+    assert (
+        preloads.linear_func_operated_mapping_matrix_dict["key0"] == dict_0["key0"]
+    ).all()
     assert (
         preloads.linear_func_weighted_mapping_vectors_dict["key0"] == dict_0["key0"]
     ).all()

--- a/test_autoarray/test_preloads.py
+++ b/test_autoarray/test_preloads.py
@@ -276,6 +276,78 @@ def test__set_operated_mapping_matrix_with_preloads():
     ).all()
 
 
+def test__set_linear_func_inversion_dicts():
+
+    # Inversion is None thus preload it to None.
+
+    fit_0 = aa.m.MockFitImaging(inversion=None)
+    fit_1 = aa.m.MockFitImaging(inversion=None)
+
+    preloads = aa.Preloads(
+        linear_func_weighted_mapping_vectors_dict=1,
+        linear_func_curvature_vectors_dict=2,
+    )
+    preloads.set_linear_func_inversion_dicts(fit_0=fit_0, fit_1=fit_1)
+
+    assert preloads.linear_func_weighted_mapping_vectors_dict is None
+    assert preloads.linear_func_curvature_vectors_dict is None
+
+    # Inversion's blurred mapping matrices are different thus no preloading.
+
+    dict_0 = {"key0": np.array([1.0, 2.0])}
+    dict_1 = {"key1": np.array([1.0, 3.0])}
+
+    inversion_0 = aa.m.MockInversionImaging(
+        linear_obj_list=[aa.m.MockLinearObjFuncList()],
+        linear_func_weighted_mapping_vectors_dict=dict_0,
+        linear_func_curvature_vectors_dict=dict_0,
+    )
+    inversion_1 = aa.m.MockInversionImaging(
+        linear_obj_list=[aa.m.MockLinearObjFuncList()],
+        linear_func_weighted_mapping_vectors_dict=dict_1,
+        linear_func_curvature_vectors_dict=dict_0,
+    )
+
+    fit_0 = aa.m.MockFitImaging(inversion=inversion_0)
+    fit_1 = aa.m.MockFitImaging(inversion=inversion_1)
+
+    preloads = aa.Preloads(
+        linear_func_weighted_mapping_vectors_dict=dict_0,
+        linear_func_curvature_vectors_dict=dict_0,
+    )
+    preloads.set_linear_func_inversion_dicts(fit_0=fit_0, fit_1=fit_1)
+
+    assert preloads.linear_func_weighted_mapping_vectors_dict is None
+    assert preloads.linear_func_curvature_vectors_dict is None
+
+    # Inversion's blurred mapping matrices are the same therefore preload it and the curvature sparse terms.
+
+    inversion_0 = aa.m.MockInversionImaging(
+        linear_obj_list=[aa.m.MockLinearObjFuncList()],
+        linear_func_weighted_mapping_vectors_dict=dict_0,
+        linear_func_curvature_vectors_dict=dict_0,
+    )
+    inversion_1 = aa.m.MockInversionImaging(
+        linear_obj_list=[aa.m.MockLinearObjFuncList()],
+        linear_func_weighted_mapping_vectors_dict=dict_0,
+        linear_func_curvature_vectors_dict=dict_0,
+    )
+
+    fit_0 = aa.m.MockFitImaging(inversion=inversion_0)
+    fit_1 = aa.m.MockFitImaging(inversion=inversion_1)
+
+    preloads = aa.Preloads(
+        linear_func_weighted_mapping_vectors_dict=dict_0,
+        linear_func_curvature_vectors_dict=dict_0,
+    )
+    preloads.set_linear_func_inversion_dicts(fit_0=fit_0, fit_1=fit_1)
+
+    assert (
+        preloads.linear_func_weighted_mapping_vectors_dict["key0"] == dict_0["key0"]
+    ).all()
+    assert (preloads.linear_func_curvature_vectors_dict["key0"] == dict_0["key0"]).all()
+
+
 def test__set_curvature_matrix():
 
     # Inversion is None thus preload curvature_matrix to None.

--- a/test_autoarray/test_preloads.py
+++ b/test_autoarray/test_preloads.py
@@ -322,6 +322,64 @@ def test__set_curvature_matrix():
     assert (preloads.curvature_matrix == curvature_matrix_0).all()
 
 
+def test__set_curvature_matrix__curvature_matrix_mapper_diag():
+
+    # Inversion is None thus preload curvature_matrix to None.
+
+    fit_0 = aa.m.MockFitImaging(inversion=None)
+    fit_1 = aa.m.MockFitImaging(inversion=None)
+
+    preloads = aa.Preloads(curvature_matrix_mapper_diag=1)
+    preloads.set_curvature_matrix(fit_0=fit_0, fit_1=fit_1)
+
+    assert preloads.curvature_matrix_mapper_diag is None
+
+    # Inversion's curvature matrices are different thus no preloading.
+
+    curvature_matrix_0 = np.array([[0.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+
+    curvature_matrix_1 = np.array([[0.0, 0.0, 1.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+
+    fit_0 = aa.m.MockFitImaging(
+        inversion=aa.m.MockInversion(
+            curvature_matrix=curvature_matrix_0,
+            curvature_matrix_mapper_diag=curvature_matrix_0,
+        )
+    )
+    fit_1 = aa.m.MockFitImaging(
+        inversion=aa.m.MockInversion(
+            curvature_matrix=curvature_matrix_1,
+            curvature_matrix_mapper_diag=curvature_matrix_1,
+        )
+    )
+
+    preloads = aa.Preloads(curvature_matrix_mapper_diag=1)
+    preloads.set_curvature_matrix(fit_0=fit_0, fit_1=fit_1)
+
+    assert preloads.curvature_matrix_mapper_diag is None
+
+    # Inversion's curvature matrices are the same therefore preload it and the curvature sparse terms.
+
+    preloads = aa.Preloads(curvature_matrix_mapper_diag=2)
+
+    fit_0 = aa.m.MockFitImaging(
+        inversion=aa.m.MockInversion(
+            curvature_matrix=curvature_matrix_0,
+            curvature_matrix_mapper_diag=curvature_matrix_0,
+        )
+    )
+    fit_1 = aa.m.MockFitImaging(
+        inversion=aa.m.MockInversion(
+            curvature_matrix=curvature_matrix_1,
+            curvature_matrix_mapper_diag=curvature_matrix_0,
+        )
+    )
+
+    preloads.set_curvature_matrix(fit_0=fit_0, fit_1=fit_1)
+
+    assert (preloads.curvature_matrix_mapper_diag == curvature_matrix_0).all()
+
+
 def test__set_regularization_matrix_and_term():
 
     regularization = aa.m.MockRegularization(regularization_matrix=np.eye(2))


### PR DESCRIPTION
Preloads quantities specific to linear light profiles, or mappers when only linear light profiles are varying (e.g. the Light pipeline) to speed up analysis.