### PR TITLE
Feature/database output

### DIFF
--- a/autoarray/dataset/imaging/imaging.py
+++ b/autoarray/dataset/imaging/imaging.py
@@ -276,9 +276,7 @@ class Imaging(AbstractDataset):
         else:
             unmasked_dataset = self.unmasked
 
-        data = Array2D(
-            values=unmasked_dataset.data.native, mask=mask.derive_mask.sub_1
-        )
+        data = Array2D(values=unmasked_dataset.data.native, mask=mask.derive_mask.sub_1)
 
         noise_map = Array2D(
             values=unmasked_dataset.noise_map.native, mask=mask.derive_mask.sub_1

--- a/autoarray/mask/abstract_mask.py
+++ b/autoarray/mask/abstract_mask.py
@@ -96,10 +96,9 @@ class Mask(AbstractNDArray, ABC):
             return {"PIXSCALE": self.pixel_scale}
         except exc.MaskException:
             return {
-                "PIXSCALEY" : self.pixel_scales[0],
-                "PIXSCALEX" : self.pixel_scales[1]
+                "PIXSCALEY": self.pixel_scales[0],
+                "PIXSCALEX": self.pixel_scales[1],
             }
-
 
     @property
     def dimensions(self) -> int:

--- a/autoarray/mask/mask_1d.py
+++ b/autoarray/mask/mask_1d.py
@@ -236,6 +236,25 @@ class Mask1D(Mask):
     def shape_slim(self) -> Tuple[int]:
         return self.shape
 
+    @property
+    def hdu_for_output(self) -> fits.PrimaryHDU:
+        """
+        The mask as a HDU object, which can be output to a .fits file.
+
+        The header of the HDU is used to store the `pixel_scale` of the array, which is used by the `Array1D.from_hdu`.
+
+        This method is used in other projects (E.g. PyAutoGalaxy, PyAutoLens) to conveniently output the array to .fits
+        files.
+
+        Returns
+        -------
+        The HDU containing the data and its header which can then be written to .fits.
+        """
+        return array_1d_util.hdu_for_output_from(
+            array_1d=self.astype("float"),
+            header_dict=self.pixel_scale_header
+        )
+
     def output_to_fits(self, file_path: Union[Path, str], overwrite: bool = False):
         """
         Write the 1D mask to a .fits file.

--- a/autoarray/mask/mask_1d.py
+++ b/autoarray/mask/mask_1d.py
@@ -251,8 +251,7 @@ class Mask1D(Mask):
         The HDU containing the data and its header which can then be written to .fits.
         """
         return array_1d_util.hdu_for_output_from(
-            array_1d=self.astype("float"),
-            header_dict=self.pixel_scale_header
+            array_1d=self.astype("float"), header_dict=self.pixel_scale_header
         )
 
     def output_to_fits(self, file_path: Union[Path, str], overwrite: bool = False):

--- a/autoarray/mask/mask_1d.py
+++ b/autoarray/mask/mask_1d.py
@@ -224,7 +224,6 @@ class Mask1D(Mask):
             origin=origin,
         )
 
-
     @property
     def shape_native(self) -> Tuple[int]:
         return self.shape
@@ -259,8 +258,8 @@ class Mask1D(Mask):
         mask.output_to_fits(file_path='/path/to/file/filename.fits', overwrite=True)
         """
         array_1d_util.numpy_array_1d_to_fits(
-            array_1d=self.astype("float"), 
-            file_path=file_path, 
-            overwrite=overwrite, 
-            header_dict=self.pixel_scale_header
+            array_1d=self.astype("float"),
+            file_path=file_path,
+            overwrite=overwrite,
+            header_dict=self.pixel_scale_header,
         )

--- a/autoarray/mask/mask_2d.py
+++ b/autoarray/mask/mask_2d.py
@@ -903,8 +903,7 @@ class Mask2D(Mask):
         The HDU containing the data and its header which can then be written to .fits.
         """
         return array_2d_util.hdu_for_output_from(
-            array_2d=self.astype("float"),
-            header_dict=self.pixel_scale_header
+            array_2d=self.astype("float"), header_dict=self.pixel_scale_header
         )
 
     def output_to_fits(self, file_path, overwrite=False):
@@ -936,7 +935,7 @@ class Mask2D(Mask):
             array_2d=self.astype("float"),
             file_path=file_path,
             overwrite=overwrite,
-            header_dict=self.pixel_scale_header
+            header_dict=self.pixel_scale_header,
         )
 
     @property

--- a/autoarray/mask/mask_2d.py
+++ b/autoarray/mask/mask_2d.py
@@ -903,8 +903,7 @@ class Mask2D(Mask):
         The HDU containing the data and its header which can then be written to .fits.
         """
         return array_2d_util.hdu_for_output_from(
-            array_2d=self.astype("float"),
-            header_dict=self.pixel_scale_header
+            array_2d=self.astype("float"), header_dict=self.pixel_scale_header
         )
 
     def output_to_fits(self, file_path, overwrite=False):

--- a/autoarray/mask/mask_2d.py
+++ b/autoarray/mask/mask_2d.py
@@ -903,7 +903,8 @@ class Mask2D(Mask):
         The HDU containing the data and its header which can then be written to .fits.
         """
         return array_2d_util.hdu_for_output_from(
-            array_2d=self.astype("float"), header_dict=self.pixel_scale_header
+            array_2d=self.astype("float"),
+            header_dict=self.pixel_scale_header
         )
 
     def output_to_fits(self, file_path, overwrite=False):

--- a/autoarray/mask/mask_2d.py
+++ b/autoarray/mask/mask_2d.py
@@ -888,6 +888,25 @@ class Mask2D(Mask):
             padded_array=blurred_image, image_shape=image_shape
         )
 
+    @property
+    def hdu_for_output(self) -> fits.PrimaryHDU:
+        """
+        The mask as a HDU object, which can be output to a .fits file.
+
+        The header of the HDU is used to store the `pixel_scale` of the array, which is used by the `Array2D.from_hdu`.
+
+        This method is used in other projects (E.g. PyAutoGalaxy, PyAutoLens) to conveniently output the array to .fits
+        files.
+
+        Returns
+        -------
+        The HDU containing the data and its header which can then be written to .fits.
+        """
+        return array_2d_util.hdu_for_output_from(
+            array_2d=self.astype("float"),
+            header_dict=self.pixel_scale_header
+        )
+
     def output_to_fits(self, file_path, overwrite=False):
         """
         Write the 2D Mask to a .fits file.

--- a/autoarray/plot/mat_plot/two_d.py
+++ b/autoarray/plot/mat_plot/two_d.py
@@ -245,20 +245,21 @@ class MatPlot2D(AbstractMatPlot):
         zoom_around_mask = False
 
         if conf.instance["visualize"]["general"]["general"]["zoom_around_mask"]:
-
             zoom_around_mask = True
 
-        if self.output.format == "fits" and conf.instance["visualize"]["general"]["general"]["disable_zoom_for_fits"]:
-
+        if (
+            self.output.format == "fits"
+            and conf.instance["visualize"]["general"]["general"][
+                "disable_zoom_for_fits"
+            ]
+        ):
             zoom_around_mask = False
 
         if zoom_around_mask:
-
             extent = array.extent_of_zoomed_array(buffer=buffer)
             array = array.zoomed_around_mask(buffer=buffer)
 
         else:
-
             extent = array.geometry.extent
 
         ax = None

--- a/autoarray/plot/multi_plotters.py
+++ b/autoarray/plot/multi_plotters.py
@@ -23,10 +23,16 @@ class MultiFigurePlotter:
         )
 
         for i, plotter in enumerate(self.plotter_list):
-            plotter.mat_plot_2d.set_for_subplot(is_for_subplot=True)
-            plotter.mat_plot_2d.number_subplots = number_subplots
-            plotter.mat_plot_2d.subplot_shape = self.subplot_shape
-            plotter.mat_plot_2d.subplot_index = i + 1
+            try:
+                plotter.mat_plot_2d.set_for_subplot(is_for_subplot=True)
+                plotter.mat_plot_2d.number_subplots = number_subplots
+                plotter.mat_plot_2d.subplot_shape = self.subplot_shape
+                plotter.mat_plot_2d.subplot_index = i + 1
+            except AttributeError:
+                plotter.mat_plot_1d.set_for_subplot(is_for_subplot=True)
+                plotter.mat_plot_1d.number_subplots = number_subplots
+                plotter.mat_plot_1d.subplot_shape = self.subplot_shape
+                plotter.mat_plot_1d.subplot_index = i + 1
 
             func = getattr(plotter, func_name)
 

--- a/autoarray/plot/multi_plotters.py
+++ b/autoarray/plot/multi_plotters.py
@@ -23,7 +23,6 @@ class MultiFigurePlotter:
         )
 
         for i, plotter in enumerate(self.plotter_list):
-
             plotter.mat_plot_2d.set_for_subplot(is_for_subplot=True)
             plotter.mat_plot_2d.number_subplots = number_subplots
             plotter.mat_plot_2d.subplot_shape = self.subplot_shape
@@ -82,12 +81,12 @@ class MultiFigurePlotter:
 
 class MultiYX1DPlotter:
     def __init__(
-            self,
-            plotter_list,
-            color_list=None,
-            legend_labels=None,
-            y_manual_min_max_value=None,
-            x_manual_min_max_value=None,
+        self,
+        plotter_list,
+        color_list=None,
+        legend_labels=None,
+        y_manual_min_max_value=None,
+        x_manual_min_max_value=None,
     ):
         self.plotter_list = plotter_list
 
@@ -137,7 +136,6 @@ class MultiYX1DPlotter:
         # TODO : func(**{**{figure_name: True}, **kwargs})
 
         if self.y_manual_min_max_value is not None:
-
             return YTicks(manual_min_max_value=self.y_manual_min_max_value)
 
         try:
@@ -150,7 +148,6 @@ class MultiYX1DPlotter:
 
     @property
     def xticks(self):
-
         if self.x_manual_min_max_value is not None:
             return XTicks(manual_min_max_value=self.x_manual_min_max_value)
 

--- a/autoarray/plot/wrap/base/cmap.py
+++ b/autoarray/plot/wrap/base/cmap.py
@@ -39,7 +39,6 @@ class Cmap(AbstractMatWrap):
         self.symmetric_value = None
 
     def symmetric_cmap_from(self, symmetric_value=None):
-
         cmap = copy.copy(self)
 
         cmap._symmetric = True

--- a/autoarray/structures/abstract_structure.py
+++ b/autoarray/structures/abstract_structure.py
@@ -107,3 +107,7 @@ class Structure(AbstractNDArray, ABC):
 
     def trimmed_after_convolution_from(self, kernel_shape) -> "Structure":
         raise NotImplementedError
+
+    @property
+    def hdu_for_output(self):
+        raise NotImplementedError

--- a/autoarray/structures/arrays/array_1d_util.py
+++ b/autoarray/structures/arrays/array_1d_util.py
@@ -192,7 +192,10 @@ def array_1d_via_indexes_1d_from(
 
 
 def numpy_array_1d_to_fits(
-    array_1d: np.ndarray, file_path: Union[Path, str], overwrite: bool = False, header_dict: Optional[dict] = None,
+    array_1d: np.ndarray,
+    file_path: Union[Path, str],
+    overwrite: bool = False,
+    header_dict: Optional[dict] = None,
 ):
     """
     Write a 1D NumPy array to a .fits file.
@@ -232,7 +235,6 @@ def numpy_array_1d_to_fits(
     if header_dict is not None:
         for key, value in header_dict.items():
             header.append((key, value, [""]))
-
 
     hdu = fits.PrimaryHDU(array_1d, header)
     hdu.writeto(file_path)

--- a/autoarray/structures/arrays/array_1d_util.py
+++ b/autoarray/structures/arrays/array_1d_util.py
@@ -225,7 +225,6 @@ def hdu_for_output_from(
     return fits.PrimaryHDU(array_1d, header)
 
 
-
 def numpy_array_1d_to_fits(
     array_1d: np.ndarray,
     file_path: Union[Path, str],
@@ -265,10 +264,7 @@ def numpy_array_1d_to_fits(
     if overwrite and os.path.exists(file_path):
         os.remove(file_path)
 
-    hdu = hdu_for_output_from(
-        array_1d=array_1d,
-        header_dict=header_dict
-    )
+    hdu = hdu_for_output_from(array_1d=array_1d, header_dict=header_dict)
     hdu.writeto(file_path)
 
 

--- a/autoarray/structures/arrays/array_1d_util.py
+++ b/autoarray/structures/arrays/array_1d_util.py
@@ -191,6 +191,41 @@ def array_1d_via_indexes_1d_from(
     return array_1d_native
 
 
+def hdu_for_output_from(
+    array_1d: np.ndarray,
+    header_dict: Optional[dict] = None,
+):
+    """
+    Returns the HDU which can be used to output an array to a .fits file.
+
+    Parameters
+    ----------
+    array_1d
+        The 1D array that is written to fits.
+    header_dict
+        A dictionary of values that are written to the header of the .fits file.
+
+    Returns
+    -------
+    hdu
+        The HDU containing the data and its header which can then be written to .fits.
+
+    Examples
+    --------
+    array_1d = np.ones((5,5))
+    hdu_for_output_from(array_1d=array_1d, file_path='/path/to/file/filename.fits', overwrite=True)
+    """
+
+    header = fits.Header()
+
+    if header_dict is not None:
+        for key, value in header_dict.items():
+            header.append((key, value, [""]))
+
+    return fits.PrimaryHDU(array_1d, header)
+
+
+
 def numpy_array_1d_to_fits(
     array_1d: np.ndarray,
     file_path: Union[Path, str],
@@ -230,13 +265,10 @@ def numpy_array_1d_to_fits(
     if overwrite and os.path.exists(file_path):
         os.remove(file_path)
 
-    header = fits.Header()
-
-    if header_dict is not None:
-        for key, value in header_dict.items():
-            header.append((key, value, [""]))
-
-    hdu = fits.PrimaryHDU(array_1d, header)
+    hdu = hdu_for_output_from(
+        array_1d=array_1d,
+        header_dict=header_dict
+    )
     hdu.writeto(file_path)
 
 

--- a/autoarray/structures/arrays/array_2d_util.py
+++ b/autoarray/structures/arrays/array_2d_util.py
@@ -743,6 +743,43 @@ def array_2d_native_complex_via_indexes_from(
     return sub_array_2d
 
 
+def hdu_for_output_from(array_2d: np.ndarray, header_dict: Optional[dict] = None):
+    """
+    Returns the HDU which can be used to output an array to a .fits file.
+
+    Before outputting a NumPy array, the array may be flipped upside-down using np.flipud depending on the project
+    config files. This is for Astronomy projects so that structures appear the same orientation as ``.fits`` files
+    loaded in DS9.
+
+    Parameters
+    ----------
+    array_2d
+        The 2D array that is written to fits.
+    header_dict
+        A dictionary of values that are written to the header of the .fits file.
+
+    Returns
+    -------
+    hdu
+        The HDU containing the data and its header which can then be written to .fits.
+
+    Examples
+    --------
+    array_2d = np.ones((5,5))
+    numpy_array_to_fits(array_2d=array_2d, file_path='/path/to/file/filename.fits', overwrite=True)
+    """
+    header = fits.Header()
+
+    if header_dict is not None:
+        for key, value in header_dict.items():
+            header.append((key, value, [""]))
+
+    flip_for_ds9 = conf.instance["general"]["fits"]["flip_for_ds9"]
+
+    if flip_for_ds9:
+        return fits.PrimaryHDU(np.flipud(array_2d), header=header)
+    return fits.PrimaryHDU(array_2d, header=header)
+
 def numpy_array_2d_to_fits(
     array_2d: np.ndarray,
     file_path: Union[Path, str],
@@ -786,18 +823,7 @@ def numpy_array_2d_to_fits(
     if overwrite and os.path.exists(file_path):
         os.remove(file_path)
 
-    header = fits.Header()
-
-    if header_dict is not None:
-        for key, value in header_dict.items():
-            header.append((key, value, [""]))
-
-    flip_for_ds9 = conf.instance["general"]["fits"]["flip_for_ds9"]
-
-    if flip_for_ds9:
-        hdu = fits.PrimaryHDU(np.flipud(array_2d), header=header)
-    else:
-        hdu = fits.PrimaryHDU(array_2d, header=header)
+    hdu = hdu_for_output_from(array_2d=array_2d, header_dict=header_dict)
 
     hdu.writeto(file_path)
 

--- a/autoarray/structures/arrays/array_2d_util.py
+++ b/autoarray/structures/arrays/array_2d_util.py
@@ -743,7 +743,9 @@ def array_2d_native_complex_via_indexes_from(
     return sub_array_2d
 
 
-def hdu_for_output_from(array_2d: np.ndarray, header_dict: Optional[dict] = None) -> fits.PrimaryHDU:
+def hdu_for_output_from(
+    array_2d: np.ndarray, header_dict: Optional[dict] = None
+) -> fits.PrimaryHDU:
     """
     Returns the HDU which can be used to output an array to a .fits file.
 
@@ -779,6 +781,7 @@ def hdu_for_output_from(array_2d: np.ndarray, header_dict: Optional[dict] = None
     if flip_for_ds9:
         return fits.PrimaryHDU(np.flipud(array_2d), header=header)
     return fits.PrimaryHDU(array_2d, header=header)
+
 
 def numpy_array_2d_to_fits(
     array_2d: np.ndarray,

--- a/autoarray/structures/arrays/array_2d_util.py
+++ b/autoarray/structures/arrays/array_2d_util.py
@@ -768,7 +768,7 @@ def hdu_for_output_from(
     Examples
     --------
     array_2d = np.ones((5,5))
-    numpy_array_to_fits(array_2d=array_2d, file_path='/path/to/file/filename.fits', overwrite=True)
+    hdu_for_output_from(array_2d=array_2d, file_path='/path/to/file/filename.fits', overwrite=True)
     """
     header = fits.Header()
 

--- a/autoarray/structures/arrays/array_2d_util.py
+++ b/autoarray/structures/arrays/array_2d_util.py
@@ -743,7 +743,7 @@ def array_2d_native_complex_via_indexes_from(
     return sub_array_2d
 
 
-def hdu_for_output_from(array_2d: np.ndarray, header_dict: Optional[dict] = None):
+def hdu_for_output_from(array_2d: np.ndarray, header_dict: Optional[dict] = None) -> fits.PrimaryHDU:
     """
     Returns the HDU which can be used to output an array to a .fits file.
 

--- a/autoarray/structures/arrays/uniform_1d.py
+++ b/autoarray/structures/arrays/uniform_1d.py
@@ -374,5 +374,5 @@ class Array1D(Structure):
             array_1d=self.native,
             file_path=file_path,
             overwrite=overwrite,
-            header_dict=self.pixel_scale_header
+            header_dict=self.pixel_scale_header,
         )

--- a/autoarray/structures/arrays/uniform_1d.py
+++ b/autoarray/structures/arrays/uniform_1d.py
@@ -359,6 +359,24 @@ class Array1D(Structure):
             sub_size=self.sub_size,
         )
 
+    @property
+    def hdu_for_output(self) -> fits.PrimaryHDU:
+        """
+        The array as an HDU object, which can be output to a .fits file.
+
+        The header of the HDU is used to store the `pixel_scale` of the array, which is used by the `Array1D.from_hdu`.
+
+        This method is used in other projects (E.g. PyAutoGalaxy, PyAutoLens) to conveniently output the array to .fits
+        files.
+
+        Returns
+        -------
+        The HDU containing the data and its header which can then be written to .fits.
+        """
+        return array_2d_util.hdu_for_output_from(
+            array_2d=self.native, header_dict=self.pixel_scale_header
+        )
+
     def output_to_fits(self, file_path: Union[Path, str], overwrite: bool = False):
         """
         Output the array to a .fits file.

--- a/autoarray/structures/arrays/uniform_2d.py
+++ b/autoarray/structures/arrays/uniform_2d.py
@@ -626,6 +626,25 @@ class AbstractArray2D(Structure):
             store_native=self.store_native,
         )
 
+    @property
+    def hdu_for_output(self) -> fits.PrimaryHDU:
+        """
+        The array as an HDU object, which can be output to a .fits file.
+
+        The header of the HDU is used to store the `pixel_scale` of the array, which is used by the `Array2D.from_hdu`.
+
+        This method is used in other projects (E.g. PyAutoGalaxy, PyAutoLens) to conveniently output the array to .fits
+        files.
+
+        Returns
+        -------
+        The HDU containing the data and its header which can then be written to .fits.
+        """
+        return array_2d_util.hdu_for_output_from(
+            array_2d=self.native,
+            header_dict=self.pixel_scale_header
+        )
+
     def output_to_fits(self, file_path: Union[Path, str], overwrite: bool = False):
         """
         Output the array to a .fits file.

--- a/autoarray/structures/arrays/uniform_2d.py
+++ b/autoarray/structures/arrays/uniform_2d.py
@@ -641,8 +641,7 @@ class AbstractArray2D(Structure):
         The HDU containing the data and its header which can then be written to .fits.
         """
         return array_2d_util.hdu_for_output_from(
-            array_2d=self.native,
-            header_dict=self.pixel_scale_header
+            array_2d=self.native, header_dict=self.pixel_scale_header
         )
 
     def output_to_fits(self, file_path: Union[Path, str], overwrite: bool = False):
@@ -663,7 +662,7 @@ class AbstractArray2D(Structure):
             array_2d=self.native,
             file_path=file_path,
             overwrite=overwrite,
-            header_dict=self.pixel_scale_header
+            header_dict=self.pixel_scale_header,
         )
 
 
@@ -1130,7 +1129,6 @@ class Array2D(AbstractArray2D):
             origin=origin,
             header=Header(header_sci_obj=primary_hdu.header),
         )
-
 
     @classmethod
     def from_yx_and_values(

--- a/autoarray/structures/visibilities.py
+++ b/autoarray/structures/visibilities.py
@@ -1,3 +1,4 @@
+from astropy.io import fits
 import logging
 import numpy as np
 from pathlib import Path
@@ -95,6 +96,22 @@ class AbstractVisibilities(Structure):
     @cached_property
     def phases(self) -> np.ndarray:
         return np.arctan2(self.imag, self.real)
+
+    @property
+    def hdu_for_output(self) -> fits.PrimaryHDU:
+        """
+        The visibilities as an HDU object, which can be output to a .fits file.
+
+        This method is used in other projects (E.g. PyAutoGalaxy, PyAutoLens) to conveniently output the array to .fits
+        files.
+
+        Returns
+        -------
+        The HDU containing the data which can then be written to .fits.
+        """
+        return array_2d_util.hdu_for_output_from(
+            array_2d=self.in_array,
+        )
 
     def output_to_fits(self, file_path: Union[Path, str], overwrite: bool = False):
         """

--- a/test_autoarray/dataset/interferometer/test_interferometer.py
+++ b/test_autoarray/dataset/interferometer/test_interferometer.py
@@ -56,7 +56,6 @@ def test__from_fits__all_files_in_one_fits__load_using_different_hdus(sub_mask_2
 
 
 def test__output_all_arrays(sub_mask_2d_7x7):
-
     test_data_path = path.join(
         "{}".format(path.dirname(path.realpath(__file__))),
         "files",

--- a/test_autoarray/mask/test_mask_1d.py
+++ b/test_autoarray/mask/test_mask_1d.py
@@ -88,6 +88,7 @@ def test__is_all_false():
 
     assert mask.is_all_false is False
 
+
 def test__from_primary_hdu():
     file_path = os.path.join(test_data_path, "mask_out.fits")
 
@@ -108,4 +109,4 @@ def test__from_primary_hdu():
 
     assert type(mask_via_hdu) == aa.Mask1D
     assert (mask_via_hdu == mask).all()
-    assert mask_via_hdu.pixel_scales == (0.1, )
+    assert mask_via_hdu.pixel_scales == (0.1,)

--- a/test_autoarray/mask/test_mask_2d.py
+++ b/test_autoarray/mask/test_mask_2d.py
@@ -339,7 +339,6 @@ def test__from_pixel_coordinates():
 
 
 def test__from_fits__output_to_fits():
-
     test_data_path = path.join(
         "{}".format(path.dirname(path.realpath(__file__))), "files", "mask"
     )
@@ -377,7 +376,9 @@ def test__from_fits__output_to_fits():
     assert mask.pixel_scales == (1.0, 1.0)
     assert mask.origin == (2.0, 2.0)
 
-    header = aa.util.array_2d.header_obj_from(file_path=path.join(test_data_path, "mask.fits"), hdu=0)
+    header = aa.util.array_2d.header_obj_from(
+        file_path=path.join(test_data_path, "mask.fits"), hdu=0
+    )
 
     assert header["PIXSCALE"] == 1.0
 

--- a/test_autoarray/structures/arrays/test_array_1d_util.py
+++ b/test_autoarray/structures/arrays/test_array_1d_util.py
@@ -95,10 +95,13 @@ def test__numpy_array_1d_to_fits__output_and_load():
 
     arr = np.array([10.0, 30.0, 40.0, 92.0, 19.0, 20.0])
 
-    aa.util.array_1d.numpy_array_1d_to_fits(arr, file_path=file_path, header_dict={"A": 1})
+    aa.util.array_1d.numpy_array_1d_to_fits(
+        arr, file_path=file_path, header_dict={"A": 1}
+    )
 
     array_load = aa.util.array_1d.numpy_array_1d_via_fits_from(
-        file_path=file_path, hdu=0,
+        file_path=file_path,
+        hdu=0,
     )
 
     assert (arr == array_load).all()

--- a/test_autoarray/structures/arrays/test_uniform_1d.py
+++ b/test_autoarray/structures/arrays/test_uniform_1d.py
@@ -177,7 +177,7 @@ def test__from_primary_hdu():
 
     assert type(arr) == aa.Array1D
     assert (arr.native == arr).all()
-    assert arr.pixel_scales == (0.1, )
+    assert arr.pixel_scales == (0.1,)
 
 
 def test__output_to_fits():
@@ -196,7 +196,9 @@ def test__output_to_fits():
 
     assert (array_from_out.native == np.ones((3,))).all()
 
-    header_load = aa.util.array_2d.header_obj_from(file_path=path.join(test_data_path, "array.fits"), hdu=0)
+    header_load = aa.util.array_2d.header_obj_from(
+        file_path=path.join(test_data_path, "array.fits"), hdu=0
+    )
 
     assert header_load["PIXSCALE"] == 1.0
 

--- a/test_autoarray/structures/arrays/test_uniform_2d.py
+++ b/test_autoarray/structures/arrays/test_uniform_2d.py
@@ -322,7 +322,9 @@ def test__from_yx_and_values():
 
 
 def test__output_to_fits():
-    test_data_path = path.join("{}".format(path.dirname(path.realpath(__file__))), "files")
+    test_data_path = path.join(
+        "{}".format(path.dirname(path.realpath(__file__))), "files"
+    )
 
     array_2d = aa.Array2D.from_fits(
         file_path=path.join(test_data_path, "3x3_ones.fits"), hdu=0, pixel_scales=1.0

--- a/test_autoarray/structures/test_visibilities.py
+++ b/test_autoarray/structures/test_visibilities.py
@@ -22,20 +22,15 @@ def test__manual__makes_visibilities_without_other_inputs():
         np.array([1.10714872, 0.92729522]), 1.0e-4
     )
 
-    visibilities = aa.Visibilities(
-        visibilities=[1.0 + 2.0j, 3.0 + 4.0j, 5.0 + 6.0j]
-    )
+    visibilities = aa.Visibilities(visibilities=[1.0 + 2.0j, 3.0 + 4.0j, 5.0 + 6.0j])
 
     assert type(visibilities) == vis.Visibilities
-    assert (
-        visibilities.slim == np.array([1.0 + 2.0j, 3.0 + 4.0j, 5.0 + 6.0j])
-    ).all()
+    assert (visibilities.slim == np.array([1.0 + 2.0j, 3.0 + 4.0j, 5.0 + 6.0j])).all()
     assert (
         visibilities.in_array == np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
     ).all()
-    assert (
-        visibilities.ordered_1d == np.array([1.0, 3.0, 5.0, 2.0, 4.0, 6.0])
-    ).all()
+    assert (visibilities.ordered_1d == np.array([1.0, 3.0, 5.0, 2.0, 4.0, 6.0])).all()
+
 
 def test__manual__makes_visibilities_with_converted_input_as_list():
     visibilities = aa.Visibilities(visibilities=[[1.0, 2.0], [3.0, 4.0]])
@@ -47,14 +42,11 @@ def test__manual__makes_visibilities_with_converted_input_as_list():
         np.array([1.10714872, 0.92729522]), 1.0e-4
     )
 
-    visibilities = aa.Visibilities(
-        visibilities=[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]
-    )
+    visibilities = aa.Visibilities(visibilities=[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
 
     assert type(visibilities) == vis.Visibilities
-    assert (
-        visibilities.slim == np.array([1.0 + 2.0j, 3.0 + 4.0j, 5.0 + 6.0j])
-    ).all()
+    assert (visibilities.slim == np.array([1.0 + 2.0j, 3.0 + 4.0j, 5.0 + 6.0j])).all()
+
 
 def test__full__makes_visibilities_without_other_inputs():
     visibilities = aa.Visibilities.ones(shape_slim=(2,))
@@ -67,6 +59,7 @@ def test__full__makes_visibilities_without_other_inputs():
     assert type(visibilities) == vis.Visibilities
     assert (visibilities.slim == np.array([2.0 + 2.0j, 2.0 + 2.0j])).all()
 
+
 def test__ones_zeros__makes_visibilities_without_other_inputs():
     visibilities = aa.Visibilities.ones(shape_slim=(2,))
 
@@ -78,30 +71,27 @@ def test__ones_zeros__makes_visibilities_without_other_inputs():
     assert type(visibilities) == vis.Visibilities
     assert (visibilities.slim == np.array([0.0 + 0.0j, 0.0 + 0.0j])).all()
 
-def test__from_fits__makes_visibilities_without_other_inputs():
 
+def test__from_fits__makes_visibilities_without_other_inputs():
     visibilities = aa.Visibilities.from_fits(
         file_path=path.join(test_data_path, "3x2_ones.fits"), hdu=0
     )
 
     assert type(visibilities) == vis.Visibilities
-    assert (
-        visibilities.slim == np.array([1.0 + 1.0j, 1.0 + 1.0j, 1.0 + 1.0j])
-    ).all()
+    assert (visibilities.slim == np.array([1.0 + 1.0j, 1.0 + 1.0j, 1.0 + 1.0j])).all()
 
     visibilities = aa.Visibilities.from_fits(
         file_path=path.join(test_data_path, "3x2_twos.fits"), hdu=0
     )
 
     assert type(visibilities) == vis.Visibilities
-    assert (
-        visibilities.slim == np.array([2.0 + 2.0j, 2.0 + 2.0j, 2.0 + 2.0j])
-    ).all()
+    assert (visibilities.slim == np.array([2.0 + 2.0j, 2.0 + 2.0j, 2.0 + 2.0j])).all()
 
 
 def test__output_to_fits():
-
-    test_data_path = path.join("{}".format(path.dirname(path.realpath(__file__))), "files")
+    test_data_path = path.join(
+        "{}".format(path.dirname(path.realpath(__file__))), "files"
+    )
 
     visibilities = aa.Visibilities.from_fits(
         file_path=path.join(test_data_path, "3x2_ones.fits"), hdu=0
@@ -130,9 +120,7 @@ def test__visibilities_noise_has_attributes():
     assert type(noise_map) == vis.VisibilitiesNoiseMap
     assert (noise_map.slim == np.array([1.0 + 2.0j, 3.0 + 4.0j])).all()
     assert (noise_map.amplitudes == np.array([np.sqrt(5), 5.0])).all()
-    assert noise_map.phases == pytest.approx(
-        np.array([1.10714872, 0.92729522]), 1.0e-4
-    )
+    assert noise_map.phases == pytest.approx(np.array([1.10714872, 0.92729522]), 1.0e-4)
     assert (noise_map.ordered_1d == np.array([1.0, 3.0, 2.0, 4.0])).all()
     assert (
         noise_map.weight_list_ordered_1d == np.array([1.0, 1.0 / 9.0, 0.25, 0.0625])


### PR DESCRIPTION
Fixes output of certain file types to database in session mode by always using `Paths` object.

Makes it so that a `DatabasePaths` fit does not output anything to hard-disk except the .sqlite.