### PR TITLE
add np.array in mapper_util

### DIFF
--- a/autoarray/dataset/interferometer/dataset.py
+++ b/autoarray/dataset/interferometer/dataset.py
@@ -118,13 +118,13 @@ class Interferometer(AbstractDataset):
 
         logger.info("INTERFEROMETER - Computing W-Tilde... May take a moment.")
 
-        import inversion_util_secret
+        from autoarray.inversion.inversion import inversion_util_secret
 
         curvature_preload = inversion_util_secret.w_tilde_curvature_preload_interferometer_from(
-            noise_map_real=self.noise_map.real,
-            uv_wavelengths=self.uv_wavelengths,
-            shape_masked_pixels_2d=self.transformer.grid.mask.shape_native_masked_pixels,
-            grid_radians_2d=self.transformer.grid.mask.derive_grid.all_false_sub_1.in_radians.native,
+            noise_map_real=np.array(self.noise_map.real),
+            uv_wavelengths=np.array(self.uv_wavelengths),
+            shape_masked_pixels_2d=np.array(self.transformer.grid.mask.shape_native_masked_pixels),
+            grid_radians_2d=np.array(self.transformer.grid.mask.derive_grid.all_false_sub_1.in_radians.native),
         )
 
         w_matrix = inversion_util_secret.w_tilde_via_preload_from(

--- a/autoarray/inversion/pixelization/mappers/mapper_util.py
+++ b/autoarray/inversion/pixelization/mappers/mapper_util.py
@@ -443,8 +443,8 @@ def pix_size_weights_voronoi_nn_from(
         bad_indexes=bad_indexes,
         pix_weights_for_sub_slim_index=pix_weights_for_sub_slim_index,
         pix_indexes_for_sub_slim_index=pix_indexes_for_sub_slim_index,
-        grid=grid,
-        mesh_grid=mesh_grid,
+        grid=np.array(grid),
+        mesh_grid=np.array(mesh_grid),
     )
 
     bad_indexes = np.argwhere(pix_indexes_for_sub_slim_index[:, 0] == -1)
@@ -456,8 +456,8 @@ def pix_size_weights_voronoi_nn_from(
         bad_indexes=bad_indexes,
         pix_weights_for_sub_slim_index=pix_weights_for_sub_slim_index,
         pix_indexes_for_sub_slim_index=pix_indexes_for_sub_slim_index,
-        grid=grid,
-        mesh_grid=mesh_grid,
+        grid=np.array(grid),
+        mesh_grid=np.array(mesh_grid),
     )
 
     pix_indexes_for_sub_slim_index_sizes = np.sum(


### PR DESCRIPTION
Fixes a few unit tests via `np.array` due to JAX array conflicts.