### PR TITLE
Feature/primary hdu flip

### DIFF
--- a/autoarray/abstract_ndarray.py
+++ b/autoarray/abstract_ndarray.py
@@ -5,6 +5,8 @@ import numpy as np
 from pathlib import Path
 from typing import Union, TYPE_CHECKING
 
+from autoconf import conf
+
 if TYPE_CHECKING:
     from autoarray.structures.abstract_structure import Structure
 
@@ -34,6 +36,12 @@ class AbstractNDArray(np.ndarray, ABC):
         """
         Returns the data structure in its `native` format which contains all unmaksed values to the native dimensions.
         """
+
+    @staticmethod
+    def flip_hdu_for_ds9(values):
+        if conf.instance["general"]["fits"]["flip_for_ds9"]:
+            return np.flipud(values)
+        return values
 
     def output_to_fits(self, file_path: Union[Path, str], overwrite: bool = False):
         """

--- a/autoarray/config/visualize/general.yaml
+++ b/autoarray/config/visualize/general.yaml
@@ -2,11 +2,12 @@ general:
   backend: default                      # The matploblib backend used for visualization. `default` uses the system default, can specifiy specific backend (e.g. TKAgg, Qt5Agg, WXAgg).
   imshow_origin: upper                  # The `origin` input of `imshow`, determining if pixel values are ascending or descending on the y-axis.
   zoom_around_mask: true                # If True, plots of data structures with a mask automatically zoom in the masked region.
+  disable_zoom_for_fits: true           # If True, the zoom-in around the masked region is disabled when outputting .fits files, which is useful to retain the same dimensions as the input data.
 inversion:
   reconstruction_vmax_factor: 0.5
 zoom:
   plane_percent: 0.01
-  inversion_percent: 0.01       # Plots of an Inversion's reconstruction use the reconstructed data's bright value multiplied by this factor.
+  inversion_percent: 0.01               # Plots of an Inversion's reconstruction use the reconstructed data's bright value multiplied by this factor.
 subplot_shape:                          # The shape of a subplots for figures with an input number of subplots (e.g. for a figure with 4 subplots, the shape is (2, 2)).
   1: (1, 1)                             # The shape of subplots for a figure with 1 subplot.
   2: (1, 2)                             # The shape of subplots for a figure with 2 subplots.

--- a/autoarray/mask/mask_2d.py
+++ b/autoarray/mask/mask_2d.py
@@ -825,7 +825,7 @@ class Mask2D(Mask):
             )
         """
         return cls(
-            mask=primary_hdu.data.astype("bool"),
+            mask=cls.flip_hdu_for_ds9(primary_hdu.data.astype("float")),
             pixel_scales=primary_hdu.header["PIXSCALE"],
             sub_size=sub_size,
             origin=origin,

--- a/autoarray/plot/mat_plot/two_d.py
+++ b/autoarray/plot/mat_plot/two_d.py
@@ -242,11 +242,23 @@ class MatPlot2D(AbstractMatPlot):
         else:
             buffer = 1
 
+        zoom_around_mask = False
+
         if conf.instance["visualize"]["general"]["general"]["zoom_around_mask"]:
+
+            zoom_around_mask = True
+
+        if self.output.format == "fits" and conf.instance["visualize"]["general"]["general"]["disable_zoom_for_fits"]:
+
+            zoom_around_mask = False
+
+        if zoom_around_mask:
+
             extent = array.extent_of_zoomed_array(buffer=buffer)
             array = array.zoomed_around_mask(buffer=buffer)
 
         else:
+
             extent = array.geometry.extent
 
         ax = None

--- a/autoarray/structures/arrays/kernel_2d.py
+++ b/autoarray/structures/arrays/kernel_2d.py
@@ -421,7 +421,7 @@ class Kernel2D(AbstractArray2D):
             )
         """
         return cls.no_mask(
-            values=primary_hdu.data.astype("float"),
+            values=cls.flip_hdu_for_ds9(primary_hdu.data.astype("float")),
             pixel_scales=primary_hdu.header["PIXSCALE"],
             origin=origin,
         )

--- a/autoarray/structures/arrays/uniform_2d.py
+++ b/autoarray/structures/arrays/uniform_2d.py
@@ -1103,13 +1103,15 @@ class Array2D(AbstractArray2D):
                 sub_size=2
             )
         """
+
         return cls.no_mask(
-            values=primary_hdu.data.astype("float"),
+            values=cls.flip_hdu_for_ds9(primary_hdu.data.astype("float")),
             pixel_scales=primary_hdu.header["PIXSCALE"],
             sub_size=sub_size,
             origin=origin,
             header=Header(header_sci_obj=primary_hdu.header),
         )
+
 
     @classmethod
     def from_yx_and_values(

--- a/test_autoarray/config/visualize.yaml
+++ b/test_autoarray/config/visualize.yaml
@@ -3,6 +3,7 @@ general:
     backend: default
     imshow_origin: upper
     zoom_around_mask: true
+    disable_zoom_for_fits: true           # If True, the zoom-in around the masked region is disabled when outputting .fits files, which is useful to retain the same dimensions as the input data.
   include_2d:
     border: true
     mapper_image_plane_mesh_grid: true

--- a/test_autoarray/fit/plot/test_fit_imaging_plotters.py
+++ b/test_autoarray/fit/plot/test_fit_imaging_plotters.py
@@ -87,4 +87,4 @@ def test__output_as_fits__correct_output_format(
         file_path=path.join(plot_path, "data.fits"), hdu=0
     )
 
-    assert image_from_plot.shape == (5, 5)
+    assert image_from_plot.shape == (7, 7)


### PR DESCRIPTION
Methods used by the aggregator to load data from a .fits primary hdu now accounts for the `flip_for_ds9`.