### PR TITLE
Feature/data subtracted dict

### DIFF
--- a/autoarray/config/visualize/plots.yaml
+++ b/autoarray/config/visualize/plots.yaml
@@ -29,6 +29,7 @@ inversion:                                 # Settings for plots of inversions (e
   all_at_end_png: true                     # Plot all individual plots listed below as .png (even if False)?
   all_at_end_fits: true                    # Plot all individual plots listed below as .fits (even if False)?
   all_at_end_pdf: false                    # Plot all individual plots listed below as publication-quality .pdf (even if False)?
+  data_subtracted: false                   # Plot individual plots of the data with the other inversion linear objects subtracted?
   errors: false                            # Plot image of the errors of every mesh-pixel reconstructed value?
   mesh_pixels_per_image_pixels : false     # Plot the number of image-plane mesh pixels per masked data pixels?
   reconstructed_image: false               # Plot image of the reconstructed data (e.g. in the image-plane)?

--- a/autoarray/inversion/inversion/abstract.py
+++ b/autoarray/inversion/inversion/abstract.py
@@ -638,6 +638,35 @@ class AbstractInversion:
         return sum(self.mapped_reconstructed_image_dict.values())
 
     @cached_property
+    def data_subtracted_dict(self) -> Dict[LinearObj, Array2D]:
+        """
+        Returns a dictionary of the data subtracted by the reconstructed images of combinations of all but one of the
+        linear objects the inversion.
+
+        This produces images of the data showing what each linear object is actually fitted to, after accounting for
+        the signal in the other linear objects.
+
+        Returns
+        -------
+        A dictionary of the data subtracted by the reconstructed images of combinations of all but one of the
+        linear objects the inversion.
+        """
+
+        data_subtracted_dict = {}
+
+        for linear_obj in self.linear_obj_list:
+
+            data_subtracted_dict[linear_obj] = copy.copy(self.data)
+
+            for linear_obj_other in self.linear_obj_list:
+
+                if linear_obj != linear_obj_other:
+
+                    data_subtracted_dict[linear_obj] -= self.mapped_reconstructed_image_dict[linear_obj_other]
+
+        return data_subtracted_dict
+
+    @cached_property
     @profile_func
     def regularization_term(self) -> float:
         """

--- a/autoarray/inversion/plot/inversion_plotters.py
+++ b/autoarray/inversion/plot/inversion_plotters.py
@@ -103,6 +103,7 @@ class InversionPlotter(Plotter):
     def figures_2d_of_pixelization(
         self,
         pixelization_index: int = 0,
+        data_subtracted: bool = False,
         reconstructed_image: bool = False,
         reconstruction: bool = False,
         errors: bool = False,
@@ -142,6 +143,17 @@ class InversionPlotter(Plotter):
             return
 
         mapper_plotter = self.mapper_plotter_from(mapper_index=pixelization_index)
+
+        if data_subtracted:
+            array = self.inversion.data_subtracted_dict[mapper_plotter.mapper]
+
+            self.mat_plot_2d.plot_array(
+                array=array,
+                visuals_2d=self.get_visuals_2d_for_data(),
+                auto_labels=AutoLabels(
+                    title="Data Subtracted", filename="data_subtracted"
+                ),
+            )
 
         if reconstructed_image:
             array = self.inversion.mapped_reconstructed_image_dict[
@@ -248,10 +260,8 @@ class InversionPlotter(Plotter):
 
         self.include_2d._mapper_image_plane_mesh_grid = False
 
-        self.mat_plot_2d.plot_array(
-            array=self.inversion.data,
-            visuals_2d=self.get_visuals_2d_for_data(),
-            auto_labels=AutoLabels(title=f" Data"),
+        self.figures_2d_of_pixelization(
+            pixelization_index=mapper_index, data_subtracted=True
         )
 
         self.figures_2d_of_pixelization(

--- a/test_autoarray/inversion/inversion/test_abstract.py
+++ b/test_autoarray/inversion/inversion/test_abstract.py
@@ -469,6 +469,36 @@ def test__mapped_reconstructed_image():
     assert (inversion.mapped_reconstructed_image == 3.0 * np.ones(2)).all()
 
 
+def test__data_subtracted_dict():
+
+    linear_obj_0 = aa.m.MockLinearObj()
+
+    mapped_reconstructed_data_dict = {linear_obj_0: np.ones(3)}
+
+    # noinspection PyTypeChecker
+    inversion = aa.m.MockInversion(
+        data=3.0*np.ones(3),
+        linear_obj_list=[linear_obj_0],
+        mapped_reconstructed_data_dict=mapped_reconstructed_data_dict,
+    )
+
+    assert (inversion.data_subtracted_dict[linear_obj_0] == 3.0*np.ones(3)).all()
+
+    linear_obj_1 = aa.m.MockLinearObj()
+
+    mapped_reconstructed_data_dict = {linear_obj_0: np.ones(3), linear_obj_1: 2.0*np.ones(3)}
+
+    # noinspection PyTypeChecker
+    inversion = aa.m.MockInversion(
+        data=3.0*np.ones(3),
+        linear_obj_list=[linear_obj_0, linear_obj_1],
+        mapped_reconstructed_data_dict=mapped_reconstructed_data_dict,
+    )
+
+    assert (inversion.data_subtracted_dict[linear_obj_0] == np.ones(3)).all()
+    assert (inversion.data_subtracted_dict[linear_obj_1] == 2.0*np.ones(3)).all()
+
+
 def test__reconstruction_raises_exception_for_linalg_error():
     # noinspection PyTypeChecker
     inversion = aa.m.MockInversion(


### PR DESCRIPTION
Add property to an `Inversion` which is the data subtracted by all other linear objects.

For example, this means the inversion can plot the MGE lens light subtracted data that the source reconstruction fits.