### PR TITLE
implemented

### DIFF
--- a/autoarray/config/visualize/general.yaml
+++ b/autoarray/config/visualize/general.yaml
@@ -2,11 +2,12 @@ general:
   backend: default                      # The matploblib backend used for visualization. `default` uses the system default, can specifiy specific backend (e.g. TKAgg, Qt5Agg, WXAgg).
   imshow_origin: upper                  # The `origin` input of `imshow`, determining if pixel values are ascending or descending on the y-axis.
   zoom_around_mask: true                # If True, plots of data structures with a mask automatically zoom in the masked region.
+  disable_zoom_for_fits: true           # If True, the zoom-in around the masked region is disabled when outputting .fits files, which is useful to retain the same dimensions as the input data.
 inversion:
   reconstruction_vmax_factor: 0.5
 zoom:
   plane_percent: 0.01
-  inversion_percent: 0.01       # Plots of an Inversion's reconstruction use the reconstructed data's bright value multiplied by this factor.
+  inversion_percent: 0.01               # Plots of an Inversion's reconstruction use the reconstructed data's bright value multiplied by this factor.
 subplot_shape:                          # The shape of a subplots for figures with an input number of subplots (e.g. for a figure with 4 subplots, the shape is (2, 2)).
   1: (1, 1)                             # The shape of subplots for a figure with 1 subplot.
   2: (1, 2)                             # The shape of subplots for a figure with 2 subplots.

--- a/autoarray/plot/mat_plot/two_d.py
+++ b/autoarray/plot/mat_plot/two_d.py
@@ -242,11 +242,23 @@ class MatPlot2D(AbstractMatPlot):
         else:
             buffer = 1
 
+        zoom_around_mask = False
+
         if conf.instance["visualize"]["general"]["general"]["zoom_around_mask"]:
+
+            zoom_around_mask = True
+
+        if self.output.format == "fits" and conf.instance["visualize"]["general"]["general"]["disable_zoom_for_fits"]:
+
+            zoom_around_mask = False
+
+        if zoom_around_mask:
+
             extent = array.extent_of_zoomed_array(buffer=buffer)
             array = array.zoomed_around_mask(buffer=buffer)
 
         else:
+
             extent = array.geometry.extent
 
         ax = None

--- a/test_autoarray/config/visualize.yaml
+++ b/test_autoarray/config/visualize.yaml
@@ -3,6 +3,7 @@ general:
     backend: default
     imshow_origin: upper
     zoom_around_mask: true
+    disable_zoom_for_fits: true           # If True, the zoom-in around the masked region is disabled when outputting .fits files, which is useful to retain the same dimensions as the input data.
   include_2d:
     border: true
     mapper_image_plane_mesh_grid: true

--- a/test_autoarray/fit/plot/test_fit_imaging_plotters.py
+++ b/test_autoarray/fit/plot/test_fit_imaging_plotters.py
@@ -87,4 +87,4 @@ def test__output_as_fits__correct_output_format(
         file_path=path.join(plot_path, "data.fits"), hdu=0
     )
 
-    assert image_from_plot.shape == (5, 5)
+    assert image_from_plot.shape == (7, 7)


### PR DESCRIPTION
The `all_at_end_fits` visualization output, which outputs .fits files for all resulting images, previously zoomed in the data based on the mask.

This was annoying as it meant images could be a different size to the data. For example, if you wanted to model the lens light subtracted image, it would have a different `shape` to the actual `noise_map`.

A config option `disable_zoom_for_fits` has been added which disables zooming for .fits output (default `True` means zoom is disabled).