### PR TITLE
Feature/check solution

### DIFF
--- a/autoarray/config/general.yaml
+++ b/autoarray/config/general.yaml
@@ -1,4 +1,5 @@
 inversion:
+  check_reconstruction: true        # If True, the inversion's reconstruction is checked to ensure the solution of a meshs's mapper is not an invalid solution where the values are all the same.
   reconstruction_vmax_factor: 0.5   # Plots of an Inversion's reconstruction use the reconstructed data's bright value multiplied by this factor.
 numba:
   use_numba: true

--- a/autoarray/inversion/inversion/abstract.py
+++ b/autoarray/inversion/inversion/abstract.py
@@ -470,10 +470,12 @@ class AbstractInversion:
                 settings=self.settings,
             )
 
+        mapper_param_range_list = self.param_range_list_from(cls=AbstractMapper)
+
         return inversion_util.reconstruction_positive_only_from(
             data_vector=self.data_vector,
             curvature_reg_matrix=self.curvature_reg_matrix_solver,
-            mapper_param_range_list=self.mapper_param_range_list,
+            mapper_param_range_list=mapper_param_range_list,
             settings=self.settings,
         )
 

--- a/autoarray/inversion/inversion/abstract.py
+++ b/autoarray/inversion/inversion/abstract.py
@@ -463,8 +463,9 @@ class AbstractInversion:
 
         S is the vector of reconstructed inversion values.
         """
-        if not self.settings.use_positive_only_solver:
-            return inversion_util.reconstruction_positive_negative_from(
+        if self.settings.use_positive_only_solver:
+
+            return inversion_util.reconstruction_positive_only_from(
                 data_vector=self.data_vector,
                 curvature_reg_matrix=self.curvature_reg_matrix_solver,
                 settings=self.settings,
@@ -472,11 +473,10 @@ class AbstractInversion:
 
         mapper_param_range_list = self.param_range_list_from(cls=AbstractMapper)
 
-        return inversion_util.reconstruction_positive_only_from(
+        return inversion_util.reconstruction_positive_negative_from(
             data_vector=self.data_vector,
             curvature_reg_matrix=self.curvature_reg_matrix_solver,
             mapper_param_range_list=mapper_param_range_list,
-            settings=self.settings,
         )
 
     @cached_property

--- a/autoarray/inversion/inversion/abstract.py
+++ b/autoarray/inversion/inversion/abstract.py
@@ -473,6 +473,7 @@ class AbstractInversion:
         return inversion_util.reconstruction_positive_only_from(
             data_vector=self.data_vector,
             curvature_reg_matrix=self.curvature_reg_matrix_solver,
+            mapper_param_range_list=self.mapper_param_range_list,
             settings=self.settings,
         )
 

--- a/autoarray/inversion/inversion/inversion_util.py
+++ b/autoarray/inversion/inversion/inversion_util.py
@@ -258,6 +258,7 @@ def mapped_reconstructed_data_via_mapping_matrix_from(
 def reconstruction_positive_negative_from(
     data_vector: np.ndarray,
     curvature_reg_matrix: np.ndarray,
+    mapper_param_range_list,
     settings: SettingsInversion = SettingsInversion(),
 ):
     """
@@ -293,6 +294,13 @@ def reconstruction_positive_negative_from(
         reconstruction = np.linalg.solve(curvature_reg_matrix, data_vector)
     except np.linalg.LinAlgError as e:
         raise exc.InversionException() from e
+
+    for mapper_param_range in mapper_param_range_list:
+        if np.allclose(
+            reconstruction[mapper_param_range[0] : mapper_param_range[1]]
+            == reconstruction[mapper_param_range[0]]
+        ):
+            raise exc.InversionException()
 
     return reconstruction
 

--- a/autoarray/inversion/inversion/inversion_util.py
+++ b/autoarray/inversion/inversion/inversion_util.py
@@ -272,8 +272,11 @@ def reconstruction_positive_negative_from(
     are nonphysical or undesirable.
 
     This function checks that the solution does not give a linear algebra error (e.g. because the input matrix is
-    not positive-definitive) and that it avoids solutions where all reconstructed values go to the same value. If these
-    occur it raises an exception.
+    not positive-definitive).
+
+    It also explicitly checks solutions where all reconstructed values go to the same value, and raises an exception if
+    this occurs. This solution occurs in many scenarios when it is clear not a valid solution, and therefore is checked
+    for and removed.
 
     Parameters
     ----------
@@ -281,6 +284,9 @@ def reconstruction_positive_negative_from(
         The `data_vector` D which is solved for.
     curvature_reg_matrix
         The sum of the curvature and regularization matrices.
+    mapper_param_range_list
+        A list of lists, where each list contains the range of values in the solution vector (reconstruction) that
+        correspond to values that are part of a mapper's mesh.
     settings
         Controls the settings of the inversion, for this function where the solution is checked to not be all
         the same values.
@@ -297,8 +303,8 @@ def reconstruction_positive_negative_from(
 
     for mapper_param_range in mapper_param_range_list:
         if np.allclose(
-            reconstruction[mapper_param_range[0] : mapper_param_range[1]]
-            == reconstruction[mapper_param_range[0]]
+            a=reconstruction[mapper_param_range[0] : mapper_param_range[1]],
+            b=reconstruction[mapper_param_range[0]]
         ):
             raise exc.InversionException()
 

--- a/autoarray/inversion/mock/mock_mapper.py
+++ b/autoarray/inversion/mock/mock_mapper.py
@@ -14,6 +14,7 @@ class MockMapper(AbstractMapper):
         edge_pixel_list=None,
         regularization=None,
         pix_sub_weights=None,
+        pix_sub_weights_split_cross=None,
         mapping_matrix=None,
         pixel_signals=None,
         parameters=None,
@@ -29,15 +30,11 @@ class MockMapper(AbstractMapper):
         super().__init__(mapper_grids=mapper_grids, regularization=regularization)
 
         self._edge_pixel_list = edge_pixel_list
-
         self._pix_sub_weights = pix_sub_weights
-
+        self._pix_sub_weights_split_cross = pix_sub_weights_split_cross
         self._mapping_matrix = mapping_matrix
-
         self._parameters = parameters
-
         self._pixel_signals = pixel_signals
-
         self._interpolated_array = interpolated_array
 
     def pixel_signals_from(self, signal_scale):
@@ -58,6 +55,10 @@ class MockMapper(AbstractMapper):
     @property
     def pix_sub_weights(self):
         return self._pix_sub_weights
+
+    @property
+    def pix_sub_weights_split_cross(self):
+        return self._pix_sub_weights_split_cross
 
     @property
     def mapping_matrix(self):

--- a/autoarray/inversion/pixelization/mappers/abstract.py
+++ b/autoarray/inversion/pixelization/mappers/abstract.py
@@ -401,15 +401,8 @@ class AbstractMapper(LinearObj):
 class PixSubWeights:
     def __init__(self, mappings: np.ndarray, sizes: np.ndarray, weights: np.ndarray):
         """
-        Packages the following three quantities of a mapper:
-
-        - `mappings` (`pix_indexes_for_sub_slim_index`): the mapping of every data pixel (given its `sub_slim_index`)
-        to pixelization pixels (given their `pix_indexes`).
-
-        - `sizes`(`pix_sizes_for_sub_slim_index`): the number of mappings of every data pixel to pixelization pixels.
-
-        - `weights` (`pix_weights_for_sub_slim_index`): the interpolation weights of every data pixel's pixelization
-        pixel mapping
+        Packages the mappings, sizes and weights of every data pixel to pixelization pixels, which are computed
+        from associated ``Mapper`` properties..
 
         The need to store separately the mappings and sizes is so that the `sizes` can be easy iterated over when
         perform calculations for efficiency.
@@ -417,9 +410,14 @@ class PixSubWeights:
         Parameters
         ----------
         mappings
-            The mappings of the masked data's sub-pixels to the pixelization's pixels.
+            The mapping of every data pixel, given its `sub_slim_index`, to its corresponding pixelization mesh
+            pixels, given their `pix_indexes` (corresponds to the ``Mapper``
+            property ``pix_indexes_for_sub_slim_index``)
         sizes
-            The number of pixelization pixels each masked data sub-pixel maps too.
+            The number of mappings of every data pixel to pixelization mesh pixels (corresponds to the ``Mapper``
+            property ``pix_sizes_for_sub_slim_index``).
+        weights
+            The interpolation weights of every data pixel's pixelization pixel mapping.
         """
         self.mappings = mappings
         self.sizes = sizes

--- a/autoarray/inversion/regularization/__init__.py
+++ b/autoarray/inversion/regularization/__init__.py
@@ -5,3 +5,5 @@ from .constant_zeroth import ConstantZeroth
 from .constant_split import ConstantSplit
 from .adaptive_brightness import AdaptiveBrightness
 from .adaptive_brightness_split import AdaptiveBrightnessSplit
+from .brightness_zeroth import BrightnessZeroth
+from .adaptive_brightness_split_zeroth import AdaptiveBrightnessSplitZeroth

--- a/autoarray/inversion/regularization/adaptive_brightness_split.py
+++ b/autoarray/inversion/regularization/adaptive_brightness_split.py
@@ -31,13 +31,13 @@ class AdaptiveBrightnessSplit(AdaptiveBrightness):
         different regions of a pixelization's mesh require different levels of regularization (e.g., high smoothing where the
         no signal is present and less smoothing where it is, see (Nightingale, Dye and Massey 2018)).
 
-        Unlike the instance regularization_matrix scheme, neighboring pixels must now be regularized with one another
+        Unlike ``Constant`` regularization, neighboring pixels must now be regularized with one another
         in both directions (e.g. if pixel 0 regularizes pixel 1, pixel 1 must also regularize pixel 0). For example:
 
         B = [-1, 1]  [0->1]
             [-1, -1]  1 now also regularizes 0
 
-        For a instance regularization coefficient this would NOT produce a positive-definite matrix. However, for
+        For ``Constant`` regularization this would NOT produce a positive-definite matrix. However, for
         the weighted scheme, it does!
 
         The regularize weight_list change the B matrix as shown below - we simply multiply each pixel's effective

--- a/autoarray/inversion/regularization/adaptive_brightness_split_zeroth.py
+++ b/autoarray/inversion/regularization/adaptive_brightness_split_zeroth.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+import numpy as np
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from autoarray.inversion.linear_obj.linear_obj import LinearObj
+
+from autoarray.inversion.regularization.adaptive_brightness import AdaptiveBrightness
+from autoarray.inversion.regularization.brightness_zeroth import BrightnessZeroth
+from autoarray.inversion.regularization import regularization_util
+
+
+class AdaptiveBrightnessSplitZeroth(AdaptiveBrightness):
+    def __init__(
+        self,
+        zeroth_coefficient: float = 1.0,
+        zeroth_signal_scale: float = 1.0,
+        inner_coefficient: float = 1.0,
+        outer_coefficient: float = 1.0,
+        signal_scale: float = 1.0,
+    ):
+        """
+        An adaptive regularization scheme which splits every source pixel into a cross of four regularization points
+        (regularization is described in the `Regularization` class above) and interpolates to these points in order
+        to apply smoothing on the solution of an `Inversion`.
+
+        The size of this cross is determined via the size of the source-pixel, for example if the source pixel is a
+        Voronoi pixel the area of the pixel is computed and the distance of each point of the cross is given by
+        the area times 0.5.
+
+        For the weighted regularization scheme, each pixel is given an 'effective regularization weight', which is
+        applied when each set of pixel neighbors are regularized with one another. The motivation of this is that
+        different regions of a pixelization's mesh require different levels of regularization (e.g., high smoothing where the
+        no signal is present and less smoothing where it is, see (Nightingale, Dye and Massey 2018)).
+
+        Unlike ``Constant`` regularization, neighboring pixels must now be regularized with one another
+        in both directions (e.g. if pixel 0 regularizes pixel 1, pixel 1 must also regularize pixel 0). For example:
+
+        B = [-1, 1]  [0->1]
+            [-1, -1]  1 now also regularizes 0
+
+        For ``Constant`` regularization this would NOT produce a positive-definite matrix. However, for
+        the weighted scheme, it does!
+
+        The regularize weight_list change the B matrix as shown below - we simply multiply each pixel's effective
+        regularization weight by each row of B it has a -1 in, so:
+
+        regularization_weights = [1, 2, 3, 4]
+
+        B = [-1, 1, 0 ,0] # [0->1]
+            [0, -2, 2 ,0] # [1->2]
+            [0, 0, -3 ,3] # [2->3]
+            [4, 0, 0 ,-4] # [3->0]
+
+        If our -1's werent down the diagonal this would look like:
+
+        B = [4, 0, 0 ,-4] # [3->0]
+            [0, -2, 2 ,0] # [1->2]
+            [-1, 1, 0 ,0] # [0->1]
+            [0, 0, -3 ,3] # [2->3] This is valid!
+
+        Parameters
+        ----------
+        coefficients
+            The regularization coefficients which controls the degree of smoothing of the inversion reconstruction in
+            high and low signal regions of the reconstruction.
+        signal_scale
+            A factor which controls how rapidly the smoothness of regularization varies from high signal regions to
+            low signal regions.
+        """
+
+        self.zeroth_coefficient = zeroth_coefficient
+        self.zeroth_signal_scale = zeroth_signal_scale
+
+        super().__init__(
+            inner_coefficient=inner_coefficient,
+            outer_coefficient=outer_coefficient,
+            signal_scale=signal_scale,
+        )
+
+    def regularization_matrix_from(self, linear_obj: LinearObj) -> np.ndarray:
+        """
+        Returns the regularization matrix of this regularization scheme.
+
+        Parameters
+        ----------
+        linear_obj
+            The linear object (e.g. a ``Mapper``) which uses this matrix to perform regularization.
+
+        Returns
+        -------
+        The regularization matrix.
+        """
+        regularization_weights = self.regularization_weights_from(linear_obj=linear_obj)
+
+        pix_sub_weights_split_cross = linear_obj.pix_sub_weights_split_cross
+
+        (
+            splitted_mappings,
+            splitted_sizes,
+            splitted_weights,
+        ) = regularization_util.reg_split_from(
+            splitted_mappings=pix_sub_weights_split_cross.mappings,
+            splitted_sizes=pix_sub_weights_split_cross.sizes,
+            splitted_weights=pix_sub_weights_split_cross.weights,
+        )
+
+        regularization_matrix = (
+            regularization_util.pixel_splitted_regularization_matrix_from(
+                regularization_weights=regularization_weights,
+                splitted_mappings=splitted_mappings,
+                splitted_sizes=splitted_sizes,
+                splitted_weights=splitted_weights,
+            )
+        )
+
+        brightness_zeroth = BrightnessZeroth(
+            coefficient=self.zeroth_coefficient, signal_scale=self.zeroth_signal_scale
+        )
+
+        regularization_matrix_zeroth = brightness_zeroth.regularization_matrix_from(
+            linear_obj=linear_obj
+        )
+
+        return regularization_matrix + regularization_matrix_zeroth

--- a/autoarray/inversion/regularization/brightness_zeroth.py
+++ b/autoarray/inversion/regularization/brightness_zeroth.py
@@ -47,8 +47,10 @@ class BrightnessZeroth(AbstractRegularization):
         """
         Returns the regularization weights of the ``BrightnessZeroth`` regularization scheme.
 
-        The regularization weights define the level of regularization applied to each parameter in the linear object
-        (e.g. the ``pixels`` in a ``Mapper``).
+        The weights define the level of zeroth order regularization applied to every mesh parameter (typically pixels
+        of a ``Mapper``).
+
+        They are computed using an estimate of the expected signal in each pixel.
 
         Parameters
         ----------
@@ -61,10 +63,8 @@ class BrightnessZeroth(AbstractRegularization):
         """
         pixel_signals = linear_obj.pixel_signals_from(signal_scale=self.signal_scale)
 
-        return regularization_util.adaptive_regularization_weights_from(
-            inner_coefficient=self.inner_coefficient,
-            outer_coefficient=self.outer_coefficient,
-            pixel_signals=pixel_signals,
+        return regularization_util.zeroth_regularization_matrix_from(
+            coefficient=self.coefficient, pixel_signals=pixel_signals
         )
 
     def regularization_matrix_from(self, linear_obj: LinearObj) -> np.ndarray:

--- a/autoarray/inversion/regularization/brightness_zeroth.py
+++ b/autoarray/inversion/regularization/brightness_zeroth.py
@@ -63,7 +63,7 @@ class BrightnessZeroth(AbstractRegularization):
         """
         pixel_signals = linear_obj.pixel_signals_from(signal_scale=self.signal_scale)
 
-        return regularization_util.zeroth_regularization_matrix_from(
+        return regularization_util.brightness_zeroth_regularization_weights_from(
             coefficient=self.coefficient, pixel_signals=pixel_signals
         )
 
@@ -82,8 +82,6 @@ class BrightnessZeroth(AbstractRegularization):
         """
         regularization_weights = self.regularization_weights_from(linear_obj=linear_obj)
 
-        return regularization_util.weighted_regularization_matrix_from(
-            regularization_weights=regularization_weights,
-            neighbors=linear_obj.source_plane_mesh_grid.neighbors,
-            neighbors_sizes=linear_obj.source_plane_mesh_grid.neighbors.sizes,
+        return regularization_util.brightness_zeroth_regularization_matrix_from(
+            regularization_weights=regularization_weights
         )

--- a/autoarray/inversion/regularization/regularization_util.py
+++ b/autoarray/inversion/regularization/regularization_util.py
@@ -174,7 +174,7 @@ def brightness_zeroth_regularization_weights_from(
     coefficient: float, pixel_signals: np.ndarray
 ) -> np.ndarray:
     """
-    Returns the regularization weights for the brighness zeroth regularization scheme (e.g. ``BrightnessZeroth``).
+    Returns the regularization weights for the brightness zeroth regularization scheme (e.g. ``BrightnessZeroth``).
 
     The weights define the level of zeroth order regularization applied to every mesh parameter (typically pixels
     of a ``Mapper``).

--- a/autoarray/inversion/regularization/regularization_util.py
+++ b/autoarray/inversion/regularization/regularization_util.py
@@ -135,13 +135,17 @@ def adaptive_regularization_weights_from(
     inner_coefficient: float, outer_coefficient: float, pixel_signals: np.ndarray
 ) -> np.ndarray:
     """
-    Returns the regularization weight_list (the effective regularization coefficient of every pixel). They are computed
-    using the pixel-signal of each pixel.
+    Returns the regularization weights for the adaptive regularization scheme (e.g. ``AdaptiveBrightness``).
+
+    The weights define the effective regularization coefficient of every mesh parameter (typically pixels
+    of a ``Mapper``).
+
+    They are computed using an estimate of the expected signal in each pixel.
 
     Two regularization coefficients are used, corresponding to the:
 
-    1) (pixel_signals) - pixels with a high pixel-signal (i.e. where the signal is located in the pixelization).
-    2) (1.0 - pixel_signals) - pixels with a low pixel-signal (i.e. where the signal is not located in the pixelization).
+    1) pixel_signals: pixels with a high pixel-signal (i.e. where the signal is located in the pixelization).
+    2) 1.0 - pixel_signals: pixels with a low pixel-signal (i.e. where the signal is not located in the pixelization).
 
     Parameters
     ----------
@@ -158,12 +162,45 @@ def adaptive_regularization_weights_from(
     Returns
     -------
     np.ndarray
-        The weight_list of the adaptive regularization scheme which act as the effective regularization coefficients of
+        The adaptive regularization weights which act as the effective regularization coefficients of
         every source pixel.
     """
     return (
         inner_coefficient * pixel_signals + outer_coefficient * (1.0 - pixel_signals)
     ) ** 2.0
+
+
+def brightness_zeroth_regularization_weights_from(
+    coefficient: float, pixel_signals: np.ndarray
+) -> np.ndarray:
+    """
+    Returns the regularization weights for the brighness zeroth regularization scheme (e.g. ``BrightnessZeroth``).
+
+    The weights define the level of zeroth order regularization applied to every mesh parameter (typically pixels
+    of a ``Mapper``).
+
+    They are computed using an estimate of the expected signal in each pixel.
+
+    The zeroth order regularization coefficients is applied in combination with  1.0 - pixel_signals, which are
+    the pixels with a low pixel-signal (i.e. where the signal is not located near the source being reconstructed in
+    the pixelization).
+
+    Parameters
+    ----------
+    coefficient
+        The level of zeroth order regularization applied to every mesh parameter (typically pixels of a ``Mapper``),
+        with the degree applied varying based on the ``pixel_signals``.
+    pixel_signals
+        The estimated signal in every pixelization pixel, used to change the regularization weighting of high signal
+        and low signal pixelizations.
+
+    Returns
+    -------
+    np.ndarray
+        The zeroth order regularization weights which act as the effective level of zeroth order regularization
+        applied to every mesh parameter.
+    """
+    return coefficient * (1.0 - pixel_signals)
 
 
 @numba_util.jit()

--- a/test_autoarray/config/general.yaml
+++ b/test_autoarray/config/general.yaml
@@ -9,6 +9,8 @@ hyper:
   hyper_minimum_percent: 0.01
   hyper_noise_limit: 100000000.0
   stochastic_outputs: false
+inversion:
+  check_reconstruction: false       # If True, the inversion's reconstruction is checked to ensure the solution of a meshs's mapper is not an invalid solution where the values are all the same.
 numba:
   cache: true
   nopython: true

--- a/test_autoarray/inversion/inversion/imaging/test_inversion_imaging_util.py
+++ b/test_autoarray/inversion/inversion/imaging/test_inversion_imaging_util.py
@@ -247,9 +247,6 @@ def test__data_vector_via_w_tilde_data_two_methods_agree():
             )
         )
 
-        # print(data_vector_via_w_tilde)
-        # print(data_vector)
-
         assert data_vector_via_w_tilde == pytest.approx(data_vector, 1.0e-4)
 
 

--- a/test_autoarray/inversion/inversion/test_factory.py
+++ b/test_autoarray/inversion/inversion/test_factory.py
@@ -652,9 +652,7 @@ def test__inversion_imaging__positive_only_solver(masked_imaging_7x7_no_blur):
     inversion = aa.Inversion(
         dataset=masked_imaging_7x7_no_blur,
         linear_obj_list=[linear_obj],
-        settings=aa.SettingsInversion(
-            use_w_tilde=False, use_positive_only_solver=True
-        ),
+        settings=aa.SettingsInversion(use_w_tilde=False, use_positive_only_solver=True),
     )
 
     assert isinstance(inversion.linear_obj_list[0], aa.m.MockLinearObjFuncList)

--- a/test_autoarray/inversion/inversion/test_inversion_util.py
+++ b/test_autoarray/inversion/inversion/test_inversion_util.py
@@ -176,6 +176,7 @@ def test__reconstruction_positive_negative_from__check_solution_raises_error_cau
             data_vector=data_vector,
             curvature_reg_matrix=curvature_reg_matrix,
             mapper_param_range_list=[[0, 3]],
+            force_check_reconstruction=True,
         )
 
 

--- a/test_autoarray/inversion/inversion/test_inversion_util.py
+++ b/test_autoarray/inversion/inversion/test_inversion_util.py
@@ -147,6 +147,38 @@ def test__curvature_matrix_via_mapping_matrix_from():
     ).all()
 
 
+def test__reconstruction_positive_negative_from():
+
+    data_vector = np.array([1.0, 1.0, 2.0])
+
+    curvature_reg_matrix = np.array([[2.0, 1.0, 0.0], [1.0, 3.0, 1.0], [0.0, 1.0, 1.0]])
+
+    reconstruction = aa.util.inversion.reconstruction_positive_negative_from(
+        data_vector=data_vector,
+        curvature_reg_matrix=curvature_reg_matrix,
+        mapper_param_range_list=[[0, 3]],
+    )
+
+    assert reconstruction == pytest.approx(np.array([1.0, -1.0, 3.0]), 1.0e-4)
+
+
+def test__reconstruction_positive_negative_from__check_solution_raises_error_cause_all_values_identical():
+
+    data_vector = np.array([1.0, 1.0, 1.0])
+
+    curvature_reg_matrix = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+
+    # reconstruction = np.array([1.0, 1.0, 1.0])
+
+    with pytest.raises(aa.exc.InversionException):
+
+        aa.util.inversion.reconstruction_positive_negative_from(
+            data_vector=data_vector,
+            curvature_reg_matrix=curvature_reg_matrix,
+            mapper_param_range_list=[[0, 3]],
+        )
+
+
 def test__mapped_reconstructed_data_via_mapping_matrix_from():
 
     mapping_matrix = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])

--- a/test_autoarray/inversion/pixelization/mappers/test_factory.py
+++ b/test_autoarray/inversion/pixelization/mappers/test_factory.py
@@ -144,8 +144,6 @@ def test__delaunay_mapper():
     assert (mapper.source_plane_mesh_grid == sparse_grid).all()
     assert mapper.source_plane_mesh_grid.origin == pytest.approx((0.0, 0.0), 1.0e-4)
 
-    print(mapper.mapping_matrix)
-
     assert mapper.mapping_matrix == pytest.approx(
         np.array(
             [

--- a/test_autoarray/inversion/regularizations/test_adaptive_brightness_split_zeroth.py
+++ b/test_autoarray/inversion/regularizations/test_adaptive_brightness_split_zeroth.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pytest
+
+import autoarray as aa
+
+
+def test__regularization_matrix_from(delaunay_mapper_9_3x3):
+
+    reg = aa.reg.AdaptiveBrightnessSplit(
+        inner_coefficient=1.0, outer_coefficient=2.0, signal_scale=1.0
+    )
+
+    regularization_matrix_adaptive = reg.regularization_matrix_from(
+        linear_obj=delaunay_mapper_9_3x3
+    )
+
+    reg = aa.reg.BrightnessZeroth(coefficient=3.0, signal_scale=2.0)
+
+    regularization_matrix_zeroth = reg.regularization_matrix_from(
+        linear_obj=delaunay_mapper_9_3x3
+    )
+
+    regularization_matrix = (
+        regularization_matrix_adaptive + regularization_matrix_zeroth
+    )
+
+    reg = aa.reg.AdaptiveBrightnessSplitZeroth(
+        inner_coefficient=1.0,
+        outer_coefficient=2.0,
+        signal_scale=1.0,
+        zeroth_coefficient=3.0,
+        zeroth_signal_scale=2.0,
+    )
+
+    regularization_matrix_both = reg.regularization_matrix_from(
+        linear_obj=delaunay_mapper_9_3x3
+    )
+
+    print(regularization_matrix_both - regularization_matrix)
+
+    assert (regularization_matrix_both == regularization_matrix).all()

--- a/test_autoarray/inversion/regularizations/test_adaptive_brightness_split_zeroth.py
+++ b/test_autoarray/inversion/regularizations/test_adaptive_brightness_split_zeroth.py
@@ -36,6 +36,4 @@ def test__regularization_matrix_from(delaunay_mapper_9_3x3):
         linear_obj=delaunay_mapper_9_3x3
     )
 
-    print(regularization_matrix_both - regularization_matrix)
-
     assert (regularization_matrix_both == regularization_matrix).all()

--- a/test_autoarray/inversion/regularizations/test_regularization_util.py
+++ b/test_autoarray/inversion/regularizations/test_regularization_util.py
@@ -201,6 +201,33 @@ def test__adaptive_regularization_weights_from():
     assert (weight_list == np.array([0.75**2.0, 0.5**2.0, 0.25**2.0])).all()
 
 
+def test__brightness_zeroth_regularization_weights_from():
+
+    pixel_signals = np.array([1.0, 1.0, 1.0])
+
+    weight_list = aa.util.regularization.brightness_zeroth_regularization_weights_from(
+        coefficient=1.0, pixel_signals=pixel_signals
+    )
+
+    assert (weight_list == np.array([0.0, 0.0, 0.0])).all()
+
+    pixel_signals = np.array([0.25, 0.5, 0.75])
+
+    weight_list = aa.util.regularization.brightness_zeroth_regularization_weights_from(
+        coefficient=1.0, pixel_signals=pixel_signals
+    )
+
+    assert (weight_list == np.array([0.75, 0.5, 0.25])).all()
+
+    pixel_signals = np.array([0.25, 0.5, 0.75])
+
+    weight_list = aa.util.regularization.brightness_zeroth_regularization_weights_from(
+        coefficient=2.0, pixel_signals=pixel_signals
+    )
+
+    assert (weight_list == np.array([1.5, 1.0, 0.5])).all()
+
+
 def test__weighted_regularization_matrix_from():
 
     neighbors = np.array([[2], [3], [0], [1]])

--- a/test_autoarray/inversion/regularizations/test_regularization_util.py
+++ b/test_autoarray/inversion/regularizations/test_regularization_util.py
@@ -514,6 +514,33 @@ def test__weighted_regularization_matrix_from():
     assert regularization_matrix == pytest.approx(test_regularization_matrix, 1.0e-4)
 
 
+def test__brightness_zeroth_regularization_matrix_from():
+
+    regularization_weights = np.ones(shape=(3,))
+
+    regularization_matrix = (
+        aa.util.regularization.brightness_zeroth_regularization_matrix_from(
+            regularization_weights=regularization_weights,
+        )
+    )
+
+    assert regularization_matrix == pytest.approx(
+        np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]), 1.0e-4
+    )
+
+    regularization_weights = np.array([1.0, 2.0, 3.0])
+
+    regularization_matrix = (
+        aa.util.regularization.brightness_zeroth_regularization_matrix_from(
+            regularization_weights=regularization_weights,
+        )
+    )
+
+    assert regularization_matrix == pytest.approx(
+        np.array([[1.0, 0.0, 0.0], [0.0, 4.0, 0.0], [0.0, 0.0, 9.0]]), 1.0e-4
+    )
+
+
 def test__constant_pixel_splitted_regularization_matrix():
     splitted_mappings = np.array(
         [

--- a/test_autoarray/plot/get_visuals/test_two_d.py
+++ b/test_autoarray/plot/get_visuals/test_two_d.py
@@ -77,8 +77,6 @@ def test__via_mapper_for_data_from(voronoi_mapper_9_3x3):
         == voronoi_mapper_9_3x3.source_plane_data_grid.mask.derive_grid.border_sub_1.binned
     ).all()
 
-    print(visuals_2d.mesh_grid)
-    print(voronoi_mapper_9_3x3.source_plane_mesh_grid)
     assert (
         visuals_2d_via.mesh_grid == voronoi_mapper_9_3x3.image_plane_mesh_grid
     ).all()

--- a/test_autoarray/structures/arrays/test_uniform_2d.py
+++ b/test_autoarray/structures/arrays/test_uniform_2d.py
@@ -610,9 +610,6 @@ def test__extent_of_zoomed_array():
 
     extent = arr_masked.extent_of_zoomed_array(buffer=1)
 
-    print(extent)
-    print(arr_masked.origin)
-
     assert extent == pytest.approx(np.array([-4.0, 6.0, -2.0, 3.0]), 1.0e-4)
 
 

--- a/test_autoarray/structures/mesh/test_delaunay.py
+++ b/test_autoarray/structures/mesh/test_delaunay.py
@@ -61,11 +61,6 @@ def test__edge_pixel_list():
 
     mesh = aa.Mesh2DDelaunay(values=grid)
 
-    print(mesh.delaunay.neighbors)
-    print(mesh.delaunay.vertex_neighbor_vertices)
-    print(mesh.neighbors)
-    print(mesh.edge_pixel_list)
-
     assert mesh.edge_pixel_list == [0, 1, 2, 3, 5, 6, 7, 8]
 
 

--- a/test_autoarray/structures/test_structure_decorators.py
+++ b/test_autoarray/structures/test_structure_decorators.py
@@ -723,8 +723,6 @@ def test__in_grid_2d_iterate__out_ndarray_yx_2d_list__values_use_iteration():
     values_sub_3 = ndarray_2d_from(grid=grid_sub_3, profile=None)
     values_sub_3 = grid_sub_3.structure_2d_from(result=values_sub_3)
 
-    print(type(ndarray_yx_2d_list[0]))
-
     assert isinstance(ndarray_yx_2d_list[0], aa.VectorYX2D)
     assert (ndarray_yx_2d_list[0][0] == values_sub_3.binned[0]).all()
     assert (ndarray_yx_2d_list[0][1] == values_sub_3.binned[1]).all()

--- a/test_autoarray/structures/vectors/test_vectors_uniform.py
+++ b/test_autoarray/structures/vectors/test_vectors_uniform.py
@@ -56,7 +56,6 @@ def test__no_mask():
     ).all()
 
     assert (vectors.binned.native == np.array([[[4.0, 5.0]]])).all()
-    print(vectors.grid)
     assert (vectors.binned.slim == np.array([[4.0, 5.0]])).all()
     assert (
         vectors.grid.native

--- a/test_autoarray/test_preloads.py
+++ b/test_autoarray/test_preloads.py
@@ -276,9 +276,6 @@ def test__set_operated_mapping_matrix_with_preloads():
 
     assert (preloads.operated_mapping_matrix == operated_mapping_matrix_0).all()
 
-    print(preloads.curvature_matrix_preload)
-    print(curvature_matrix_preload)
-
     assert (
         preloads.curvature_matrix_preload == curvature_matrix_preload.astype("int")
     ).all()


### PR DESCRIPTION
In a previous PR, I removed a function which checks that a reconstruction of an inverison is not all the same value, in order to simplify the code base.

Well, it turns out that was a terrible idea, so I have reimplemented it, albeit in a way that has less of an impact on the codebase complexity.

The solution is always checked in this way by default and does not you to tell autolens to do it.