### PR TITLE
Feature/apply over sampling

### DIFF
--- a/autoarray/dataset/abstract/dataset.py
+++ b/autoarray/dataset/abstract/dataset.py
@@ -216,3 +216,36 @@ class AbstractDataset:
         )
 
         return dataset
+
+    def apply_over_sampling(
+        self,
+        over_sampling: Optional[AbstractOverSampling] = None,
+        over_sampling_pixelization: Optional[AbstractOverSampling] = None,
+    ) -> "AbstractDataset":
+        """
+        Apply new over sampling objects to the grid and grid pixelization of the dataset.
+
+        This method is used to change the over sampling of the grid and grid pixelization, for example when the
+        user wishes to perform over sampling with a higher sub grid size or with an iterative over sampling strategy.
+
+        The `grid` and grid_pixelization` are cached properties which after use are stored in memory for efficiency.
+        This function resets the cached properties so that the new over sampling is used in the grid and grid
+        pixelization.
+
+        Parameters
+        ----------
+        over_sampling
+            The new over sampling object to apply to the grid.
+        over_sampling_pixelization
+            The new over sampling object to apply to the grid pixelization.
+        """
+
+        if over_sampling is not None:
+            self.over_sampling = over_sampling
+            del self.__dict__["grid"]
+
+        if over_sampling_pixelization is not None:
+            self.over_sampling_pixelization = over_sampling_pixelization
+            del self.__dict__["grid_pixelization"]
+
+        return self

--- a/autoarray/dataset/abstract/dataset.py
+++ b/autoarray/dataset/abstract/dataset.py
@@ -247,5 +247,9 @@ class AbstractDataset:
         if over_sampling_pixelization is not None:
             self.over_sampling_pixelization = over_sampling_pixelization
             del self.__dict__["grid_pixelization"]
+            try:
+                del self.__dict__["border_relocator"]
+            except KeyError:
+                pass
 
         return self

--- a/autoarray/dataset/imaging/dataset.py
+++ b/autoarray/dataset/imaging/dataset.py
@@ -171,7 +171,7 @@ class Imaging(AbstractDataset):
         """
 
         return self.grid.blurring_grid_via_kernel_shape_from(
-            kernel_shape_native=self.psf.shape_native
+            kernel_shape_native=self.psf.shape_native,
         )
 
     @cached_property

--- a/autoarray/inversion/pixelization/mappers/voronoi.py
+++ b/autoarray/inversion/pixelization/mappers/voronoi.py
@@ -1,12 +1,10 @@
 import numpy as np
-from typing import Dict, Optional, Tuple
+from typing import Optional, Tuple
 
 from autoconf import cached_property
 
 from autoarray.inversion.pixelization.mappers.abstract import AbstractMapper
 from autoarray.inversion.pixelization.mappers.abstract import PixSubWeights
-from autoarray.inversion.pixelization.mappers.mapper_grids import MapperGrids
-from autoarray.inversion.regularization.abstract import AbstractRegularization
 from autoarray.structures.arrays.uniform_2d import Array2D
 
 from autoarray.numba_util import profile_func


### PR DESCRIPTION
Adds a method `apply_over_sampling` to dataset objects so a user can easily customize how over sampling is performed.

For example:

```
    dataset = dataset.apply_over_sampling(
        over_sampling_pixelization=al.OverSamplingUniform(sub_size=4)
    )
```