### PR TITLE
Visualization mode

### DIFF
--- a/autoarray/dataset/plot/imaging_plotters.py
+++ b/autoarray/dataset/plot/imaging_plotters.py
@@ -60,7 +60,7 @@ class ImagingPlotterMeta(Plotter):
         noise_map: bool = False,
         psf: bool = False,
         signal_to_noise_map: bool = False,
-        title_str : Optional[str] = None,
+        title_str: Optional[str] = None,
     ):
         """
         Plots the individual attributes of the plotter's `Imaging` object in 2D.
@@ -98,7 +98,11 @@ class ImagingPlotterMeta(Plotter):
             self.mat_plot_2d.plot_array(
                 array=self.dataset.psf,
                 visuals_2d=self.get_visuals_2d(),
-                auto_labels=AutoLabels(title=title_str or f"Point Spread Function", filename="psf"),
+                auto_labels=AutoLabels(
+                    title=title_str or f"Point Spread Function",
+                    filename="psf",
+                    cb_unit="",
+                ),
             )
 
         if signal_to_noise_map:
@@ -106,7 +110,9 @@ class ImagingPlotterMeta(Plotter):
                 array=self.dataset.signal_to_noise_map,
                 visuals_2d=self.get_visuals_2d(),
                 auto_labels=AutoLabels(
-                    title=title_str or f"Signal-To-Noise Map", filename="signal_to_noise_map"
+                    title=title_str or f"Signal-To-Noise Map",
+                    filename="signal_to_noise_map",
+                    cb_unit="",
                 ),
             )
 

--- a/autoarray/dataset/plot/interferometer_plotters.py
+++ b/autoarray/dataset/plot/interferometer_plotters.py
@@ -281,6 +281,8 @@ class InterferometerPlotter(Plotter):
             uv_wavelengths=True,
             amplitudes_vs_uv_distances=True,
             phases_vs_uv_distances=True,
+            dirty_image=True,
+            dirty_signal_to_noise_map=True,
             auto_filename="subplot_dataset",
         )
 

--- a/autoarray/fit/fit_dataset.py
+++ b/autoarray/fit/fit_dataset.py
@@ -127,7 +127,7 @@ class FitDataset(AbstractFitInversion):
         self,
         dataset: AbstractDataset,
         use_mask_in_fit: bool = False,
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ):
         """Class to fit a masked dataset where the dataset's data structures are any dimension.
 
@@ -163,7 +163,7 @@ class FitDataset(AbstractFitInversion):
         self.dataset = dataset
         self.use_mask_in_fit = use_mask_in_fit
 
-        self.profiling_dict = profiling_dict
+        self.run_time_dict = run_time_dict
 
     @property
     @abstractmethod

--- a/autoarray/fit/fit_imaging.py
+++ b/autoarray/fit/fit_imaging.py
@@ -11,7 +11,7 @@ class FitImaging(FitDataset):
         self,
         dataset: Imaging,
         use_mask_in_fit: bool = False,
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ):
         """
         Class to fit a masked imaging dataset.
@@ -49,7 +49,7 @@ class FitImaging(FitDataset):
         super().__init__(
             dataset=dataset,
             use_mask_in_fit=use_mask_in_fit,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )
 
     @property

--- a/autoarray/fit/fit_interferometer.py
+++ b/autoarray/fit/fit_interferometer.py
@@ -15,7 +15,7 @@ class FitInterferometer(FitDataset):
         self,
         dataset: Interferometer,
         use_mask_in_fit: bool = False,
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ):
         """Class to fit a masked interferometer dataset.
 
@@ -52,7 +52,7 @@ class FitInterferometer(FitDataset):
         super().__init__(
             dataset=dataset,
             use_mask_in_fit=use_mask_in_fit,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )
 
     @property

--- a/autoarray/fit/mock/mock_fit_imaging.py
+++ b/autoarray/fit/mock/mock_fit_imaging.py
@@ -13,12 +13,12 @@ class MockFitImaging(FitImaging):
         model_data=None,
         inversion=None,
         blurred_image=None,
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ):
         super().__init__(
             dataset=dataset,
             use_mask_in_fit=use_mask_in_fit,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )
 
         self._noise_map = noise_map

--- a/autoarray/fit/plot/fit_interferometer_plotters.py
+++ b/autoarray/fit/plot/fit_interferometer_plotters.py
@@ -213,7 +213,7 @@ class FitInterferometerPlotterMeta(Plotter):
 
         if normalized_residual_map_real:
             self.mat_plot_1d.plot_yx(
-                y=np.real(self.fit.residual_map),
+                y=np.real(self.fit.normalized_residual_map),
                 x=self.fit.dataset.uv_distances / 10**3.0,
                 visuals_1d=self.visuals_1d,
                 auto_labels=AutoLabels(
@@ -226,7 +226,7 @@ class FitInterferometerPlotterMeta(Plotter):
             )
         if normalized_residual_map_imag:
             self.mat_plot_1d.plot_yx(
-                y=np.imag(self.fit.residual_map),
+                y=np.imag(self.fit.normalized_residual_map),
                 x=self.fit.dataset.uv_distances / 10**3.0,
                 visuals_1d=self.visuals_1d,
                 auto_labels=AutoLabels(
@@ -240,7 +240,7 @@ class FitInterferometerPlotterMeta(Plotter):
 
         if chi_squared_map_real:
             self.mat_plot_1d.plot_yx(
-                y=np.real(self.fit.residual_map),
+                y=np.real(self.fit.chi_squared_map),
                 x=self.fit.dataset.uv_distances / 10**3.0,
                 visuals_1d=self.visuals_1d,
                 auto_labels=AutoLabels(
@@ -253,7 +253,7 @@ class FitInterferometerPlotterMeta(Plotter):
             )
         if chi_squared_map_imag:
             self.mat_plot_1d.plot_yx(
-                y=np.imag(self.fit.residual_map),
+                y=np.imag(self.fit.chi_squared_map),
                 x=self.fit.dataset.uv_distances / 10**3.0,
                 visuals_1d=self.visuals_1d,
                 auto_labels=AutoLabels(

--- a/autoarray/inversion/inversion/abstract.py
+++ b/autoarray/inversion/inversion/abstract.py
@@ -31,7 +31,7 @@ class AbstractInversion:
         linear_obj_list: List[LinearObj],
         settings: SettingsInversion = SettingsInversion(),
         preloads: Optional["Preloads"] = None,
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ):
         """
         An `Inversion` reconstructs an input dataset using a list of linear objects (e.g. a list of analytic functions
@@ -72,7 +72,7 @@ class AbstractInversion:
         preloads
             Preloads in memory certain arrays which may be known beforehand in order to speed up the calculation,
             for example certain matrices used by the linear algebra could be preloaded.
-        profiling_dict
+        run_time_dict
             A dictionary which contains timing of certain functions calls which is used for profiling.
         """
 
@@ -99,7 +99,7 @@ class AbstractInversion:
         self.settings = settings
 
         self.preloads = preloads
-        self.profiling_dict = profiling_dict
+        self.run_time_dict = run_time_dict
 
     def has(self, cls: Type) -> bool:
         """

--- a/autoarray/inversion/inversion/factory.py
+++ b/autoarray/inversion/inversion/factory.py
@@ -31,7 +31,7 @@ def inversion_from(
     linear_obj_list: List[LinearObj],
     settings: SettingsInversion = SettingsInversion(),
     preloads: Preloads = Preloads(),
-    profiling_dict: Optional[Dict] = None,
+    run_time_dict: Optional[Dict] = None,
 ):
     """
     Factory which given an input dataset and list of linear objects, creates an `Inversion`.
@@ -59,7 +59,7 @@ def inversion_from(
     preloads
         Preloads in memory certain arrays which may be known beforehand in order to speed up the calculation,
         for example certain matrices used by the linear algebra could be preloaded.
-    profiling_dict
+    run_time_dict
         A dictionary which contains timing of certain functions calls which is used for profiling.
 
     Returns
@@ -80,7 +80,7 @@ def inversion_from(
             linear_obj_list=linear_obj_list,
             settings=settings,
             preloads=preloads,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )
 
     return inversion_interferometer_unpacked_from(
@@ -90,7 +90,7 @@ def inversion_from(
         w_tilde=w_tilde,
         linear_obj_list=linear_obj_list,
         settings=settings,
-        profiling_dict=profiling_dict,
+        run_time_dict=run_time_dict,
     )
 
 
@@ -102,7 +102,7 @@ def inversion_unpacked_from(
     linear_obj_list: List[LinearObj],
     settings: SettingsInversion = SettingsInversion(),
     preloads: Preloads = Preloads(),
-    profiling_dict: Optional[Dict] = None,
+    run_time_dict: Optional[Dict] = None,
 ):
     """
     Factory which given an input dataset and list of linear objects, creates an `Inversion`.
@@ -142,7 +142,7 @@ def inversion_unpacked_from(
     preloads
         Preloads in memory certain arrays which may be known beforehand in order to speed up the calculation,
         for example certain matrices used by the linear algebra could be preloaded.
-    profiling_dict
+    run_time_dict
         A dictionary which contains timing of certain functions calls which is used for profiling.
 
     Returns
@@ -158,7 +158,7 @@ def inversion_unpacked_from(
             linear_obj_list=linear_obj_list,
             settings=settings,
             preloads=preloads,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )
 
     return inversion_interferometer_unpacked_from(
@@ -168,7 +168,7 @@ def inversion_unpacked_from(
         w_tilde=w_tilde,
         linear_obj_list=linear_obj_list,
         settings=settings,
-        profiling_dict=profiling_dict,
+        run_time_dict=run_time_dict,
     )
 
 
@@ -180,7 +180,7 @@ def inversion_imaging_unpacked_from(
     linear_obj_list: List[LinearObj],
     settings: SettingsInversion = SettingsInversion(),
     preloads: Preloads = Preloads(),
-    profiling_dict: Optional[Dict] = None,
+    run_time_dict: Optional[Dict] = None,
 ):
     """
     Factory which given an input `Imaging` dataset and list of linear objects, creates an `InversionImaging`.
@@ -217,7 +217,7 @@ def inversion_imaging_unpacked_from(
     preloads
         Preloads in memory certain arrays which may be known beforehand in order to speed up the calculation,
         for example certain matrices used by the linear algebra could be preloaded.
-    profiling_dict
+    run_time_dict
         A dictionary which contains timing of certain functions calls which is used for profiling.
 
     Returns
@@ -250,7 +250,7 @@ def inversion_imaging_unpacked_from(
             linear_obj_list=linear_obj_list,
             settings=settings,
             preloads=preloads,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )
 
     return InversionImagingMapping(
@@ -260,7 +260,7 @@ def inversion_imaging_unpacked_from(
         linear_obj_list=linear_obj_list,
         settings=settings,
         preloads=preloads,
-        profiling_dict=profiling_dict,
+        run_time_dict=run_time_dict,
     )
 
 
@@ -272,7 +272,7 @@ def inversion_interferometer_unpacked_from(
     linear_obj_list: List[LinearObj],
     settings: SettingsInversion = SettingsInversion(),
     preloads: Preloads = Preloads(),
-    profiling_dict: Optional[Dict] = None,
+    run_time_dict: Optional[Dict] = None,
 ):
     """
     Factory which given an input `Interferometer` dataset and list of linear objects, creates
@@ -310,7 +310,7 @@ def inversion_interferometer_unpacked_from(
     preloads
         Preloads in memory certain arrays which may be known beforehand in order to speed up the calculation,
         for example certain matrices used by the linear algebra could be preloaded.
-    profiling_dict
+    run_time_dict
         A dictionary which contains timing of certain functions calls which is used for profiling.
 
     Returns
@@ -340,7 +340,7 @@ def inversion_interferometer_unpacked_from(
                 linear_obj_list=linear_obj_list,
                 settings=settings,
                 preloads=preloads,
-                profiling_dict=profiling_dict,
+                run_time_dict=run_time_dict,
             )
 
         else:
@@ -351,7 +351,7 @@ def inversion_interferometer_unpacked_from(
                 linear_obj_list=linear_obj_list,
                 settings=settings,
                 preloads=preloads,
-                profiling_dict=profiling_dict,
+                run_time_dict=run_time_dict,
             )
 
     else:
@@ -362,5 +362,5 @@ def inversion_interferometer_unpacked_from(
             linear_obj_list=linear_obj_list,
             settings=settings,
             preloads=preloads,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )

--- a/autoarray/inversion/inversion/imaging/abstract.py
+++ b/autoarray/inversion/inversion/imaging/abstract.py
@@ -25,7 +25,7 @@ class AbstractInversionImaging(AbstractInversion):
         linear_obj_list: List[LinearObj],
         settings: SettingsInversion = SettingsInversion(),
         preloads=None,
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ):
         """
         An `Inversion` reconstructs an input dataset using a list of linear objects (e.g. a list of analytic functions
@@ -70,7 +70,7 @@ class AbstractInversionImaging(AbstractInversion):
         preloads
             Preloads in memory certain arrays which may be known beforehand in order to speed up the calculation,
             for example certain matrices used by the linear algebra could be preloaded.
-        profiling_dict
+        run_time_dict
             A dictionary which contains timing of certain functions calls which is used for profiling.
         """
 
@@ -86,7 +86,7 @@ class AbstractInversionImaging(AbstractInversion):
             linear_obj_list=linear_obj_list,
             settings=settings,
             preloads=preloads,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )
 
     @property

--- a/autoarray/inversion/inversion/imaging/mapping.py
+++ b/autoarray/inversion/inversion/imaging/mapping.py
@@ -26,7 +26,7 @@ class InversionImagingMapping(AbstractInversionImaging):
         linear_obj_list: List[LinearObj],
         settings: SettingsInversion = SettingsInversion(),
         preloads=None,
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ):
         """
         Constructs linear equations (via vectors and matrices) which allow for sets of simultaneous linear equations
@@ -48,7 +48,7 @@ class InversionImagingMapping(AbstractInversionImaging):
         linear_obj_list
             The linear objects used to reconstruct the data's observed values. If multiple linear objects are passed
             the simultaneous linear equations are combined and solved simultaneously.
-        profiling_dict
+        run_time_dict
             A dictionary which contains timing of certain functions calls which is used for profiling.
         """
 
@@ -59,7 +59,7 @@ class InversionImagingMapping(AbstractInversionImaging):
             linear_obj_list=linear_obj_list,
             settings=settings,
             preloads=preloads,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )
 
     @property

--- a/autoarray/inversion/inversion/imaging/w_tilde.py
+++ b/autoarray/inversion/inversion/imaging/w_tilde.py
@@ -30,7 +30,7 @@ class InversionImagingWTilde(AbstractInversionImaging):
         linear_obj_list: List[LinearObj],
         settings: SettingsInversion = SettingsInversion(),
         preloads: Preloads = Preloads(),
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ):
         """
         Constructs linear equations (via vectors and matrices) which allow for sets of simultaneous linear equations
@@ -55,7 +55,7 @@ class InversionImagingWTilde(AbstractInversionImaging):
         linear_obj_list
             The linear objects used to reconstruct the data's observed values. If multiple linear objects are passed
             the simultaneous linear equations are combined and solved simultaneously.
-        profiling_dict
+        run_time_dict
             A dictionary which contains timing of certain functions calls which is used for profiling.
         """
 
@@ -66,7 +66,7 @@ class InversionImagingWTilde(AbstractInversionImaging):
             linear_obj_list=linear_obj_list,
             settings=settings,
             preloads=preloads,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )
 
         if self.settings.use_w_tilde:

--- a/autoarray/inversion/inversion/interferometer/abstract.py
+++ b/autoarray/inversion/inversion/interferometer/abstract.py
@@ -25,7 +25,7 @@ class AbstractInversionInterferometer(AbstractInversion):
         linear_obj_list: List[LinearObj],
         settings: SettingsInversion = SettingsInversion(),
         preloads: Preloads = Preloads(),
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ):
         """
         Constructs linear equations (via vectors and matrices) which allow for sets of simultaneous linear equations
@@ -46,7 +46,7 @@ class AbstractInversionInterferometer(AbstractInversion):
         linear_obj_list
             The linear objects used to reconstruct the data's observed values. If multiple linear objects are passed
             the simultaneous linear equations are combined and solved simultaneously.
-        profiling_dict
+        run_time_dict
             A dictionary which contains timing of certain functions calls which is used for profiling.
         """
 
@@ -56,7 +56,7 @@ class AbstractInversionInterferometer(AbstractInversion):
             linear_obj_list=linear_obj_list,
             settings=settings,
             preloads=preloads,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )
 
         self.transformer = transformer

--- a/autoarray/inversion/inversion/interferometer/mapping.py
+++ b/autoarray/inversion/inversion/interferometer/mapping.py
@@ -28,7 +28,7 @@ class InversionInterferometerMapping(AbstractInversionInterferometer):
         linear_obj_list: List[LinearObj],
         settings: SettingsInversion = SettingsInversion(),
         preloads: Preloads = Preloads(),
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ):
         """
         Constructs linear equations (via vectors and matrices) which allow for sets of simultaneous linear equations
@@ -52,7 +52,7 @@ class InversionInterferometerMapping(AbstractInversionInterferometer):
         linear_obj_list
             The linear objects used to reconstruct the data's observed values. If multiple linear objects are passed
             the simultaneous linear equations are combined and solved simultaneously.
-        profiling_dict
+        run_time_dict
             A dictionary which contains timing of certain functions calls which is used for profiling.
         """
 
@@ -63,7 +63,7 @@ class InversionInterferometerMapping(AbstractInversionInterferometer):
             linear_obj_list=linear_obj_list,
             settings=settings,
             preloads=preloads,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )
 
         self.transformer = transformer

--- a/autoarray/inversion/inversion/interferometer/w_tilde.py
+++ b/autoarray/inversion/inversion/interferometer/w_tilde.py
@@ -30,7 +30,7 @@ class InversionInterferometerWTilde(AbstractInversionInterferometer):
         linear_obj_list: List[LinearObj],
         settings: SettingsInversion = SettingsInversion(),
         preloads: Preloads = Preloads(),
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ):
         """
         Constructs linear equations (via vectors and matrices) which allow for sets of simultaneous linear equations
@@ -57,7 +57,7 @@ class InversionInterferometerWTilde(AbstractInversionInterferometer):
         linear_obj_list
             The linear objects used to reconstruct the data's observed values. If multiple linear objects are passed
             the simultaneous linear equations are combined and solved simultaneously.
-        profiling_dict
+        run_time_dict
             A dictionary which contains timing of certain functions calls which is used for profiling.
         """
 
@@ -71,7 +71,7 @@ class InversionInterferometerWTilde(AbstractInversionInterferometer):
             linear_obj_list=linear_obj_list,
             settings=settings,
             preloads=preloads,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )
 
         self.settings = settings

--- a/autoarray/inversion/linear_obj/func_list.py
+++ b/autoarray/inversion/linear_obj/func_list.py
@@ -17,7 +17,7 @@ class AbstractLinearObjFuncList(LinearObj):
         self,
         grid: Grid1D2DLike,
         regularization: Optional[AbstractRegularization],
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ):
         """
         A linear object which reconstructs a dataset based on mapping between the data points of that dataset and
@@ -42,11 +42,11 @@ class AbstractLinearObjFuncList(LinearObj):
             is evaluated.
         regularization
             The regularization scheme which may be applied to this linear object in order to smooth its solution.
-        profiling_dict
+        run_time_dict
             A dictionary which contains timing of certain functions calls which is used for profiling.
         """
 
-        super().__init__(regularization=regularization, profiling_dict=profiling_dict)
+        super().__init__(regularization=regularization, run_time_dict=run_time_dict)
 
         self.grid = grid
 

--- a/autoarray/inversion/linear_obj/linear_obj.py
+++ b/autoarray/inversion/linear_obj/linear_obj.py
@@ -13,7 +13,7 @@ class LinearObj:
     def __init__(
         self,
         regularization: Optional[AbstractRegularization],
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ):
         """
         A linear object which reconstructs a dataset based on mapping between the data points of that dataset and
@@ -33,11 +33,11 @@ class LinearObj:
         ----------
         regularization
             The regularization scheme which may be applied to this linear object in order to smooth its solution.
-        profiling_dict
+        run_time_dict
             A dictionary which contains timing of certain functions calls which is used for profiling.
         """
         self.regularization = regularization
-        self.profiling_dict = profiling_dict
+        self.run_time_dict = run_time_dict
 
     @property
     def params(self) -> int:

--- a/autoarray/inversion/mock/mock_mesh.py
+++ b/autoarray/inversion/mock/mock_mesh.py
@@ -23,7 +23,7 @@ class MockMesh(AbstractMesh):
         adapt_data: np.ndarray = None,
         settings=SettingsPixelization(),
         preloads: Preloads = Preloads(),
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ) -> MapperGrids:
         return MapperGrids(
             source_plane_data_grid=source_plane_data_grid,
@@ -32,7 +32,7 @@ class MockMesh(AbstractMesh):
             adapt_data=adapt_data,
             settings=settings,
             preloads=preloads,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )
 
     def image_plane_mesh_grid_from(

--- a/autoarray/inversion/mock/mock_pixelization.py
+++ b/autoarray/inversion/mock/mock_pixelization.py
@@ -19,7 +19,7 @@ class MockPixelization(Pixelization):
         adapt_data=None,
         settings=None,
         preloads=None,
-        profiling_dict=None,
+        run_time_dict=None,
     ):
         return self.mapper
 

--- a/autoarray/inversion/pixelization/mappers/abstract.py
+++ b/autoarray/inversion/pixelization/mappers/abstract.py
@@ -23,7 +23,7 @@ class AbstractMapper(LinearObj):
         self,
         mapper_grids: MapperGrids,
         regularization: Optional[AbstractRegularization],
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ):
         """
         To understand a `Mapper` one must be familiar `Mesh` objects and the `mesh` and `pixelization` packages, where
@@ -77,11 +77,11 @@ class AbstractMapper(LinearObj):
         regularization
             The regularization scheme which may be applied to this linear object in order to smooth its solution,
             which for a mapper smooths neighboring pixels on the mesh.
-        profiling_dict
+        run_time_dict
             A dictionary which contains timing of certain functions calls which is used for profiling.
         """
 
-        super().__init__(regularization=regularization, profiling_dict=profiling_dict)
+        super().__init__(regularization=regularization, run_time_dict=run_time_dict)
 
         self.mapper_grids = mapper_grids
 

--- a/autoarray/inversion/pixelization/mappers/delaunay.py
+++ b/autoarray/inversion/pixelization/mappers/delaunay.py
@@ -17,7 +17,7 @@ class MapperDelaunay(AbstractMapper):
         self,
         mapper_grids: MapperGrids,
         regularization: Optional[AbstractRegularization],
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ):
         """
         To understand a `Mapper` one must be familiar `Mesh` objects and the `mesh` and `pixelization` packages, where
@@ -65,13 +65,13 @@ class MapperDelaunay(AbstractMapper):
         regularization
             The regularization scheme which may be applied to this linear object in order to smooth its solution,
             which for a mapper smooths neighboring pixels on the mesh.
-        profiling_dict
+        run_time_dict
             A dictionary which contains timing of certain functions calls which is used for profiling.
         """
         super().__init__(
             mapper_grids=mapper_grids,
             regularization=regularization,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )
 
     @property

--- a/autoarray/inversion/pixelization/mappers/factory.py
+++ b/autoarray/inversion/pixelization/mappers/factory.py
@@ -10,7 +10,7 @@ from autoarray.structures.mesh.voronoi_2d import Mesh2DVoronoi
 def mapper_from(
     mapper_grids: MapperGrids,
     regularization: Optional[AbstractRegularization],
-    profiling_dict: Optional[Dict] = None,
+    run_time_dict: Optional[Dict] = None,
 ):
     """
     Factory which given input `MapperGrids` and `Regularization` objects creates a `Mapper`.
@@ -30,7 +30,7 @@ def mapper_from(
     regularization
         The regularization scheme which may be applied to this linear object in order to smooth its solution,
         which for a mapper smooths neighboring pixels on the mesh.
-    profiling_dict
+    run_time_dict
         A dictionary which contains timing of certain functions calls which is used for profiling.
 
     Returns
@@ -48,24 +48,24 @@ def mapper_from(
         return MapperRectangularNoInterp(
             mapper_grids=mapper_grids,
             regularization=regularization,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )
     elif isinstance(mapper_grids.source_plane_mesh_grid, Mesh2DDelaunay):
         return MapperDelaunay(
             mapper_grids=mapper_grids,
             regularization=regularization,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )
     elif isinstance(mapper_grids.source_plane_mesh_grid, Mesh2DVoronoi):
         if mapper_grids.source_plane_mesh_grid.uses_interpolation:
             return MapperVoronoi(
                 mapper_grids=mapper_grids,
                 regularization=regularization,
-                profiling_dict=profiling_dict,
+                run_time_dict=run_time_dict,
             )
 
         return MapperVoronoiNoInterp(
             mapper_grids=mapper_grids,
             regularization=regularization,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )

--- a/autoarray/inversion/pixelization/mappers/mapper_grids.py
+++ b/autoarray/inversion/pixelization/mappers/mapper_grids.py
@@ -20,7 +20,7 @@ class MapperGrids:
         adapt_data: np.ndarray = None,
         settings: SettingsPixelization = SettingsPixelization(),
         preloads: Preloads = None,
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ):
         """
         Groups the different grids used by `Mesh` objects, the `mesh` package and the `pixelization` package, which
@@ -61,7 +61,7 @@ class MapperGrids:
         preloads
             Preloads in memory certain arrays which may be known beforehand in order to speed up the calculation,
             for example the `source_plane_mesh_grid` could be preloaded.
-        profiling_dict
+        run_time_dict
             A dictionary which contains timing of certain functions calls which is used for profiling.
         """
 
@@ -73,4 +73,4 @@ class MapperGrids:
         self.adapt_data = adapt_data
         self.settings = settings
         self.preloads = preloads or Preloads()
-        self.profiling_dict = profiling_dict
+        self.run_time_dict = run_time_dict

--- a/autoarray/inversion/pixelization/mappers/rectangular.py
+++ b/autoarray/inversion/pixelization/mappers/rectangular.py
@@ -17,7 +17,7 @@ class MapperRectangularNoInterp(AbstractMapper):
         self,
         mapper_grids: MapperGrids,
         regularization: Optional[AbstractRegularization],
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ):
         """
         To understand a `Mapper` one must be familiar `Mesh` objects and the `mesh` and `pixelization` packages, where
@@ -64,13 +64,13 @@ class MapperRectangularNoInterp(AbstractMapper):
         regularization
             The regularization scheme which may be applied to this linear object in order to smooth its solution,
             which for a mapper smooths neighboring pixels on the mesh.
-        profiling_dict
+        run_time_dict
             A dictionary which contains timing of certain functions calls which is used for profiling.
         """
         super().__init__(
             mapper_grids=mapper_grids,
             regularization=regularization,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )
 
     @property

--- a/autoarray/inversion/pixelization/mappers/voronoi.py
+++ b/autoarray/inversion/pixelization/mappers/voronoi.py
@@ -18,7 +18,7 @@ class AbstractMapperVoronoi(AbstractMapper):
         self,
         mapper_grids: MapperGrids,
         regularization: Optional[AbstractRegularization],
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ):
         """
         To understand a `Mapper` one must be familiar `Mesh` objects and the `mesh` and `pixelization` packages, where
@@ -65,13 +65,13 @@ class AbstractMapperVoronoi(AbstractMapper):
         regularization
             The regularization scheme which may be applied to this linear object in order to smooth its solution,
             which for a mapper smooths neighboring pixels on the mesh.
-        profiling_dict
+        run_time_dict
             A dictionary which contains timing of certain functions calls which is used for profiling.
         """
         super().__init__(
             mapper_grids=mapper_grids,
             regularization=regularization,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )
 
     @property

--- a/autoarray/inversion/pixelization/mesh/abstract.py
+++ b/autoarray/inversion/pixelization/mesh/abstract.py
@@ -98,7 +98,7 @@ class AbstractMesh:
         adapt_data: np.ndarray = None,
         settings=SettingsPixelization(),
         preloads: Preloads = Preloads(),
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ) -> MapperGrids:
         raise NotImplementedError
 

--- a/autoarray/inversion/pixelization/mesh/rectangular.py
+++ b/autoarray/inversion/pixelization/mesh/rectangular.py
@@ -52,7 +52,7 @@ class Rectangular(AbstractMesh):
         self.pixels = self.shape[0] * self.shape[1]
         super().__init__()
 
-        self.profiling_dict = {}
+        self.run_time_dict = {}
 
     @property
     def uses_interpolation(self) -> bool:
@@ -69,7 +69,7 @@ class Rectangular(AbstractMesh):
         adapt_data: np.ndarray = None,
         settings: SettingsPixelization = SettingsPixelization(),
         preloads: Preloads = Preloads(),
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ) -> MapperGrids:
         """
         Mapper objects describe the mappings between pixels in the masked 2D data and the pixels in a pixelization,
@@ -103,11 +103,11 @@ class Rectangular(AbstractMesh):
         preloads
             Object which may contain preloaded arrays of quantities computed in the pixelization, which are passed via
             this object speed up the calculation.
-        profiling_dict
+        run_time_dict
             A dictionary which contains timing of certain functions calls which is used for profiling.
         """
 
-        self.profiling_dict = profiling_dict
+        self.run_time_dict = run_time_dict
 
         relocated_grid = self.relocated_grid_from(
             source_plane_data_grid=source_plane_data_grid,
@@ -122,7 +122,7 @@ class Rectangular(AbstractMesh):
             image_plane_mesh_grid=image_plane_mesh_grid,
             adapt_data=adapt_data,
             preloads=preloads,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )
 
     @profile_func

--- a/autoarray/inversion/pixelization/mesh/triangulation.py
+++ b/autoarray/inversion/pixelization/mesh/triangulation.py
@@ -18,7 +18,7 @@ class Triangulation(AbstractMesh):
         adapt_data: np.ndarray = None,
         settings=SettingsPixelization(),
         preloads: Preloads = Preloads(),
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ) -> MapperGrids:
         """
         Mapper objects describe the mappings between pixels in the masked 2D data and the pixels in a mesh,
@@ -62,11 +62,11 @@ class Triangulation(AbstractMesh):
         preloads
             Object which may contain preloaded arrays of quantities computed in the mesh, which are passed via
             this object speed up the calculation.
-        profiling_dict
+        run_time_dict
             A dictionary which contains timing of certain functions calls which is used for profiling.
         """
 
-        self.profiling_dict = profiling_dict
+        self.run_time_dict = run_time_dict
 
         source_plane_data_grid = self.relocated_grid_from(
             source_plane_data_grid=source_plane_data_grid,
@@ -95,5 +95,5 @@ class Triangulation(AbstractMesh):
             image_plane_mesh_grid=image_plane_mesh_grid,
             adapt_data=adapt_data,
             preloads=preloads,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )

--- a/autoarray/numba_util.py
+++ b/autoarray/numba_util.py
@@ -70,7 +70,7 @@ def profile_func(func: Callable):
     """
     Time every function called in a class and averages over repeated calls for profiling likelihood functions.
 
-    The timings are stored in the variable `_profiling_dict` of the class(s) from which each function is called,
+    The timings are stored in the variable `_run_time_dict` of the class(s) from which each function is called,
     which are collected at the end of the profiling process via recursion.
 
     Parameters
@@ -87,11 +87,11 @@ def profile_func(func: Callable):
     def wrapper(obj, *args, **kwargs):
         """
         Time a function and average over repeated calls for profiling an `Analysis` class's likelihood function. The
-        time is stored in a `profiling_dict` attribute.
+        time is stored in a `run_time_dict` attribute.
 
         It is possible for multiple functions with the `profile_func` decorator to be called. In this circumstance,
         we risk repeated profiling of the same functionality in these nested functions. Thus, before added
-        the time to the profiling_dict, the keys of the dictionary are iterated over in reverse, subtracting off the
+        the time to the run_time_dict, the keys of the dictionary are iterated over in reverse, subtracting off the
         times of nested functions (which will already have been added to the profiling dict).
 
         Returns
@@ -99,16 +99,16 @@ def profile_func(func: Callable):
             The result of the function being timed.
         """
 
-        if not hasattr(obj, "profiling_dict"):
+        if not hasattr(obj, "run_time_dict"):
             return func(obj, *args, **kwargs)
 
-        if obj.profiling_dict is None:
+        if obj.run_time_dict is None:
             return func(obj, *args, **kwargs)
 
         repeats = conf.instance["general"]["profiling"]["repeats"]
 
         last_key_before_call = (
-            list(obj.profiling_dict)[-1] if obj.profiling_dict else None
+            list(obj.run_time_dict)[-1] if obj.run_time_dict else None
         )
 
         start = time.time()
@@ -118,7 +118,7 @@ def profile_func(func: Callable):
         time_func = (time.time() - start) / repeats
 
         last_key_after_call = (
-            list(obj.profiling_dict)[-1] if obj.profiling_dict else None
+            list(obj.run_time_dict)[-1] if obj.run_time_dict else None
         )
 
         profile_call_max = 5
@@ -126,16 +126,16 @@ def profile_func(func: Callable):
         for i in range(profile_call_max):
             key_func = f"{func.__name__}_{i}"
 
-            if key_func not in obj.profiling_dict:
+            if key_func not in obj.run_time_dict:
                 if last_key_before_call == last_key_after_call:
-                    obj.profiling_dict[key_func] = time_func
+                    obj.run_time_dict[key_func] = time_func
                 else:
-                    for key, value in reversed(list(obj.profiling_dict.items())):
+                    for key, value in reversed(list(obj.run_time_dict.items())):
                         if last_key_before_call == key:
-                            obj.profiling_dict[key_func] = time_func
+                            obj.run_time_dict[key_func] = time_func
                             break
 
-                        time_func -= obj.profiling_dict[key]
+                        time_func -= obj.run_time_dict[key]
 
                 break
 

--- a/autoarray/numba_util.py
+++ b/autoarray/numba_util.py
@@ -98,6 +98,10 @@ def profile_func(func: Callable):
         -------
             The result of the function being timed.
         """
+
+        if not hasattr(obj, "profiling_dict"):
+            return func(obj, *args, **kwargs)
+
         if obj.profiling_dict is None:
             return func(obj, *args, **kwargs)
 

--- a/autoarray/plot/abstract_plotters.py
+++ b/autoarray/plot/abstract_plotters.py
@@ -182,6 +182,16 @@ class AbstractPlotter:
                 except AttributeError:
                     self.figures_1d(**{key: True})
 
+            try:
+                self.mat_plot_2d.subplot_index = max(
+                    self.mat_plot_1d.subplot_index, self.mat_plot_2d.subplot_index
+                )
+                self.mat_plot_1d.subplot_index = max(
+                    self.mat_plot_1d.subplot_index, self.mat_plot_2d.subplot_index
+                )
+            except AttributeError:
+                pass
+
         try:
             self.mat_plot_2d.output.subplot_to_figure(
                 auto_filename=kwargs["auto_labels"].filename

--- a/autoarray/plot/mat_plot/two_d.py
+++ b/autoarray/plot/mat_plot/two_d.py
@@ -338,7 +338,7 @@ class MatPlot2D(AbstractMatPlot):
         color_array=None,
         y_errors=None,
         x_errors=None,
-        buffer=1.0,
+        buffer=0.1,
     ):
         """Plot a grid of (y,x) Cartesian coordinates as a scatter plotter of points.
 
@@ -407,8 +407,7 @@ class MatPlot2D(AbstractMatPlot):
         extent = self.axis.config_dict.get("extent")
 
         if extent is None:
-            extent = np.asarray(grid.geometry.extent)
-            extent = extent + (buffer * extent)
+            extent = grid.extent_with_buffer_from(buffer=buffer)
 
         self.axis.set(extent=extent, grid=grid)
 

--- a/autoarray/plot/multi_plotters.py
+++ b/autoarray/plot/multi_plotters.py
@@ -19,11 +19,11 @@ class MultiFigurePlotter:
 
         if self.plotter_list[0].mat_plot_1d is not None:
             self.plotter_list[0].mat_plot_1d.output.subplot_to_figure(
-                auto_filename=f"subplot_{figure_name}{filename_suffix}_list"
+                auto_filename=f"subplot_{figure_name}{filename_suffix}"
             )
         if self.plotter_list[0].mat_plot_2d is not None:
             self.plotter_list[0].mat_plot_2d.output.subplot_to_figure(
-                auto_filename=f"subplot_{figure_name}{filename_suffix}_list"
+                auto_filename=f"subplot_{figure_name}{filename_suffix}"
             )
         self.plotter_list[0].close_subplot_figure()
 

--- a/autoarray/plot/wrap/base/output.py
+++ b/autoarray/plot/wrap/base/output.py
@@ -120,6 +120,9 @@ class Output:
                 os.makedirs(output_path, exist_ok=True)
 
             if not self.bypass:
+                if os.environ.get("PYAUTOARRAY_OUTPUT_MODE") == "1":
+                    return self.to_figure_output_mode(filename=filename)
+
                 if format == "show":
                     plt.show()
                 elif format == "png":
@@ -157,6 +160,9 @@ class Output:
             if format != "show":
                 os.makedirs(output_path, exist_ok=True)
 
+            if os.environ.get("PYAUTOARRAY_OUTPUT_MODE") == "1":
+                return self.to_figure_output_mode(filename=filename)
+
             if format == "show":
                 plt.show()
             elif format == "png":
@@ -169,3 +175,23 @@ class Output:
                     path.join(output_path, f"{filename}.pdf"),
                     bbox_inches=self.bbox_inches,
                 )
+
+    def to_figure_output_mode(self, filename: str):
+        global COUNT
+
+        try:
+            COUNT += 1
+        except NameError:
+            COUNT = 0
+
+        import sys
+
+        script_name = path.split(sys.argv[0])[-1].replace(".py", "")
+
+        output_path = path.join(os.getcwd(), "output_mode", script_name)
+        os.makedirs(output_path, exist_ok=True)
+
+        plt.savefig(
+            path.join(output_path, f"{COUNT}_{filename}.png"),
+            bbox_inches=self.bbox_inches,
+        )

--- a/autoarray/structures/grids/irregular_2d.py
+++ b/autoarray/structures/grids/irregular_2d.py
@@ -120,6 +120,43 @@ class Grid2DIrregular(AbstractNDArray):
         """
         return [tuple(value) for value in self]
 
+    @property
+    def scaled_minima(self) -> Tuple:
+        """
+        The (y,x) minimum values of the grid in scaled units, buffed such that their extent is further than the grid's
+        extent.
+        """
+        return (
+            np.amin(self[:, 0]).astype("float"),
+            np.amin(self[:, 1]).astype("float"),
+        )
+
+    @property
+    def scaled_maxima(self) -> Tuple:
+        """
+        The (y,x) maximum values of the grid in scaled units, buffed such that their extent is further than the grid's
+        extent.
+        """
+        return (
+            np.amax(self[:, 0]).astype("float"),
+            np.amax(self[:, 1]).astype("float"),
+        )
+
+    def extent_with_buffer_from(self, buffer: float = 1.0e-8) -> List[float]:
+        """
+        The extent of the grid in scaled units returned as a list [x_min, x_max, y_min, y_max], where all values are
+        buffed such that their extent is further than the grid's extent..
+
+        This follows the format of the extent input parameter in the matplotlib method imshow (and other methods) and
+        is used for visualization in the plot module.
+        """
+        return [
+            self.scaled_minima[1] - buffer,
+            self.scaled_maxima[1] + buffer,
+            self.scaled_minima[0] - buffer,
+            self.scaled_maxima[0] + buffer,
+        ]
+
     def values_from(self, array_slim: np.ndarray) -> ArrayIrregular:
         """
         Create a *ArrayIrregular* object from a 1D NumPy array of values of shape [total_coordinates], which

--- a/autoarray/structures/grids/uniform_2d.py
+++ b/autoarray/structures/grids/uniform_2d.py
@@ -1112,6 +1112,28 @@ class Grid2D(Structure):
             np.amax(self[:, 1]) - np.amin(self[:, 1]),
         )
 
+    @property
+    def scaled_minima(self) -> Tuple:
+        """
+        The (y,x) minimum values of the grid in scaled units, buffed such that their extent is further than the grid's
+        extent.
+        """
+        return (
+            np.amin(self[:, 0]).astype("float"),
+            np.amin(self[:, 1]).astype("float"),
+        )
+
+    @property
+    def scaled_maxima(self) -> Tuple:
+        """
+        The (y,x) maximum values of the grid in scaled units, buffed such that their extent is further than the grid's
+        extent.
+        """
+        return (
+            np.amax(self[:, 0]).astype("float"),
+            np.amax(self[:, 1]).astype("float"),
+        )
+
     def extent_with_buffer_from(self, buffer: float = 1.0e-8) -> List[float]:
         """
         The extent of the grid in scaled units returned as a list [x_min, x_max, y_min, y_max], where all values are

--- a/test_autoarray/fit/test_fit_imaging.py
+++ b/test_autoarray/fit/test_fit_imaging.py
@@ -142,7 +142,7 @@ def test__image_and_model_are_identical__inversion_included__changes_certain_pro
     assert fit.figure_of_merit == fit.log_evidence
 
 
-def test__profiling_dict__profiles_appropriate_functions():
+def test__run_time_dict__profiles_appropriate_functions():
     mask = aa.Mask2D(
         mask=[[False, False], [False, False]], sub_size=1, pixel_scales=(1.0, 1.0)
     )
@@ -156,14 +156,14 @@ def test__profiling_dict__profiles_appropriate_functions():
 
     model_image = aa.Array2D(values=[1.0, 2.0, 3.0, 4.0], mask=mask)
 
-    profiling_dict = {}
+    run_time_dict = {}
 
     fit = aa.m.MockFitImaging(
         dataset=masked_dataset,
         use_mask_in_fit=False,
         model_data=model_image,
-        profiling_dict=profiling_dict,
+        run_time_dict=run_time_dict,
     )
     fit.figure_of_merit
 
-    assert "figure_of_merit_0" in fit.profiling_dict
+    assert "figure_of_merit_0" in fit.run_time_dict

--- a/test_autoarray/plot/test_multi_plotters.py
+++ b/test_autoarray/plot/test_multi_plotters.py
@@ -28,7 +28,7 @@ def test__multi_plotter__subplot_of_plotter_list_figure(
     multi_plotter = aplt.MultiFigurePlotter(plotter_list=plotter_list)
     multi_plotter.subplot_of_figure(func_name="figures_2d", figure_name="data")
 
-    assert path.join(plot_path, "subplot_data_list.png") in plot_patch.paths
+    assert path.join(plot_path, "subplot_data.png") in plot_patch.paths
 
     plot_patch.paths = []
 
@@ -37,7 +37,7 @@ def test__multi_plotter__subplot_of_plotter_list_figure(
         func_name="figures_2d", figure_name="data", noise_map=True
     )
 
-    assert path.join(plot_path, "subplot_data_list.png") in plot_patch.paths
+    assert path.join(plot_path, "subplot_data.png") in plot_patch.paths
 
 
 class MockYX1DPlotter(aplt.YX1DPlotter):

--- a/test_autoarray/test_decorators.py
+++ b/test_autoarray/test_decorators.py
@@ -2,9 +2,9 @@ import autoarray as aa
 
 
 class MockClass:
-    def __init__(self, value, profiling_dict=None):
+    def __init__(self, value, run_time_dict=None):
         self._value = value
-        self.profiling_dict = profiling_dict
+        self.run_time_dict = run_time_dict
 
     @property
     @aa.profile_func
@@ -13,7 +13,7 @@ class MockClass:
 
 
 def test__profile_decorator_times_decorated_function():
-    cls = MockClass(value=1.0, profiling_dict={})
+    cls = MockClass(value=1.0, run_time_dict={})
     cls.value
 
-    assert "value_0" in cls.profiling_dict
+    assert "value_0" in cls.run_time_dict


### PR DESCRIPTION
By settings `PYAUTOARRAY_OUTPUT_MODE=1` all visualization is written to hard-disk in a folder with a tracked naming convention.

This is primarily used by myself to make producing visualizations of `overview` pages of readthedocs (e.g. https://pyautolens.readthedocs.io/en/latest/overview/overview_1_lensing.html) really fast to produce.