### PR TITLE
Feature/remove legacy

### DIFF
--- a/autoarray/fixtures.py
+++ b/autoarray/fixtures.py
@@ -410,7 +410,7 @@ def make_rectangular_mapper_7x7_3x3():
         source_plane_data_grid=make_sub_grid_2d_7x7(),
         source_plane_mesh_grid=make_rectangular_mesh_grid_3x3(),
         image_plane_mesh_grid=None,
-        hyper_data=aa.Array2D.ones(shape_native=(3, 3), pixel_scales=0.1),
+        adapt_data=aa.Array2D.ones(shape_native=(3, 3), pixel_scales=0.1),
     )
 
     return aa.MapperRectangularNoInterp(
@@ -423,7 +423,7 @@ def make_delaunay_mapper_9_3x3():
         source_plane_data_grid=make_sub_grid_2d_7x7(),
         source_plane_mesh_grid=make_delaunay_mesh_grid_9(),
         image_plane_mesh_grid=aa.Grid2D.uniform(shape_native=(3, 3), pixel_scales=0.1),
-        hyper_data=aa.Array2D.ones(shape_native=(3, 3), pixel_scales=0.1),
+        adapt_data=aa.Array2D.ones(shape_native=(3, 3), pixel_scales=0.1),
     )
 
     return aa.MapperDelaunay(
@@ -436,7 +436,7 @@ def make_voronoi_mapper_9_3x3():
         source_plane_data_grid=make_sub_grid_2d_7x7(),
         source_plane_mesh_grid=make_voronoi_mesh_grid_9(),
         image_plane_mesh_grid=aa.Grid2D.uniform(shape_native=(3, 3), pixel_scales=0.1),
-        hyper_data=aa.Array2D.ones(shape_native=(3, 3), pixel_scales=0.1),
+        adapt_data=aa.Array2D.ones(shape_native=(3, 3), pixel_scales=0.1),
     )
 
     return aa.MapperVoronoiNoInterp(
@@ -449,7 +449,7 @@ def make_voronoi_mapper_nn_9_3x3():
         source_plane_data_grid=make_sub_grid_2d_7x7(),
         source_plane_mesh_grid=make_voronoi_mesh_grid_9(),
         image_plane_mesh_grid=aa.Grid2D.uniform(shape_native=(3, 3), pixel_scales=0.1),
-        hyper_data=aa.Array2D.ones(shape_native=(3, 3), pixel_scales=0.1),
+        adapt_data=aa.Array2D.ones(shape_native=(3, 3), pixel_scales=0.1),
     )
 
     return aa.MapperVoronoi(mapper_grids=mapper_grids, regularization=None)

--- a/autoarray/inversion/mock/mock_mapper.py
+++ b/autoarray/inversion/mock/mock_mapper.py
@@ -10,7 +10,7 @@ class MockMapper(AbstractMapper):
         self,
         source_plane_data_grid=None,
         source_plane_mesh_grid=None,
-        hyper_data=None,
+        adapt_data=None,
         edge_pixel_list=None,
         regularization=None,
         pix_sub_weights=None,
@@ -23,7 +23,7 @@ class MockMapper(AbstractMapper):
         mapper_grids = MapperGrids(
             source_plane_data_grid=source_plane_data_grid,
             source_plane_mesh_grid=source_plane_mesh_grid,
-            hyper_data=hyper_data,
+            adapt_data=adapt_data,
         )
 
         super().__init__(mapper_grids=mapper_grids, regularization=regularization)

--- a/autoarray/inversion/mock/mock_mesh.py
+++ b/autoarray/inversion/mock/mock_mesh.py
@@ -20,7 +20,7 @@ class MockMesh(AbstractMesh):
         source_plane_data_grid: Grid2D,
         source_plane_mesh_grid: Grid2DSparse = None,
         image_plane_mesh_grid: Grid2DSparse = None,
-        hyper_data: np.ndarray = None,
+        adapt_data: np.ndarray = None,
         settings=SettingsPixelization(),
         preloads: Preloads = Preloads(),
         profiling_dict: Optional[Dict] = None,
@@ -29,16 +29,16 @@ class MockMesh(AbstractMesh):
             source_plane_data_grid=source_plane_data_grid,
             source_plane_mesh_grid=source_plane_mesh_grid,
             image_plane_mesh_grid=self.image_plane_mesh_grid,
-            hyper_data=hyper_data,
+            adapt_data=adapt_data,
             settings=settings,
             preloads=preloads,
             profiling_dict=profiling_dict,
         )
 
     def image_plane_mesh_grid_from(
-        self, image_plane_data_grid, hyper_data, settings=None
+        self, image_plane_data_grid, adapt_data, settings=None
     ):
-        if hyper_data is not None and self.image_plane_mesh_grid is not None:
-            return hyper_data * self.image_plane_mesh_grid
+        if adapt_data is not None and self.image_plane_mesh_grid is not None:
+            return adapt_data * self.image_plane_mesh_grid
 
         return self.image_plane_mesh_grid

--- a/autoarray/inversion/mock/mock_pixelization.py
+++ b/autoarray/inversion/mock/mock_pixelization.py
@@ -16,7 +16,7 @@ class MockPixelization(Pixelization):
         source_plane_data_grid,
         source_plane_mesh_grid,
         image_plane_mesh_grid=None,
-        hyper_data=None,
+        adapt_data=None,
         settings=None,
         preloads=None,
         profiling_dict=None,
@@ -24,9 +24,9 @@ class MockPixelization(Pixelization):
         return self.mapper
 
     def image_plane_mesh_grid_from(
-        self, image_plane_data_grid, hyper_data, settings=None
+        self, image_plane_data_grid, adapt_data, settings=None
     ):
-        if hyper_data is not None and self.image_plane_mesh_grid is not None:
-            return hyper_data * self.image_plane_mesh_grid
+        if adapt_data is not None and self.image_plane_mesh_grid is not None:
+            return adapt_data * self.image_plane_mesh_grid
 
         return self.image_plane_mesh_grid

--- a/autoarray/inversion/pixelization/mappers/abstract.py
+++ b/autoarray/inversion/pixelization/mappers/abstract.py
@@ -110,8 +110,8 @@ class AbstractMapper(LinearObj):
         return self.source_plane_mesh_grid.edge_pixel_list
 
     @property
-    def hyper_data(self) -> np.ndarray:
-        return self.mapper_grids.hyper_data
+    def adapt_data(self) -> np.ndarray:
+        return self.mapper_grids.adapt_data
 
     @property
     def neighbors(self) -> Neighbors:
@@ -302,7 +302,7 @@ class AbstractMapper(LinearObj):
             pix_indexes_for_sub_slim_index=self.pix_indexes_for_sub_slim_index,
             pix_size_for_sub_slim_index=self.pix_sizes_for_sub_slim_index,
             slim_index_for_sub_slim_index=self.source_plane_data_grid.mask.derive_indexes.slim_for_sub_slim,
-            hyper_data=self.hyper_data,
+            adapt_data=self.adapt_data,
         )
 
     def pix_indexes_for_slim_indexes(self, pix_indexes: List) -> List[List]:

--- a/autoarray/inversion/pixelization/mappers/abstract.py
+++ b/autoarray/inversion/pixelization/mappers/abstract.py
@@ -284,7 +284,7 @@ class AbstractMapper(LinearObj):
 
     def pixel_signals_from(self, signal_scale: float) -> np.ndarray:
         """
-        Returns the (hyper) signal in each pixelization pixel, where this signal is an estimate of the expected signal
+        Returns the signal in each pixelization pixel, where this signal is an estimate of the expected signal
         each pixelization pixel contains given the data pixels it maps too.
 
         A full description of this is given in the function `mapper_util.adaptive_pixel_signals_from().

--- a/autoarray/inversion/pixelization/mappers/mapper_grids.py
+++ b/autoarray/inversion/pixelization/mappers/mapper_grids.py
@@ -17,7 +17,7 @@ class MapperGrids:
         source_plane_data_grid: Grid2D,
         source_plane_mesh_grid: Abstract2DMesh = None,
         image_plane_mesh_grid: Grid2DSparse = None,
-        hyper_data: np.ndarray = None,
+        adapt_data: np.ndarray = None,
         settings: SettingsPixelization = SettingsPixelization(),
         preloads: Preloads = None,
         profiling_dict: Optional[Dict] = None,
@@ -53,7 +53,7 @@ class MapperGrids:
         image_plane_mesh_grid
             The sparse set of (y,x) coordinates computed from the unmasked data in the `data` frame. This has a
             transformation applied to it to create the `source_plane_mesh_grid`.
-        hyper_data
+        adapt_data
             An image which is used to determine the `image_plane_mesh_grid` and therefore adapt the distribution of
             pixels of the Delaunay grid to the data it discretizes.
         settings
@@ -70,7 +70,7 @@ class MapperGrids:
         self.source_plane_data_grid = source_plane_data_grid
         self.source_plane_mesh_grid = source_plane_mesh_grid
         self.image_plane_mesh_grid = image_plane_mesh_grid
-        self.hyper_data = hyper_data
+        self.adapt_data = adapt_data
         self.settings = settings
         self.preloads = preloads or Preloads()
         self.profiling_dict = profiling_dict

--- a/autoarray/inversion/pixelization/mappers/mapper_util.py
+++ b/autoarray/inversion/pixelization/mappers/mapper_util.py
@@ -480,7 +480,7 @@ def adaptive_pixel_signals_from(
     pix_indexes_for_sub_slim_index: np.ndarray,
     pix_size_for_sub_slim_index: np.ndarray,
     slim_index_for_sub_slim_index: np.ndarray,
-    hyper_data: np.ndarray,
+    adapt_data: np.ndarray,
 ) -> np.ndarray:
     """
     Returns the (hyper) signal in each pixel, where the signal is the sum of its mapped data values.
@@ -506,7 +506,7 @@ def adaptive_pixel_signals_from(
         low signal regions.
     regular_to_pix
         A 1D array util every pixel on the grid to a pixel on the pixelization.
-    hyper_data
+    adapt_data
         The image of the galaxy which is used to compute the weigghted pixel signals.
     """
 
@@ -522,11 +522,11 @@ def adaptive_pixel_signals_from(
 
         if pix_size_tem > 1:
             pixel_signals[vertices_indexes[:pix_size_tem]] += (
-                hyper_data[mask_1d_index] * pixel_weights[sub_slim_index]
+                adapt_data[mask_1d_index] * pixel_weights[sub_slim_index]
             )
             pixel_sizes[vertices_indexes] += 1
         else:
-            pixel_signals[vertices_indexes[0]] += hyper_data[mask_1d_index]
+            pixel_signals[vertices_indexes[0]] += adapt_data[mask_1d_index]
             pixel_sizes[vertices_indexes[0]] += 1
 
     pixel_sizes[pixel_sizes == 0] = 1

--- a/autoarray/inversion/pixelization/mappers/mapper_util.py
+++ b/autoarray/inversion/pixelization/mappers/mapper_util.py
@@ -483,7 +483,7 @@ def adaptive_pixel_signals_from(
     adapt_data: np.ndarray,
 ) -> np.ndarray:
     """
-    Returns the (hyper) signal in each pixel, where the signal is the sum of its mapped data values.
+    Returns the signal in each pixel, where the signal is the sum of its mapped data values.
     These pixel-signals are used to compute the effective regularization weight of each pixel.
 
     The pixel signals are computed as follows:
@@ -494,7 +494,7 @@ def adaptive_pixel_signals_from(
     2) Divided by the maximum pixel-signal, so that all signals vary between 0 and 1. This ensures that the
        regularization weight_list are defined identically for any data quantity or signal-to-noise_map ratio.
 
-    3) Raised to the power of the hyper-parameter *signal_scale*, so the method can control the relative
+    3) Raised to the power of the parameter *signal_scale*, so the method can control the relative
        contribution regularization in different regions of pixelization.
 
     Parameters

--- a/autoarray/inversion/pixelization/mesh/abstract.py
+++ b/autoarray/inversion/pixelization/mesh/abstract.py
@@ -95,7 +95,7 @@ class AbstractMesh:
         source_plane_data_grid: Grid2D,
         source_plane_mesh_grid: Grid2DSparse = None,
         image_plane_mesh_grid: Grid2DSparse = None,
-        hyper_data: np.ndarray = None,
+        adapt_data: np.ndarray = None,
         settings=SettingsPixelization(),
         preloads: Preloads = Preloads(),
         profiling_dict: Optional[Dict] = None,
@@ -110,7 +110,7 @@ class AbstractMesh:
     ):
         raise NotImplementedError
 
-    def weight_map_from(self, hyper_data: np.ndarray):
+    def weight_map_from(self, adapt_data: np.ndarray):
         raise NotImplementedError()
 
     @property

--- a/autoarray/inversion/pixelization/mesh/delaunay.py
+++ b/autoarray/inversion/pixelization/mesh/delaunay.py
@@ -112,7 +112,7 @@ class DelaunayMagnification(Delaunay):
     def image_plane_mesh_grid_from(
         self,
         image_plane_data_grid: Grid2D,
-        hyper_data: np.ndarray = None,
+        adapt_data: np.ndarray = None,
         settings=SettingsPixelization(),
     ):
         """
@@ -128,7 +128,7 @@ class DelaunayMagnification(Delaunay):
         image_plane_mesh_grid
             The sparse set of (y,x) coordinates computed from the unmasked data in the image-plane. This has a
             transformation applied to it to create the ``source_plane_mesh_grid``.
-        hyper_data
+        adapt_data
             An image which is used to determine the ``image_plane_mesh_grid`` and therefore adapt the distribution of
             pixels of the Delaunay grid to the data it discretizes.
         settings
@@ -188,31 +188,31 @@ class DelaunayBrightnessImage(Delaunay):
         self.weight_floor = weight_floor
         self.weight_power = weight_power
 
-    def weight_map_from(self, hyper_data: np.ndarray):
+    def weight_map_from(self, adapt_data: np.ndarray):
         """
-        Computes a ``weight_map`` from an input ``hyper_data``, where this image represents components in the masked 2d
+        Computes a ``weight_map`` from an input ``adapt_data``, where this image represents components in the masked 2d
         data in the image-plane. This applies the ``weight_floor`` and ``weight_power`` attributes of the class, which
         scale the weights to make different components upweighted relative to one another.
 
         Parameters
         ----------
-        hyper_data
+        adapt_data
             A image which represents one or more components in the masked 2D data in the image-plane.
 
         Returns
         -------
         The weight map which is used to adapt the Delaunay pixels in the image-plane to components in the data.
         """
-        weight_map = (hyper_data - np.min(hyper_data)) / (
-            np.max(hyper_data) - np.min(hyper_data)
-        ) + self.weight_floor * np.max(hyper_data)
+        weight_map = (adapt_data - np.min(adapt_data)) / (
+            np.max(adapt_data) - np.min(adapt_data)
+        ) + self.weight_floor * np.max(adapt_data)
 
         return np.power(weight_map, self.weight_power)
 
     def image_plane_mesh_grid_from(
         self,
         image_plane_data_grid: Grid2D,
-        hyper_data: np.ndarray,
+        adapt_data: np.ndarray,
         settings=SettingsPixelization(),
     ):
         """
@@ -223,7 +223,7 @@ class DelaunayBrightnessImage(Delaunay):
         which then act the centres of the Delaunay pixelization's pixels.
 
         For a ``DelaunayBrightnessImage`` this grid is computed by applying a KMeans clustering algorithm to the masked
-        data's values, where these values are reweighted by the ``hyper_data`` so that the algorithm can adapt to
+        data's values, where these values are reweighted by the ``adapt_data`` so that the algorithm can adapt to
         specific parts of the data.
 
         Parameters
@@ -231,13 +231,13 @@ class DelaunayBrightnessImage(Delaunay):
         image_plane_mesh_grid
             The sparse set of (y,x) coordinates computed from the unmasked data in the image-plane. This has a
             transformation applied to it to create the ``source_plane_mesh_grid``.
-        hyper_data
+        adapt_data
             An image which is used to determine the ``image_plane_mesh_grid`` and therefore adapt the distribution of
             pixels of the Delaunay grid to the data it discretizes.
         settings
             Settings controlling the pixelization for example if a border is used to relocate its exterior coordinates.
         """
-        weight_map = self.weight_map_from(hyper_data=hyper_data)
+        weight_map = self.weight_map_from(adapt_data=adapt_data)
 
         return Grid2DSparse.from_total_pixels_grid_and_weight_map(
             total_pixels=self.pixels,

--- a/autoarray/inversion/pixelization/mesh/mesh_util.py
+++ b/autoarray/inversion/pixelization/mesh/mesh_util.py
@@ -584,7 +584,7 @@ def voronoi_revised_from(
 
             t = voronoi.points[p2] - voronoi.points[p1]  # tangent
             t /= np.linalg.norm(t)
-            n = np.array([-t[1], t[0]])  # hyper
+            n = np.array([-t[1], t[0]])
 
             midpoint = voronoi.points[[p1, p2]].mean(axis=0)
             direction = np.sign(np.dot(midpoint - center, n)) * n

--- a/autoarray/inversion/pixelization/mesh/rectangular.py
+++ b/autoarray/inversion/pixelization/mesh/rectangular.py
@@ -66,7 +66,7 @@ class Rectangular(AbstractMesh):
         source_plane_data_grid: Grid2D,
         source_plane_mesh_grid: Grid2D = None,
         image_plane_mesh_grid: Grid2D = None,
-        hyper_data: np.ndarray = None,
+        adapt_data: np.ndarray = None,
         settings: SettingsPixelization = SettingsPixelization(),
         preloads: Preloads = Preloads(),
         profiling_dict: Optional[Dict] = None,
@@ -96,7 +96,7 @@ class Rectangular(AbstractMesh):
             by overlaying the `source_plane_data_grid` with the rectangular pixelization.
         image_plane_mesh_grid
             Not used for a rectangular pixelization.
-        hyper_data
+        adapt_data
             Not used for a rectangular pixelization.
         settings
             Settings controlling the pixelization for example if a border is used to relocate its exterior coordinates.
@@ -120,7 +120,7 @@ class Rectangular(AbstractMesh):
             source_plane_data_grid=relocated_grid,
             source_plane_mesh_grid=mesh_grid,
             image_plane_mesh_grid=image_plane_mesh_grid,
-            hyper_data=hyper_data,
+            adapt_data=adapt_data,
             preloads=preloads,
             profiling_dict=profiling_dict,
         )
@@ -154,7 +154,7 @@ class Rectangular(AbstractMesh):
     def image_plane_mesh_grid_from(
         self,
         image_plane_data_grid: Grid2D,
-        hyper_data: np.ndarray = None,
+        adapt_data: np.ndarray = None,
         settings=SettingsPixelization(),
     ):
         """

--- a/autoarray/inversion/pixelization/mesh/triangulation.py
+++ b/autoarray/inversion/pixelization/mesh/triangulation.py
@@ -15,7 +15,7 @@ class Triangulation(AbstractMesh):
         source_plane_data_grid: Grid2D,
         source_plane_mesh_grid: Grid2DSparse = None,
         image_plane_mesh_grid: Grid2DSparse = None,
-        hyper_data: np.ndarray = None,
+        adapt_data: np.ndarray = None,
         settings=SettingsPixelization(),
         preloads: Preloads = Preloads(),
         profiling_dict: Optional[Dict] = None,
@@ -55,7 +55,7 @@ class Triangulation(AbstractMesh):
         image_plane_mesh_grid
             The sparse set of (y,x) coordinates computed from the unmasked data in the `data` frame. This has a
             transformation applied to it to create the `source_plane_mesh_grid`.
-        hyper_data
+        adapt_data
             Not used for a rectangular mesh.
         settings
             Settings controlling the mesh for example if a border is used to relocate its exterior coordinates.
@@ -93,7 +93,7 @@ class Triangulation(AbstractMesh):
             source_plane_data_grid=source_plane_data_grid,
             source_plane_mesh_grid=source_plane_mesh_grid,
             image_plane_mesh_grid=image_plane_mesh_grid,
-            hyper_data=hyper_data,
+            adapt_data=adapt_data,
             preloads=preloads,
             profiling_dict=profiling_dict,
         )

--- a/autoarray/inversion/pixelization/mesh/voronoi.py
+++ b/autoarray/inversion/pixelization/mesh/voronoi.py
@@ -123,7 +123,7 @@ class VoronoiMagnification(Voronoi):
     def image_plane_mesh_grid_from(
         self,
         image_plane_data_grid: Grid2D,
-        hyper_data: np.ndarray = None,
+        adapt_data: np.ndarray = None,
         settings=SettingsPixelization(),
     ) -> Grid2DSparse:
         """
@@ -139,7 +139,7 @@ class VoronoiMagnification(Voronoi):
         image_plane_mesh_grid
             The sparse set of (y,x) coordinates computed from the unmasked data in the `data` frame. This has a
             transformation applied to it to create the `source_plane_mesh_grid`.
-        hyper_data
+        adapt_data
             An image which is used to determine the `image_plane_mesh_grid` and therefore adapt the distribution of
             pixels of the Voronoi grid to the data it discretizes.
         settings
@@ -200,31 +200,31 @@ class VoronoiBrightnessImage(Voronoi):
         self.weight_floor = weight_floor
         self.weight_power = weight_power
 
-    def weight_map_from(self, hyper_data: np.ndarray) -> np.ndarray:
+    def weight_map_from(self, adapt_data: np.ndarray) -> np.ndarray:
         """
-        Computes a `weight_map` from an input `hyper_data`, where this image represents components in the masked 2d
+        Computes a `weight_map` from an input `adapt_data`, where this image represents components in the masked 2d
         data in the `data` frame. This applies the `weight_floor` and `weight_power` attributes of the class, which
         scale the weights to make different components upweighted relative to one another.
 
         Parameters
         ----------
-        hyper_data
+        adapt_data
             A image which represents one or more components in the masked 2D data in the `data` frame.
 
         Returns
         -------
         The weight map which is used to adapt the Voronoi pixels in the `data` frame to components in the data.
         """
-        weight_map = (hyper_data - np.min(hyper_data)) / (
-            np.max(hyper_data) - np.min(hyper_data)
-        ) + self.weight_floor * np.max(hyper_data)
+        weight_map = (adapt_data - np.min(adapt_data)) / (
+            np.max(adapt_data) - np.min(adapt_data)
+        ) + self.weight_floor * np.max(adapt_data)
 
         return np.power(weight_map, self.weight_power)
 
     def image_plane_mesh_grid_from(
         self,
         image_plane_data_grid: Grid2D,
-        hyper_data: np.ndarray,
+        adapt_data: np.ndarray,
         settings=SettingsPixelization(),
     ):
         """
@@ -235,7 +235,7 @@ class VoronoiBrightnessImage(Voronoi):
         which then act the centres of the Voronoi mesh's pixels.
 
         For a `VoronoiBrightnessImage` this grid is computed by applying a KMeans clustering algorithm to the masked
-        data's values, where these values are reweighted by the `hyper_data` so that the algorithm can adapt to
+        data's values, where these values are reweighted by the `adapt_data` so that the algorithm can adapt to
         specific parts of the data.
 
         Parameters
@@ -243,13 +243,13 @@ class VoronoiBrightnessImage(Voronoi):
         image_plane_mesh_grid
             The sparse set of (y,x) coordinates computed from the unmasked data in the `data` frame. This has a
             transformation applied to it to create the `source_plane_mesh_grid`.
-        hyper_data
+        adapt_data
             An image which is used to determine the `image_plane_mesh_grid` and therefore adapt the distribution of
             pixels of the Voronoi grid to the data it discretizes.
         settings
             Settings controlling the pixelization for example if a border is used to relocate its exterior coordinates.
         """
-        weight_map = self.weight_map_from(hyper_data=hyper_data)
+        weight_map = self.weight_map_from(adapt_data=adapt_data)
 
         return Grid2DSparse.from_total_pixels_grid_and_weight_map(
             total_pixels=self.pixels,

--- a/autoarray/inversion/regularization/abstract.py
+++ b/autoarray/inversion/regularization/abstract.py
@@ -17,18 +17,18 @@ class AbstractRegularization:
     def __init__(self):
         """
         Abstract base class for a regularization-scheme, which is applied to a pixelization to enforce a \
-        smooth-source solution and prevent over-fitting noise_map in the hyper_galaxies. This is achieved by computing a \
+        smooth-source solution and prevent over-fitting. This is achieved by computing a \
         'regularization term' - which is the sum of differences in reconstructed flux between every set of neighboring \
         pixels. This regularization term is added to the solution's chi-squared as a penalty term. This effects \
         a pixelization in the following ways:
 
         1) The regularization matrix (see below) is added to the curvature matrix used by the inversion to \
-           linearly invert and fit the hyper_galaxies. Thus, it changes the pixelization in a linear manner, ensuring that \
+           linearly invert and fit the data. Thus, it changes the pixelization in a linear manner, ensuring that \
            the minimum chi-squared solution is achieved accounting for the penalty term.
 
-        2) The log likelihood of the pixelization's fit to the hyper_galaxies changes from L = -0.5 *(chi^2 + noise_normalization) \
+        2) The log likelihood of the pixelization's fit to the dataset changes from L = -0.5 *(chi^2 + noise_normalization) \
            to L = -0.5 (chi^2 + coefficients * regularization_term + noise_normalization). The regularization \
-           coefficient is a 'hyper_galaxies-parameter' which determines how strongly we smooth the pixelization's reconstruction.
+           coefficient is a parameter which determines how strongly we smooth the pixelization's reconstruction.
 
         The value of the coefficients(s) is set using the Bayesian framework of (Suyu 2006) and this \
         is described further in the (*inversion.inversion* class).

--- a/autoarray/operators/convolver.py
+++ b/autoarray/operators/convolver.py
@@ -473,7 +473,7 @@ class Convolver:
         [[0.0, 1.0, 1.0]]
         [[0.0, 0.0, 0.0]]
 
-        We then convolve each of these with our PSF kernel, in 2 dimensions, like we would a hyper grid. For
+        We then convolve each of these with our PSF kernel, in 2 dimensions, like we would a grid. For
         example, using the kernel below:
 
         kernel:

--- a/autoarray/preloads.py
+++ b/autoarray/preloads.py
@@ -124,7 +124,7 @@ class Preloads:
         This function compares the relocated grids of the mappers of two fit corresponding to two model instances, and
         preloads the grid if the grids of both fits are the same.
 
-        The preload is typically used in adapt searches, where the mass model is fixed and the hyper-parameters are
+        The preload is typically used in adapt searches, where the mass model is fixed and the parameters are
         varied.
 
         Parameters

--- a/test_autoarray/inversion/pixelization/mappers/test_abstract.py
+++ b/test_autoarray/inversion/pixelization/mappers/test_abstract.py
@@ -114,7 +114,7 @@ def test__adaptive_pixel_signals_from___matches_util(grid_2d_7x7, image_7x7):
     mapper = aa.m.MockMapper(
         source_plane_data_grid=grid_2d_7x7,
         pix_sub_weights=pix_sub_weights,
-        hyper_data=image_7x7,
+        adapt_data=image_7x7,
         parameters=pixels,
     )
 
@@ -127,7 +127,7 @@ def test__adaptive_pixel_signals_from___matches_util(grid_2d_7x7, image_7x7):
         pix_indexes_for_sub_slim_index=pix_sub_weights.mappings,
         pix_size_for_sub_slim_index=pix_sub_weights.sizes,
         slim_index_for_sub_slim_index=grid_2d_7x7.mask.derive_indexes.slim_for_sub_slim,
-        hyper_data=image_7x7,
+        adapt_data=image_7x7,
     )
 
     assert (pixel_signals == pixel_signals_util).all()

--- a/test_autoarray/inversion/pixelization/mappers/test_mapper_util.py
+++ b/test_autoarray/inversion/pixelization/mappers/test_mapper_util.py
@@ -515,7 +515,7 @@ def test__adaptive_pixel_signals_from():
         pix_size_for_sub_slim_index=pixel_sizes,
         pixel_weights=pixel_weights,
         slim_index_for_sub_slim_index=slim_index_for_sub_slim_index,
-        hyper_data=galaxy_image,
+        adapt_data=galaxy_image,
     )
 
     assert (pixel_signals == np.array([1.0, 1.0, 1.0])).all()
@@ -533,7 +533,7 @@ def test__adaptive_pixel_signals_from():
         pix_size_for_sub_slim_index=pixel_sizes,
         pixel_weights=pixel_weights,
         slim_index_for_sub_slim_index=slim_index_for_sub_slim_index,
-        hyper_data=galaxy_image,
+        adapt_data=galaxy_image,
     )
 
     assert (pixel_signals == np.array([1.0, 1.0, 1.0])).all()
@@ -551,7 +551,7 @@ def test__adaptive_pixel_signals_from():
         pix_size_for_sub_slim_index=pixel_sizes,
         pixel_weights=pixel_weights,
         slim_index_for_sub_slim_index=slim_index_for_sub_slim_index,
-        hyper_data=galaxy_image,
+        adapt_data=galaxy_image,
     )
 
     assert (pixel_signals == np.array([1.0, 0.5, 0.5])).all()
@@ -569,7 +569,7 @@ def test__adaptive_pixel_signals_from():
         pix_size_for_sub_slim_index=pixel_sizes,
         pixel_weights=pixel_weights,
         slim_index_for_sub_slim_index=slim_index_for_sub_slim_index,
-        hyper_data=galaxy_image,
+        adapt_data=galaxy_image,
     )
 
     assert (pixel_signals == np.array([1.0, 0.25, 0.25])).all()

--- a/test_autoarray/inversion/pixelization/mappers/test_rectangular.py
+++ b/test_autoarray/inversion/pixelization/mappers/test_rectangular.py
@@ -50,7 +50,7 @@ def test__pixel_signals_from__matches_util(grid_2d_7x7, image_7x7):
     mapper_grids = aa.MapperGrids(
         source_plane_data_grid=grid_2d_7x7,
         source_plane_mesh_grid=mesh_grid,
-        hyper_data=image_7x7,
+        adapt_data=image_7x7,
     )
 
     mapper = aa.Mapper(mapper_grids=mapper_grids, regularization=None)
@@ -64,7 +64,7 @@ def test__pixel_signals_from__matches_util(grid_2d_7x7, image_7x7):
         pix_size_for_sub_slim_index=mapper.pix_sizes_for_sub_slim_index,
         pixel_weights=mapper.pix_weights_for_sub_slim_index,
         slim_index_for_sub_slim_index=grid_2d_7x7.mask.derive_indexes.slim_for_sub_slim,
-        hyper_data=image_7x7,
+        adapt_data=image_7x7,
     )
 
     assert (pixel_signals == pixel_signals_util).all()

--- a/test_autoarray/inversion/pixelization/mesh/test_delaunay.py
+++ b/test_autoarray/inversion/pixelization/mesh/test_delaunay.py
@@ -43,13 +43,13 @@ def test__magnification__preloads_used_for_relocated_grid(sub_grid_2d_7x7):
 
 
 def test__brightness__weight_map_from():
-    hyper_data = np.array([0.0, 1.0, 0.0])
+    adapt_data = np.array([0.0, 1.0, 0.0])
 
     pixelization = aa.mesh.DelaunayBrightnessImage(
         pixels=5, weight_floor=0.0, weight_power=0.0
     )
 
-    weight_map = pixelization.weight_map_from(hyper_data=hyper_data)
+    weight_map = pixelization.weight_map_from(adapt_data=adapt_data)
 
     assert (weight_map == np.ones(3)).all()
 
@@ -57,7 +57,7 @@ def test__brightness__weight_map_from():
         pixels=5, weight_floor=0.0, weight_power=1.0
     )
 
-    weight_map = pixelization.weight_map_from(hyper_data=hyper_data)
+    weight_map = pixelization.weight_map_from(adapt_data=adapt_data)
 
     assert (weight_map == np.array([0.0, 1.0, 0.0])).all()
 
@@ -65,7 +65,7 @@ def test__brightness__weight_map_from():
         pixels=5, weight_floor=1.0, weight_power=1.0
     )
 
-    weight_map = pixelization.weight_map_from(hyper_data=hyper_data)
+    weight_map = pixelization.weight_map_from(adapt_data=adapt_data)
 
     assert (weight_map == np.array([1.0, 2.0, 1.0])).all()
 
@@ -73,17 +73,17 @@ def test__brightness__weight_map_from():
         pixels=5, weight_floor=1.0, weight_power=2.0
     )
 
-    weight_map = pixelization.weight_map_from(hyper_data=hyper_data)
+    weight_map = pixelization.weight_map_from(adapt_data=adapt_data)
 
     assert (weight_map == np.array([1.0, 4.0, 1.0])).all()
 
-    hyper_data = np.array([-1.0, 1.0, 3.0])
+    adapt_data = np.array([-1.0, 1.0, 3.0])
 
     pixelization = aa.mesh.DelaunayBrightnessImage(
         pixels=5, weight_floor=0.0, weight_power=1.0
     )
 
-    weight_map = pixelization.weight_map_from(hyper_data=hyper_data)
+    weight_map = pixelization.weight_map_from(adapt_data=adapt_data)
 
     assert (weight_map == np.array([0.0, 0.5, 1.0])).all()
 
@@ -91,7 +91,7 @@ def test__brightness__weight_map_from():
         pixels=5, weight_floor=0.0, weight_power=2.0
     )
 
-    weight_map = pixelization.weight_map_from(hyper_data=hyper_data)
+    weight_map = pixelization.weight_map_from(adapt_data=adapt_data)
 
     assert (weight_map == np.array([0.0, 0.25, 1.0])).all()
 
@@ -99,7 +99,7 @@ def test__brightness__weight_map_from():
         pixels=5, weight_floor=1.0, weight_power=1.0
     )
 
-    weight_map = pixelization.weight_map_from(hyper_data=hyper_data)
+    weight_map = pixelization.weight_map_from(adapt_data=adapt_data)
 
     assert (weight_map == np.array([3.0, 3.5, 4.0])).all()
 
@@ -111,9 +111,9 @@ def test__brightness_mesh_grid__matches_manual_comparison_to_grids_module(
         pixels=6, weight_floor=0.1, weight_power=2.0
     )
 
-    hyper_data = np.array([0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0])
+    adapt_data = np.array([0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0])
 
-    weight_map = pixelization.weight_map_from(hyper_data=hyper_data)
+    weight_map = pixelization.weight_map_from(adapt_data=adapt_data)
 
     sparse_grid = aa.Grid2DSparse.from_total_pixels_grid_and_weight_map(
         total_pixels=pixelization.pixels,

--- a/test_autoarray/inversion/pixelization/mesh/test_voronoi.py
+++ b/test_autoarray/inversion/pixelization/mesh/test_voronoi.py
@@ -43,13 +43,13 @@ def test__magnification__preloads_used_for_relocated_grid(sub_grid_2d_7x7):
 
 
 def test__brightness__weight_map_from():
-    hyper_data = np.array([0.0, 1.0, 0.0])
+    adapt_data = np.array([0.0, 1.0, 0.0])
 
     pixelization = aa.mesh.VoronoiBrightnessImage(
         pixels=5, weight_floor=0.0, weight_power=0.0
     )
 
-    weight_map = pixelization.weight_map_from(hyper_data=hyper_data)
+    weight_map = pixelization.weight_map_from(adapt_data=adapt_data)
 
     assert (weight_map == np.ones(3)).all()
 
@@ -57,7 +57,7 @@ def test__brightness__weight_map_from():
         pixels=5, weight_floor=0.0, weight_power=1.0
     )
 
-    weight_map = pixelization.weight_map_from(hyper_data=hyper_data)
+    weight_map = pixelization.weight_map_from(adapt_data=adapt_data)
 
     assert (weight_map == np.array([0.0, 1.0, 0.0])).all()
 
@@ -65,7 +65,7 @@ def test__brightness__weight_map_from():
         pixels=5, weight_floor=1.0, weight_power=1.0
     )
 
-    weight_map = pixelization.weight_map_from(hyper_data=hyper_data)
+    weight_map = pixelization.weight_map_from(adapt_data=adapt_data)
 
     assert (weight_map == np.array([1.0, 2.0, 1.0])).all()
 
@@ -73,17 +73,17 @@ def test__brightness__weight_map_from():
         pixels=5, weight_floor=1.0, weight_power=2.0
     )
 
-    weight_map = pixelization.weight_map_from(hyper_data=hyper_data)
+    weight_map = pixelization.weight_map_from(adapt_data=adapt_data)
 
     assert (weight_map == np.array([1.0, 4.0, 1.0])).all()
 
-    hyper_data = np.array([-1.0, 1.0, 3.0])
+    adapt_data = np.array([-1.0, 1.0, 3.0])
 
     pixelization = aa.mesh.VoronoiBrightnessImage(
         pixels=5, weight_floor=0.0, weight_power=1.0
     )
 
-    weight_map = pixelization.weight_map_from(hyper_data=hyper_data)
+    weight_map = pixelization.weight_map_from(adapt_data=adapt_data)
 
     assert (weight_map == np.array([0.0, 0.5, 1.0])).all()
 
@@ -91,7 +91,7 @@ def test__brightness__weight_map_from():
         pixels=5, weight_floor=0.0, weight_power=2.0
     )
 
-    weight_map = pixelization.weight_map_from(hyper_data=hyper_data)
+    weight_map = pixelization.weight_map_from(adapt_data=adapt_data)
 
     assert (weight_map == np.array([0.0, 0.25, 1.0])).all()
 
@@ -99,7 +99,7 @@ def test__brightness__weight_map_from():
         pixels=5, weight_floor=1.0, weight_power=1.0
     )
 
-    weight_map = pixelization.weight_map_from(hyper_data=hyper_data)
+    weight_map = pixelization.weight_map_from(adapt_data=adapt_data)
 
     assert (weight_map == np.array([3.0, 3.5, 4.0])).all()
 
@@ -111,9 +111,9 @@ def test__brightness__mesh_grid__matches_manual_comparison_to_grids_module(
         pixels=6, weight_floor=0.1, weight_power=2.0
     )
 
-    hyper_data = np.array([0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0])
+    adapt_data = np.array([0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0])
 
-    weight_map = pixelization.weight_map_from(hyper_data=hyper_data)
+    weight_map = pixelization.weight_map_from(adapt_data=adapt_data)
 
     sparse_grid = aa.Grid2DSparse.from_total_pixels_grid_and_weight_map(
         total_pixels=pixelization.pixels,

--- a/test_autoarray/structures/files/config_flip/general.ini
+++ b/test_autoarray/structures/files/config_flip/general.ini
@@ -28,7 +28,7 @@ use_dataset_grids=True
 [pixelization]
 voronoi_nn_max_interpolation_neighbors=100
 
-[hyper]
+[adapt]
 adapt_minimum_percent=0.01
 adapt_noise_limit=1.0e8
 stochastic_outputs=False


### PR DESCRIPTION
I tried to retain hyper galaxy noise scaling in the source code as a legacy feature, but the maintenance is getting annoying so I have removed it.

We can reimplement it if we ever need it, but I suspect there are better approaches now we have MGEs anyway.