### PR TITLE
Feature/over sample non uniform

### DIFF
--- a/autoarray/__init__.py
+++ b/autoarray/__init__.py
@@ -14,6 +14,7 @@ from .dataset.imaging.w_tilde import WTildeImaging
 from .dataset.interferometer.dataset import Interferometer
 from .dataset.interferometer.simulator import SimulatorInterferometer
 from .dataset.interferometer.w_tilde import WTildeInterferometer
+from .dataset.over_sampling import OverSamplingDataset
 from .dataset.dataset_model import DatasetModel
 from .fit.fit_dataset import FitDataset
 from .fit.fit_imaging import FitImaging

--- a/autoarray/__init__.py
+++ b/autoarray/__init__.py
@@ -8,6 +8,7 @@ from .preloads import Preloads
 from .dataset import preprocess
 from .dataset.abstract.dataset import AbstractDataset
 from .dataset.abstract.w_tilde import AbstractWTilde
+from .dataset.grids import GridsInterface
 from .dataset.imaging.dataset import Imaging
 from .dataset.imaging.simulator import SimulatorImaging
 from .dataset.imaging.w_tilde import WTildeImaging

--- a/autoarray/config/visualize/plots.yaml
+++ b/autoarray/config/visualize/plots.yaml
@@ -9,6 +9,7 @@ dataset:                                   # Settings for plots of all datasets 
   noise_map: false                         # Plot the individual noise-map of every dataset?
   signal_to_noise_map: false               # Plot the individual signal-to-noise-map of every dataset?
   over_sampling_sub_size: false            # Plot the over-sampling sub-size, used to evaluate light profiles, of every dataset?
+  over_sampling_sub_size_non_uniform: false  # Plot the over-sampling sub-size, used to evaluate non uniform grids, of every dataset?
   over_sampling_sub_size_pixelization: false  # Plot the over-sampling sub-size, used to evaluate pixelizations, of every dataset?
 imaging:                                   # Settings for plots of imaging datasets (e.g. ImagingPlotter)
    psf: false

--- a/autoarray/config/visualize/plots.yaml
+++ b/autoarray/config/visualize/plots.yaml
@@ -8,9 +8,9 @@ dataset:                                   # Settings for plots of all datasets 
   data: false                              # Plot the individual data of every dataset?
   noise_map: false                         # Plot the individual noise-map of every dataset?
   signal_to_noise_map: false               # Plot the individual signal-to-noise-map of every dataset?
-  over_sampling_sub_size: false            # Plot the over-sampling sub-size, used to evaluate light profiles, of every dataset?
-  over_sampling_sub_size_non_uniform: false  # Plot the over-sampling sub-size, used to evaluate non uniform grids, of every dataset?
-  over_sampling_sub_size_pixelization: false  # Plot the over-sampling sub-size, used to evaluate pixelizations, of every dataset?
+  over_sampling: false            # Plot the over-sampling sub-size, used to evaluate light profiles, of every dataset?
+  over_sampling_non_uniform: false  # Plot the over-sampling sub-size, used to evaluate non uniform grids, of every dataset?
+  over_sampling_pixelization: false  # Plot the over-sampling sub-size, used to evaluate pixelizations, of every dataset?
 imaging:                                   # Settings for plots of imaging datasets (e.g. ImagingPlotter)
    psf: false
 fit:                                       # Settings for plots of all fits (e.g. FitImagingPlotter, FitInterferometerPlotter).

--- a/autoarray/dataset/abstract/dataset.py
+++ b/autoarray/dataset/abstract/dataset.py
@@ -197,12 +197,6 @@ class AbstractDataset:
         non_uniform = over_sampling.non_uniform or self.over_sampling.non_uniform
         pixelization = over_sampling.pixelization or self.over_sampling.pixelization
 
-        if over_sampling.pixelization is not None:
-            try:
-                del self.__dict__["border_relocator"]
-            except KeyError:
-                pass
-
         over_sampling = OverSamplingDataset(
             uniform=uniform,
             non_uniform=non_uniform,

--- a/autoarray/dataset/abstract/dataset.py
+++ b/autoarray/dataset/abstract/dataset.py
@@ -72,7 +72,6 @@ class AbstractDataset:
         """
 
         self.data = data
-        self.over_sampling = over_sampling
 
         self.noise_covariance_matrix = noise_covariance_matrix
 
@@ -104,6 +103,10 @@ class AbstractDataset:
         self.noise_map = noise_map
 
         self.grids = GridsDataset(mask=data.mask, over_sampling=over_sampling)
+
+    @property
+    def over_sampling(self):
+        return self.grids.over_sampling
 
     @property
     def shape_native(self):
@@ -190,37 +193,25 @@ class AbstractDataset:
             This class controls over sampling for all the different grids (e.g. `grid`, `grid_pixelization).
         """
 
-        if over_sampling.uniform is not None:
-            self.over_sampling = over_sampling
-            try:
-                del self.__dict__["grid"]
-            except KeyError:
-                pass
-
-        if over_sampling.non_uniform is not None:
-            self.over_sampling.non_uniform = over_sampling.non_uniform
-            try:
-                del self.__dict__["grid_non_uniform"]
-            except KeyError:
-                pass
-            try:
-                del self.__dict__["over_sampler_non_uniform"]
-            except KeyError:
-                pass
+        uniform = over_sampling.uniform or self.over_sampling.uniform
+        non_uniform = over_sampling.non_uniform or self.over_sampling.non_uniform
+        pixelization = over_sampling.pixelization or self.over_sampling.pixelization
 
         if over_sampling.pixelization is not None:
-            self.over_sampling.pixelization = over_sampling.pixelization
-            try:
-                del self.__dict__["grid_pixelization"]
-            except KeyError:
-                pass
-            try:
-                del self.__dict__["over_sampler_pixelization"]
-            except KeyError:
-                pass
+
             try:
                 del self.__dict__["border_relocator"]
             except KeyError:
                 pass
+
+        over_sampling = OverSamplingDataset(
+            uniform=uniform,
+            non_uniform=non_uniform,
+            pixelization=pixelization,
+        )
+
+        self.grids = GridsDataset(
+            mask=self.mask, over_sampling=over_sampling
+        )
 
         return self

--- a/autoarray/dataset/abstract/dataset.py
+++ b/autoarray/dataset/abstract/dataset.py
@@ -13,7 +13,6 @@ from autoarray.mask.mask_1d import Mask1D
 from autoarray.mask.mask_2d import Mask2D
 from autoarray.structures.abstract_structure import Structure
 from autoarray.structures.arrays.uniform_2d import Array2D
-from autoarray.operators.over_sampling.abstract import AbstractOverSampling
 from autoarray.operators.over_sampling.uniform import OverSamplingUniform
 from autoarray.inversion.pixelization.border_relocator import BorderRelocator
 from autoconf import cached_property
@@ -28,7 +27,7 @@ class AbstractDataset:
         data: Structure,
         noise_map: Structure,
         noise_covariance_matrix: Optional[np.ndarray] = None,
-        over_sampling: Optional[OverSamplingDataset] = None,
+        over_sampling: Optional[OverSamplingDataset] = OverSamplingDataset(),
     ):
         """
         An abstract dataset, containing the image data, noise-map, PSF and associated quantities for calculations

--- a/autoarray/dataset/abstract/dataset.py
+++ b/autoarray/dataset/abstract/dataset.py
@@ -198,7 +198,6 @@ class AbstractDataset:
         pixelization = over_sampling.pixelization or self.over_sampling.pixelization
 
         if over_sampling.pixelization is not None:
-
             try:
                 del self.__dict__["border_relocator"]
             except KeyError:
@@ -210,8 +209,6 @@ class AbstractDataset:
             pixelization=pixelization,
         )
 
-        self.grids = GridsDataset(
-            mask=self.mask, over_sampling=over_sampling
-        )
+        self.grids = GridsDataset(mask=self.mask, over_sampling=over_sampling)
 
         return self

--- a/autoarray/dataset/abstract/dataset.py
+++ b/autoarray/dataset/abstract/dataset.py
@@ -132,8 +132,26 @@ class AbstractDataset:
         return Grid2D.from_mask(
             mask=self.mask,
             over_sampling=self.over_sampling,
-            over_sampling_non_uniform=self.over_sampling_non_uniform
-            or OverSamplingUniform(sub_size=1),
+        )
+
+    @cached_property
+    def grid_non_uniform(self) -> Optional[Union[Grid1D, Grid2D]]:
+        """
+        Returns the grid of (y,x) Cartesian coordinates of every pixel in the masked data structure.
+
+        This grid is computed based on the mask, in particular its pixel-scale and sub-grid size.
+
+        Returns
+        -------
+        The (y,x) coordinates of every pixel in the data structure.
+        """
+
+        if self.over_sampling_non_uniform is None:
+            return None
+
+        return Grid2D.from_mask(
+            mask=self.mask,
+            over_sampling=self.over_sampling_non_uniform,
         )
 
     @cached_property
@@ -165,7 +183,7 @@ class AbstractDataset:
 
     @cached_property
     def over_sampler_non_uniform(self):
-        return self.grid.over_sampling_non_uniform.over_sampler_from(mask=self.mask)
+        return self.grid_non_uniform.over_sampling.over_sampler_from(mask=self.mask)
 
     @cached_property
     def over_sampler_pixelization(self):
@@ -278,7 +296,7 @@ class AbstractDataset:
         if over_sampling_non_uniform is not None:
             self.over_sampling_non_uniform = over_sampling_non_uniform
             try:
-                del self.__dict__["grid"]
+                del self.__dict__["grid_non_uniform"]
             except KeyError:
                 pass
             try:

--- a/autoarray/dataset/abstract/dataset.py
+++ b/autoarray/dataset/abstract/dataset.py
@@ -40,19 +40,10 @@ class AbstractDataset:
         - `noise_map`: The RMS standard deviation error in every pixel, which is used to compute the chi-squared value
         and likelihood of a fit.
 
-        Datasets also contains following properties:
-
-        - `grid`: A grids of (y,x) coordinates which align with the image pixels, whereby each coordinate corresponds to
-        the centre of an image pixel. This may be used in fits to calculate the model image of the imaging data.
-
-        - `grid_pixelization`: A grid of (y,x) coordinates which align with the pixels of a pixelization. This grid
-        is specifically used for pixelizations computed via the `inversion` module, which often use different
-        oversampling and sub-size values to the grid above.
-
-        The `over_sampling` and `over_sampling_pixelization` define how over sampling is performed for these grids.
-
-        This is used in the project PyAutoGalaxy to load imaging data of a galaxy and fit it with galaxy light profiles.
-        It is used in PyAutoLens to load imaging data of a strong lens and fit it with a lens model.
+        The dataset also has a number of (y,x) grids of coordinates associated with it, which map to the centres
+        of its image pixels. They are used for performing calculations which map directly to the data and have
+        over sampling calculations built in which approximate the 2D line integral of these calculations within a
+        pixel. This is explained in more detail in the `GridsDataset` class.
 
         Parameters
         ----------

--- a/autoarray/dataset/abstract/dataset.py
+++ b/autoarray/dataset/abstract/dataset.py
@@ -163,6 +163,10 @@ class AbstractDataset:
         )
 
     @cached_property
+    def over_sampler_non_uniform(self):
+        return self.grid.over_sampling_non_uniform.over_sampler_from(mask=self.mask)
+
+    @cached_property
     def over_sampler_pixelization(self):
         return self.grid_pixelization.over_sampling.over_sampler_from(mask=self.mask)
 
@@ -232,6 +236,7 @@ class AbstractDataset:
     def apply_over_sampling(
         self,
         over_sampling: Optional[AbstractOverSampling] = None,
+        over_sampling_non_uniform: Optional[AbstractOverSampling] = None,
         over_sampling_pixelization: Optional[AbstractOverSampling] = None,
     ) -> "AbstractDataset":
         """
@@ -254,6 +259,10 @@ class AbstractDataset:
         ----------
         over_sampling
             The new over sampling object to apply to the grid.
+        over_sampling_non_uniform
+            The over sampling scheme when the grid input into a function is not a uniform grid. This is used
+            by **PyAutoLens** when the grid has been deflected and ray-traced and therefore some of the default
+            over sampling schemes are not appropriate.
         over_sampling_pixelization
             The new over sampling object to apply to the grid pixelization.
         """
@@ -264,6 +273,10 @@ class AbstractDataset:
                 del self.__dict__["grid"]
             except KeyError:
                 pass
+
+
+        if over_sampling_non_uniform is not None:
+            self.over_sampling_non_uniform = over_sampling_non_uniform
 
         if over_sampling_pixelization is not None:
             self.over_sampling_pixelization = over_sampling_pixelization

--- a/autoarray/dataset/abstract/dataset.py
+++ b/autoarray/dataset/abstract/dataset.py
@@ -102,11 +102,11 @@ class AbstractDataset:
 
         self.noise_map = noise_map
 
-        self.grids = GridsDataset(mask=data.mask, over_sampling=over_sampling)
+        self.over_sampling = over_sampling
 
-    @property
-    def over_sampling(self):
-        return self.grids.over_sampling
+    @cached_property
+    def grids(self):
+        return GridsDataset(mask=self.data.mask, over_sampling=self.over_sampling)
 
     @property
     def shape_native(self):
@@ -164,45 +164,3 @@ class AbstractDataset:
         )
 
         return dataset
-
-    def apply_over_sampling(
-        self,
-        over_sampling: Optional[OverSamplingDataset] = OverSamplingDataset(),
-    ) -> "AbstractDataset":
-        """
-        Apply new over sampling objects to the grid and grid pixelization of the dataset.
-
-        This method is used to change the over sampling of the grid and grid pixelization, for example when the
-        user wishes to perform over sampling with a higher sub grid size or with an iterative over sampling strategy.
-
-        The `grid` and grid_pixelization` are cached properties which after use are stored in memory for efficiency.
-        This function resets the cached properties so that the new over sampling is used in the grid and grid
-        pixelization.
-
-        The `default_galaxy_mode` parameter is used to set up default over sampling for galaxy light profiles in
-        the project PyAutoGalaxy. This sets up the over sampling such that there is high over sampling in the centre
-        of the mask, where the galaxy is located, and lower over sampling in the outer regions of the mask. It
-        does this based on the pixel scale, which gives a good estimate of how large the central region
-        requiring over sampling is.
-
-        Parameters
-        ----------
-        over_sampling
-            The over sampling schemes which divide the grids into sub grids of smaller pixels within their host image
-            pixels when using the grid to evaluate a function (e.g. images) to better approximate the 2D line integral
-            This class controls over sampling for all the different grids (e.g. `grid`, `grid_pixelization).
-        """
-
-        uniform = over_sampling.uniform or self.over_sampling.uniform
-        non_uniform = over_sampling.non_uniform or self.over_sampling.non_uniform
-        pixelization = over_sampling.pixelization or self.over_sampling.pixelization
-
-        over_sampling = OverSamplingDataset(
-            uniform=uniform,
-            non_uniform=non_uniform,
-            pixelization=pixelization,
-        )
-
-        self.grids = GridsDataset(mask=self.mask, over_sampling=over_sampling)
-
-        return self

--- a/autoarray/dataset/abstract/dataset.py
+++ b/autoarray/dataset/abstract/dataset.py
@@ -132,7 +132,8 @@ class AbstractDataset:
         return Grid2D.from_mask(
             mask=self.mask,
             over_sampling=self.over_sampling,
-            over_sampling_non_uniform=self.over_sampling_non_uniform,
+            over_sampling_non_uniform=self.over_sampling_non_uniform
+            or OverSamplingUniform(sub_size=1),
         )
 
     @cached_property
@@ -274,9 +275,16 @@ class AbstractDataset:
             except KeyError:
                 pass
 
-
         if over_sampling_non_uniform is not None:
             self.over_sampling_non_uniform = over_sampling_non_uniform
+            try:
+                del self.__dict__["grid"]
+            except KeyError:
+                pass
+            try:
+                del self.__dict__["over_sampler_non_uniform"]
+            except KeyError:
+                pass
 
         if over_sampling_pixelization is not None:
             self.over_sampling_pixelization = over_sampling_pixelization

--- a/autoarray/dataset/grids.py
+++ b/autoarray/dataset/grids.py
@@ -8,11 +8,8 @@ from autoarray.inversion.pixelization.border_relocator import BorderRelocator
 from autoconf import cached_property
 
 
-
 class GridsDataset:
-
     def __init__(self, mask, over_sampling):
-
         self.mask = mask
         self.over_sampling = over_sampling
 
@@ -78,6 +75,27 @@ class GridsDataset:
         return Grid2D.from_mask(
             mask=self.mask,
             over_sampling=over_sampling,
+        )
+
+    @cached_property
+    def blurring(self) -> Grid2D:
+        """
+        Returns a blurring-grid from a mask and the 2D shape of the PSF kernel.
+
+        A blurring grid consists of all pixels that are masked (and therefore have their values set to (0.0, 0.0)),
+        but are close enough to the unmasked pixels that their values will be convolved into the unmasked those pixels.
+        This when computing images from light profile objects.
+
+        This uses lazy allocation such that the calculation is only performed when the blurring grid is used, ensuring
+        efficient set up of the `Imaging` class.
+
+        Returns
+        -------
+        The blurring grid given the mask of the imaging data.
+        """
+
+        return self.grid.blurring_grid_via_kernel_shape_from(
+            kernel_shape_native=self.psf.shape_native,
         )
 
     @cached_property

--- a/autoarray/dataset/grids.py
+++ b/autoarray/dataset/grids.py
@@ -1,0 +1,95 @@
+from typing import Optional, Union
+
+from autoarray.structures.grids.uniform_1d import Grid1D
+from autoarray.structures.grids.uniform_2d import Grid2D
+
+from autoarray.operators.over_sampling.uniform import OverSamplingUniform
+from autoarray.inversion.pixelization.border_relocator import BorderRelocator
+from autoconf import cached_property
+
+
+
+class GridsDataset:
+
+    def __init__(self, mask, over_sampling):
+
+        self.mask = mask
+        self.over_sampling = over_sampling
+
+    @cached_property
+    def uniform(self) -> Union[Grid1D, Grid2D]:
+        """
+        Returns the grid of (y,x) Cartesian coordinates of every pixel in the masked data structure.
+
+        This grid is computed based on the mask, in particular its pixel-scale and sub-grid size.
+
+        Returns
+        -------
+        The (y,x) coordinates of every pixel in the data structure.
+        """
+
+        return Grid2D.from_mask(
+            mask=self.mask,
+            over_sampling=self.over_sampling.uniform,
+        )
+
+    @cached_property
+    def non_uniform(self) -> Optional[Union[Grid1D, Grid2D]]:
+        """
+        Returns the grid of (y,x) Cartesian coordinates of every pixel in the masked data structure.
+
+        This grid is computed based on the mask, in particular its pixel-scale and sub-grid size.
+
+        Returns
+        -------
+        The (y,x) coordinates of every pixel in the data structure.
+        """
+
+        if self.over_sampling.non_uniform is None:
+            return None
+
+        return Grid2D.from_mask(
+            mask=self.mask,
+            over_sampling=self.over_sampling.non_uniform,
+        )
+
+    @cached_property
+    def pixelization(self) -> Grid2D:
+        """
+        Returns the grid of (y,x) Cartesian coordinates of every pixel in the masked data structure which is used
+        specifically for pixelization reconstructions (e.g. an `inversion`).
+
+        This grid is computed based on the mask, in particular its pixel-scale and sub-grid size.
+
+        A pixelization often uses a different grid of coordinates compared to the main `grid` of the data structure.
+        A common example is that a pixelization may use a higher `sub_size` than the main grid, in order to better
+        prevent aliasing effects.
+
+        Returns
+        -------
+        The (y,x) coordinates of every pixel in the data structure, used for pixelization / inversion calculations.
+        """
+
+        over_sampling = self.over_sampling.pixelization
+
+        if over_sampling is None:
+            over_sampling = OverSamplingUniform(sub_size=4)
+
+        return Grid2D.from_mask(
+            mask=self.mask,
+            over_sampling=over_sampling,
+        )
+
+    @cached_property
+    def over_sampler_non_uniform(self):
+        return self.non_uniform.over_sampling.over_sampler_from(mask=self.mask)
+
+    @cached_property
+    def over_sampler_pixelization(self):
+        return self.pixelization.over_sampling.over_sampler_from(mask=self.mask)
+
+    @cached_property
+    def border_relocator(self) -> BorderRelocator:
+        return BorderRelocator(
+            mask=self.mask, sub_size=self.pixelization.over_sampling.sub_size
+        )

--- a/autoarray/dataset/grids.py
+++ b/autoarray/dataset/grids.py
@@ -9,9 +9,10 @@ from autoconf import cached_property
 
 
 class GridsDataset:
-    def __init__(self, mask, over_sampling):
+    def __init__(self, mask, over_sampling, psf = None):
         self.mask = mask
         self.over_sampling = over_sampling
+        self.psf = psf
 
     @cached_property
     def uniform(self) -> Union[Grid1D, Grid2D]:
@@ -94,7 +95,7 @@ class GridsDataset:
         The blurring grid given the mask of the imaging data.
         """
 
-        return self.grid.blurring_grid_via_kernel_shape_from(
+        return self.uniform.blurring_grid_via_kernel_shape_from(
             kernel_shape_native=self.psf.shape_native,
         )
 

--- a/autoarray/dataset/grids.py
+++ b/autoarray/dataset/grids.py
@@ -9,7 +9,7 @@ from autoconf import cached_property
 
 
 class GridsDataset:
-    def __init__(self, mask, over_sampling, psf = None):
+    def __init__(self, mask, over_sampling, psf=None):
         self.mask = mask
         self.over_sampling = over_sampling
         self.psf = psf
@@ -79,7 +79,7 @@ class GridsDataset:
         )
 
     @cached_property
-    def blurring(self) -> Grid2D:
+    def blurring(self) -> Optional[Grid2D]:
         """
         Returns a blurring-grid from a mask and the 2D shape of the PSF kernel.
 
@@ -94,6 +94,9 @@ class GridsDataset:
         -------
         The blurring grid given the mask of the imaging data.
         """
+
+        if self.psf is None:
+            return None
 
         return self.uniform.blurring_grid_via_kernel_shape_from(
             kernel_shape_native=self.psf.shape_native,
@@ -112,3 +115,19 @@ class GridsDataset:
         return BorderRelocator(
             mask=self.mask, sub_size=self.pixelization.over_sampling.sub_size
         )
+
+
+class GridsInterface:
+    def __init__(
+        self,
+        uniform=None,
+        non_uniform=None,
+        pixelization=None,
+        blurring=None,
+        border_relocator=None,
+    ):
+        self.uniform = uniform
+        self.non_uniform = non_uniform
+        self.pixelization = pixelization
+        self.blurring = blurring
+        self.border_relocator = border_relocator

--- a/autoarray/dataset/imaging/dataset.py
+++ b/autoarray/dataset/imaging/dataset.py
@@ -11,7 +11,6 @@ from autoarray.dataset.over_sampling import OverSamplingDataset
 from autoarray.structures.arrays.uniform_2d import Array2D
 from autoarray.operators.convolver import Convolver
 from autoarray.structures.grids.uniform_2d import Grid2D
-from autoarray.operators.over_sampling.abstract import AbstractOverSampling
 from autoarray.structures.arrays.kernel_2d import Kernel2D
 from autoarray.mask.mask_2d import Mask2D
 from autoarray import type as ty
@@ -29,7 +28,7 @@ class Imaging(AbstractDataset):
         noise_map: Optional[Array2D] = None,
         psf: Optional[Kernel2D] = None,
         noise_covariance_matrix: Optional[np.ndarray] = None,
-        over_sampling: Optional[OverSamplingDataset] = None,
+        over_sampling: Optional[OverSamplingDataset] = OverSamplingDataset(),
         pad_for_convolver: bool = False,
         use_normalized_psf: Optional[bool] = True,
         check_noise_map: bool = True,

--- a/autoarray/dataset/imaging/dataset.py
+++ b/autoarray/dataset/imaging/dataset.py
@@ -6,6 +6,7 @@ from typing import Optional, Union
 from autoconf import cached_property
 
 from autoarray.dataset.abstract.dataset import AbstractDataset
+from autoarray.dataset.grids import GridsDataset
 from autoarray.dataset.imaging.w_tilde import WTildeImaging
 from autoarray.dataset.over_sampling import OverSamplingDataset
 from autoarray.structures.arrays.uniform_2d import Array2D
@@ -152,6 +153,8 @@ class Imaging(AbstractDataset):
             )
 
         self.psf = psf
+
+        self.grids = GridsDataset(mask=data.mask, over_sampling=over_sampling, psf=self.psf)
 
     @cached_property
     def convolver(self):

--- a/autoarray/dataset/imaging/dataset.py
+++ b/autoarray/dataset/imaging/dataset.py
@@ -154,27 +154,6 @@ class Imaging(AbstractDataset):
         self.psf = psf
 
     @cached_property
-    def blurring_grid(self) -> Grid2D:
-        """
-        Returns a blurring-grid from a mask and the 2D shape of the PSF kernel.
-
-        A blurring grid consists of all pixels that are masked (and therefore have their values set to (0.0, 0.0)),
-        but are close enough to the unmasked pixels that their values will be convolved into the unmasked those pixels.
-        This when computing images from light profile objects.
-
-        This uses lazy allocation such that the calculation is only performed when the blurring grid is used, ensuring
-        efficient set up of the `Imaging` class.
-
-        Returns
-        -------
-        The blurring grid given the mask of the imaging data.
-        """
-
-        return self.grid.blurring_grid_via_kernel_shape_from(
-            kernel_shape_native=self.psf.shape_native,
-        )
-
-    @cached_property
     def convolver(self):
         """
         Returns a `Convolver` from a mask and 2D PSF kernel.

--- a/autoarray/dataset/imaging/dataset.py
+++ b/autoarray/dataset/imaging/dataset.py
@@ -241,7 +241,7 @@ class Imaging(AbstractDataset):
         psf_path: Optional[Union[Path, str]] = None,
         psf_hdu: int = 0,
         noise_covariance_matrix: Optional[np.ndarray] = None,
-        over_sampling: Optional[OverSamplingDataset] = None,
+        over_sampling: Optional[OverSamplingDataset] = OverSamplingDataset(),
     ) -> "Imaging":
         """
         Load an imaging dataset from multiple .fits file.

--- a/autoarray/dataset/imaging/dataset.py
+++ b/autoarray/dataset/imaging/dataset.py
@@ -154,7 +154,11 @@ class Imaging(AbstractDataset):
 
         self.psf = psf
 
-        self.grids = GridsDataset(mask=data.mask, over_sampling=over_sampling, psf=self.psf)
+    @cached_property
+    def grids(self):
+        return GridsDataset(
+            mask=self.data.mask, over_sampling=self.over_sampling, psf=self.psf
+        )
 
     @cached_property
     def convolver(self):
@@ -345,6 +349,52 @@ class Imaging(AbstractDataset):
         )
 
         return dataset
+
+    def apply_over_sampling(
+        self,
+        over_sampling: Optional[OverSamplingDataset] = OverSamplingDataset(),
+    ) -> "AbstractDataset":
+        """
+        Apply new over sampling objects to the grid and grid pixelization of the dataset.
+
+        This method is used to change the over sampling of the grid and grid pixelization, for example when the
+        user wishes to perform over sampling with a higher sub grid size or with an iterative over sampling strategy.
+
+        The `grid` and grid_pixelization` are cached properties which after use are stored in memory for efficiency.
+        This function resets the cached properties so that the new over sampling is used in the grid and grid
+        pixelization.
+
+        The `default_galaxy_mode` parameter is used to set up default over sampling for galaxy light profiles in
+        the project PyAutoGalaxy. This sets up the over sampling such that there is high over sampling in the centre
+        of the mask, where the galaxy is located, and lower over sampling in the outer regions of the mask. It
+        does this based on the pixel scale, which gives a good estimate of how large the central region
+        requiring over sampling is.
+
+        Parameters
+        ----------
+        over_sampling
+            The over sampling schemes which divide the grids into sub grids of smaller pixels within their host image
+            pixels when using the grid to evaluate a function (e.g. images) to better approximate the 2D line integral
+            This class controls over sampling for all the different grids (e.g. `grid`, `grid_pixelization).
+        """
+
+        uniform = over_sampling.uniform or self.over_sampling.uniform
+        non_uniform = over_sampling.non_uniform or self.over_sampling.non_uniform
+        pixelization = over_sampling.pixelization or self.over_sampling.pixelization
+
+        over_sampling = OverSamplingDataset(
+            uniform=uniform,
+            non_uniform=non_uniform,
+            pixelization=pixelization,
+        )
+
+        return Imaging(
+            data=self.data,
+            noise_map=self.noise_map,
+            psf=self.psf,
+            over_sampling=over_sampling,
+            pad_for_convolver=True,
+        )
 
     def output_to_fits(
         self,

--- a/autoarray/dataset/imaging/dataset.py
+++ b/autoarray/dataset/imaging/dataset.py
@@ -11,7 +11,6 @@ from autoarray.dataset.imaging.w_tilde import WTildeImaging
 from autoarray.dataset.over_sampling import OverSamplingDataset
 from autoarray.structures.arrays.uniform_2d import Array2D
 from autoarray.operators.convolver import Convolver
-from autoarray.structures.grids.uniform_2d import Grid2D
 from autoarray.structures.arrays.kernel_2d import Kernel2D
 from autoarray.mask.mask_2d import Mask2D
 from autoarray import type as ty
@@ -51,23 +50,10 @@ class Imaging(AbstractDataset):
         - `psf`: The Point Spread Function of the data, used to perform 2D convolution on images to produce a model
         image which is compared to the data.
 
-        Datasets also contains following properties:
-
-        - `grid`: A grids of (y,x) coordinates which aligns with the centre of every image pixel of the image data.
-
-        - `grid_pixelization`: A grid of (y,x) coordinates which again align with the centre of every image pixel of
-        the image data. This grid is used specifically for pixelizations computed via the `inversion` module, which
-        can benefit from using different oversampling schemes than the normal grid.
-
-        - `grid_non_uniform`: A grid of (y,x) coordinates which are mapped from the image pixel centres but have had
-        their values deflected to become non-uniform. This is used to compute over sampled light profiles of lensed
-        sources in PyAutoLens.
-
-        The `over_sampling` class defines how over sampling is performed for these grids and is described in the
-        corresponding `over_sampling.py` module.
-
-        This is used in the project PyAutoGalaxy to load imaging data of a galaxy and fit it with galaxy light profiles.
-        It is used in PyAutoLens to load imaging data of a strong lens and fit it with a lens model.
+        The dataset also has a number of (y,x) grids of coordinates associated with it, which map to the centres
+        of its image pixels. They are used for performing calculations which map directly to the data and have
+        over sampling calculations built in which approximate the 2D line integral of these calculations within a
+        pixel. This is explained in more detail in the `GridsDataset` class.
 
         Parameters
         ----------

--- a/autoarray/dataset/interferometer/dataset.py
+++ b/autoarray/dataset/interferometer/dataset.py
@@ -109,7 +109,7 @@ class Interferometer(AbstractDataset):
         noise_map_hdu=0,
         uv_wavelengths_hdu=0,
         transformer_class=TransformerNUFFT,
-        over_sampling: Optional[OverSamplingDataset] = None,
+        over_sampling: Optional[OverSamplingDataset] = OverSamplingDataset(),
     ):
         """
         Factory for loading the interferometer data_type from .fits files, as well as computing properties like the

--- a/autoarray/dataset/interferometer/dataset.py
+++ b/autoarray/dataset/interferometer/dataset.py
@@ -6,6 +6,7 @@ from autoconf import cached_property
 
 from autoarray.dataset.abstract.dataset import AbstractDataset
 from autoarray.dataset.interferometer.w_tilde import WTildeInterferometer
+from autoarray.dataset.over_sampling import OverSamplingDataset
 from autoarray.operators.transformer import TransformerNUFFT
 from autoarray.operators.over_sampling.abstract import AbstractOverSampling
 from autoarray.structures.visibilities import Visibilities
@@ -24,9 +25,7 @@ class Interferometer(AbstractDataset):
         uv_wavelengths: np.ndarray,
         real_space_mask,
         transformer_class=TransformerNUFFT,
-        over_sampling: Optional[AbstractOverSampling] = None,
-        over_sampling_non_uniform: Optional[AbstractOverSampling] = None,
-        over_sampling_pixelization: Optional[AbstractOverSampling] = None,
+        over_sampling: Optional[OverSamplingDataset] = None,
     ):
         """
         An interferometer dataset, containing the visibilities data, noise-map, real-space msk, Fourier transformer and
@@ -79,15 +78,9 @@ class Interferometer(AbstractDataset):
             A noise-map covariance matrix representing the covariance between noise in every `data` value, which
             can be used via a bespoke fit to account for correlated noise in the data.
         over_sampling
-            How over sampling is performed for the grid which performs calculations not associated with a pixelization.
-            In PyAutoGalaxy and PyAutoLens this is light profile calculations.
-        over_sampling_non_uniform
-            The over sampling scheme when the grid input into a function is not a uniform grid. This is used
-            by **PyAutoLens** when the grid has been deflected and ray-traced and therefore some of the default
-            over sampling schemes are not appropriate.
-        over_sampling_pixelization
-            How over sampling is performed for the grid which is associated with a pixelization, which is therefore
-            passed into the calculations performed in the `inversion` module.
+            The over sampling schemes which divide the grids into sub grids of smaller pixels within their host image
+            pixels when using the grid to evaluate a function (e.g. images) to better approximate the 2D line integral
+            This class controls over sampling for all the different grids (e.g. `grid`, `grid_pixelization).
         transformer_class
             The class of the Fourier Transform which maps images from real space to Fourier space visibilities and
             the uv-plane.
@@ -98,8 +91,6 @@ class Interferometer(AbstractDataset):
             data=data,
             noise_map=noise_map,
             over_sampling=over_sampling,
-            over_sampling_non_uniform=over_sampling_non_uniform,
-            over_sampling_pixelization=over_sampling_pixelization,
         )
 
         self.uv_wavelengths = uv_wavelengths
@@ -119,8 +110,7 @@ class Interferometer(AbstractDataset):
         noise_map_hdu=0,
         uv_wavelengths_hdu=0,
         transformer_class=TransformerNUFFT,
-        over_sampling: Optional[AbstractOverSampling] = None,
-        over_sampling_pixelization: Optional[AbstractOverSampling] = None,
+        over_sampling: Optional[OverSamplingDataset] = None,
     ):
         """
         Factory for loading the interferometer data_type from .fits files, as well as computing properties like the
@@ -147,7 +137,6 @@ class Interferometer(AbstractDataset):
             uv_wavelengths=uv_wavelengths,
             transformer_class=transformer_class,
             over_sampling=over_sampling,
-            over_sampling_pixelization=over_sampling_pixelization,
         )
 
     @cached_property

--- a/autoarray/dataset/interferometer/dataset.py
+++ b/autoarray/dataset/interferometer/dataset.py
@@ -47,19 +47,10 @@ class Interferometer(AbstractDataset):
         `real_space_mask`: Defines in real space where the signal is present. This mask is used to transform images to
         Fourier space via the Fourier transform. The grids contained in the settings are aligned with this mask.
 
-        Datasets also contains following properties:
-
-        - `grid`: A grids of (y,x) coordinates which align with the image pixels, whereby each coordinate corresponds to
-        the centre of an image pixel. This may be used in fits to calculate the model image of the imaging data.
-
-        - `grid_pixelization`: A grid of (y,x) coordinates which align with the pixels of a pixelization. This grid
-        is specifically used for pixelizations computed via the `invserion` module, which often use different
-        oversampling and sub-size values to the grid above.
-
-        The `over_sampling` and `over_sampling_pixelization` define how over sampling is performed for these grids.
-
-        This is used in the project PyAutoGalaxy to load imaging data of a galaxy and fit it with galaxy light profiles.
-        It is used in PyAutoLens to load imaging data of a strong lens and fit it with a lens model.
+        The dataset also has a number of (y,x) grids of coordinates associated with it, which map to the centres
+        of its image pixels. They are used for performing calculations which map directly to the data and have
+        over sampling calculations built in which approximate the 2D line integral of these calculations within a
+        pixel. This is explained in more detail in the `GridsDataset` class.
 
         Parameters
         ----------

--- a/autoarray/dataset/interferometer/dataset.py
+++ b/autoarray/dataset/interferometer/dataset.py
@@ -258,9 +258,5 @@ class Interferometer(AbstractDataset):
             )
 
     @property
-    def blurring_grid(self):
-        return None
-
-    @property
     def convolver(self):
         return None

--- a/autoarray/dataset/interferometer/dataset.py
+++ b/autoarray/dataset/interferometer/dataset.py
@@ -8,7 +8,6 @@ from autoarray.dataset.abstract.dataset import AbstractDataset
 from autoarray.dataset.interferometer.w_tilde import WTildeInterferometer
 from autoarray.dataset.over_sampling import OverSamplingDataset
 from autoarray.operators.transformer import TransformerNUFFT
-from autoarray.operators.over_sampling.abstract import AbstractOverSampling
 from autoarray.structures.visibilities import Visibilities
 from autoarray.structures.visibilities import VisibilitiesNoiseMap
 
@@ -25,7 +24,7 @@ class Interferometer(AbstractDataset):
         uv_wavelengths: np.ndarray,
         real_space_mask,
         transformer_class=TransformerNUFFT,
-        over_sampling: Optional[OverSamplingDataset] = None,
+        over_sampling: Optional[OverSamplingDataset] = OverSamplingDataset(),
     ):
         """
         An interferometer dataset, containing the visibilities data, noise-map, real-space msk, Fourier transformer and

--- a/autoarray/dataset/mock/mock_dataset.py
+++ b/autoarray/dataset/mock/mock_dataset.py
@@ -3,7 +3,7 @@ from autoarray.structures.grids.uniform_2d import Grid2D
 
 class MockDataset:
     def __init__(self, grid_pixelization=None, psf=None, mask=None):
-        self.grid_pixelization = grid_pixelization or Grid2D.no_mask(
+        self.grids_pixelization = grid_pixelization or Grid2D.no_mask(
             values=[[[1.0, 1.0]]], pixel_scales=1.0
         )
         self.psf = psf

--- a/autoarray/dataset/mock/mock_dataset.py
+++ b/autoarray/dataset/mock/mock_dataset.py
@@ -1,10 +1,17 @@
 from autoarray.structures.grids.uniform_2d import Grid2D
+from autoarray.dataset.grids import GridsInterface
 
 
 class MockDataset:
-    def __init__(self, grid_pixelization=None, psf=None, mask=None):
-        self.grids_pixelization = grid_pixelization or Grid2D.no_mask(
-            values=[[[1.0, 1.0]]], pixel_scales=1.0
-        )
+    def __init__(self, grids=None, psf=None, mask=None):
+        if grids is None:
+            self.grids = GridsInterface(
+                uniform=None,
+                non_uniform=None,
+                pixelization=Grid2D.no_mask(values=[[[1.0, 1.0]]], pixel_scales=1.0),
+                blurring=None,
+                border_relocator=None,
+            )
+
         self.psf = psf
         self.mask = mask

--- a/autoarray/dataset/over_sampling.py
+++ b/autoarray/dataset/over_sampling.py
@@ -1,0 +1,62 @@
+import logging
+from typing import Optional
+
+from autoarray.operators.over_sampling.abstract import AbstractOverSampling
+
+logger = logging.getLogger(__name__)
+
+
+class OverSamplingDataset:
+    def __init__(
+        self,
+        uniform: Optional[AbstractOverSampling] = None,
+        non_uniform: Optional[AbstractOverSampling] = None,
+        pixelization: Optional[AbstractOverSampling] = None,
+    ):
+        """
+        Customizes how over sampling calculations are performed using the grids of the data.
+
+        If a grid is uniform and the centre of each point on the grid is the centre of a 2D pixel, evaluating
+        the value of a function on the grid requires a 2D line integral to compute it precisely. This can be
+        computationally expensive and difficult to implement.
+
+        Over sampling is a numerical technique where the function is evaluated on a sub-grid within each grid pixel
+        which is higher resolution than the grid itself. This approximates more closely the value of the function
+        within a 2D line intergral of the values in the square pixel that the grid is centred.
+
+        For example, in PyAutoGalaxy and PyAutoLens the light profiles and galaxies are evaluated in order to determine
+        how much light falls in each pixel. This uses over sampling and therefore a higher resolution grid than the
+        image data to ensure the calculation is accurate.
+
+        This class controls how over sampling is performed for 3 different types of grids:
+
+        `grid`: A grids of (y,x) coordinates which aligns with the centre of every image pixel of the image data.
+
+        - `grid_pixelization`: A grid of (y,x) coordinates which again align with the centre of every image pixel of
+        the image data. This grid is used specifically for pixelizations computed via the `inversion` module, which
+        can benefit from using different oversampling schemes than the normal grid.
+
+        - `grid_non_uniform`: A grid of (y,x) coordinates which are mapped from the image pixel centres but have had
+        their values deflected to become non-uniform. This is used to compute over sampled light profiles of lensed
+        sources in PyAutoLens.
+
+        Different calculations typically benefit from different over sampling, which this class enables
+        the customization of.
+
+        Parameters
+        ----------
+        uniform
+            The over sampling scheme, which divides the grid into a sub grid of smaller pixels when computing values
+            (e.g. images) from the grid so as to approximate the 2D line integral of the amount of light that falls
+            into each pixel.
+        pixelization
+            How over sampling is performed for the grid which is associated with a pixelization, which is therefore
+            passed into the calculations performed in the `inversion` module.
+        non_uniform
+            The over sampling scheme when the grid input into a function is not a uniform grid. This is used
+            by **PyAutoLens** when the grid has been deflected and ray-traced and therefore some of the default
+            over sampling schemes are not appropriate.
+        """
+        self.uniform = uniform
+        self.pixelization = pixelization
+        self.non_uniform = non_uniform

--- a/autoarray/dataset/plot/imaging_plotters.py
+++ b/autoarray/dataset/plot/imaging_plotters.py
@@ -62,6 +62,7 @@ class ImagingPlotterMeta(Plotter):
         psf: bool = False,
         signal_to_noise_map: bool = False,
         over_sampling_sub_size: bool = False,
+        over_sampling_sub_size_non_uniform: bool = False,
         over_sampling_sub_size_pixelization: bool = False,
         title_str: Optional[str] = None,
     ):
@@ -137,7 +138,7 @@ class ImagingPlotterMeta(Plotter):
 
             else:
                 over_sampling = self.dataset.over_sampling
-                title = (title_str or f"Over Sampling Sub Size",)
+                title = (title_str or f"Over Sampling Sub Size")
 
             over_sampler = over_sampling.over_sampler_from(
                 mask=self.dataset.mask,
@@ -152,6 +153,21 @@ class ImagingPlotterMeta(Plotter):
                     cb_unit="",
                 ),
             )
+
+        if over_sampling_sub_size_non_uniform:
+
+            if self.dataset.over_sampler_non_uniform is not None:
+
+                self.mat_plot_2d.plot_array(
+                    array=self.dataset.over_sampler_non_uniform.sub_size,
+                    visuals_2d=self.get_visuals_2d(),
+                    auto_labels=AutoLabels(
+                        title=title_str or f"Over Sampling Sub Size Non Uniform",
+                        filename="over_sampling_sub_size_non_uniform",
+                        cb_unit="",
+                    ),
+                )
+
 
         if over_sampling_sub_size_pixelization:
             self.mat_plot_2d.plot_array(

--- a/autoarray/dataset/plot/imaging_plotters.py
+++ b/autoarray/dataset/plot/imaging_plotters.py
@@ -155,12 +155,12 @@ class ImagingPlotterMeta(Plotter):
             )
 
         if over_sampling_non_uniform:
-            if self.dataset.over_sampler_non_uniform is not None:
+            if self.dataset.over_sampling_non_uniform is not None:
                 self.mat_plot_2d.plot_array(
                     array=self.dataset.over_sampler_non_uniform.sub_size,
                     visuals_2d=self.get_visuals_2d(),
                     auto_labels=AutoLabels(
-                        title=title_str or f"Over Sampling Non Uniform",
+                        title=title_str or f"Over Sampling (Non Uniform)",
                         filename="over_sampling_non_uniform",
                         cb_unit="",
                     ),
@@ -171,7 +171,7 @@ class ImagingPlotterMeta(Plotter):
                 array=self.dataset.over_sampler_pixelization.sub_size,
                 visuals_2d=self.get_visuals_2d(),
                 auto_labels=AutoLabels(
-                    title=title_str or f"Over Sampling Pixelization",
+                    title=title_str or f"Over Sampling (Pixelization)",
                     filename="over_sampling_pixelization",
                     cb_unit="",
                 ),

--- a/autoarray/dataset/plot/imaging_plotters.py
+++ b/autoarray/dataset/plot/imaging_plotters.py
@@ -157,7 +157,7 @@ class ImagingPlotterMeta(Plotter):
         if over_sampling_non_uniform:
             if self.dataset.over_sampling.non_uniform is not None:
                 self.mat_plot_2d.plot_array(
-                    array=self.dataset.over_sampler_non_uniform.sub_size,
+                    array=self.dataset.grids.over_sampler_non_uniform.sub_size,
                     visuals_2d=self.get_visuals_2d(),
                     auto_labels=AutoLabels(
                         title=title_str or f"Over Sampling (Non Uniform)",
@@ -168,7 +168,7 @@ class ImagingPlotterMeta(Plotter):
 
         if over_sampling_pixelization:
             self.mat_plot_2d.plot_array(
-                array=self.dataset.over_sampler_pixelization.sub_size,
+                array=self.dataset.grids.over_sampler_pixelization.sub_size,
                 visuals_2d=self.get_visuals_2d(),
                 auto_labels=AutoLabels(
                     title=title_str or f"Over Sampling (Pixelization)",

--- a/autoarray/dataset/plot/imaging_plotters.py
+++ b/autoarray/dataset/plot/imaging_plotters.py
@@ -138,7 +138,7 @@ class ImagingPlotterMeta(Plotter):
 
             else:
                 over_sampling = self.dataset.over_sampling
-                title = (title_str or f"Over Sampling Sub Size")
+                title = title_str or f"Over Sampling Sub Size"
 
             over_sampler = over_sampling.over_sampler_from(
                 mask=self.dataset.mask,
@@ -155,9 +155,7 @@ class ImagingPlotterMeta(Plotter):
             )
 
         if over_sampling_sub_size_non_uniform:
-
             if self.dataset.over_sampler_non_uniform is not None:
-
                 self.mat_plot_2d.plot_array(
                     array=self.dataset.over_sampler_non_uniform.sub_size,
                     visuals_2d=self.get_visuals_2d(),
@@ -167,7 +165,6 @@ class ImagingPlotterMeta(Plotter):
                         cb_unit="",
                     ),
                 )
-
 
         if over_sampling_sub_size_pixelization:
             self.mat_plot_2d.plot_array(
@@ -253,6 +250,7 @@ class ImagingPlotterMeta(Plotter):
         self.figures_2d(signal_to_noise_map=True)
 
         self.figures_2d(over_sampling_sub_size=True)
+        self.figures_2d(over_sampling_sub_size_non_uniform=True)
         self.figures_2d(over_sampling_sub_size_pixelization=True)
 
         self.mat_plot_2d.output.subplot_to_figure(auto_filename="subplot_dataset")

--- a/autoarray/dataset/plot/imaging_plotters.py
+++ b/autoarray/dataset/plot/imaging_plotters.py
@@ -126,7 +126,7 @@ class ImagingPlotterMeta(Plotter):
             )
 
         if over_sampling:
-            if self.dataset.over_sampling is None:
+            if self.dataset.over_sampling.uniform is None:
                 from autoarray.operators.over_sampling.uniform import (
                     OverSamplingUniform,
                 )
@@ -140,7 +140,7 @@ class ImagingPlotterMeta(Plotter):
                 over_sampling = self.dataset.over_sampling
                 title = title_str or f"Over Sampling"
 
-            over_sampler = over_sampling.over_sampler_from(
+            over_sampler = over_sampling.uniform.over_sampler_from(
                 mask=self.dataset.mask,
             )
 
@@ -155,7 +155,7 @@ class ImagingPlotterMeta(Plotter):
             )
 
         if over_sampling_non_uniform:
-            if self.dataset.over_sampling_non_uniform is not None:
+            if self.dataset.over_sampling.non_uniform is not None:
                 self.mat_plot_2d.plot_array(
                     array=self.dataset.over_sampler_non_uniform.sub_size,
                     visuals_2d=self.get_visuals_2d(),

--- a/autoarray/dataset/plot/imaging_plotters.py
+++ b/autoarray/dataset/plot/imaging_plotters.py
@@ -61,9 +61,9 @@ class ImagingPlotterMeta(Plotter):
         noise_map: bool = False,
         psf: bool = False,
         signal_to_noise_map: bool = False,
-        over_sampling_sub_size: bool = False,
-        over_sampling_sub_size_non_uniform: bool = False,
-        over_sampling_sub_size_pixelization: bool = False,
+        over_sampling: bool = False,
+        over_sampling_non_uniform: bool = False,
+        over_sampling_pixelization: bool = False,
         title_str: Optional[str] = None,
     ):
         """
@@ -82,11 +82,11 @@ class ImagingPlotterMeta(Plotter):
             Whether to make a 2D plot (via `imshow`) of the psf.
         signal_to_noise_map
             Whether to make a 2D plot (via `imshow`) of the signal-to-noise map.
-        over_sampling_sub_size
-            Whether to make a 2D plot (via `imshow`) of the over sampling sub size for input light profiles. If
+        over_sampling
+            Whether to make a 2D plot (via `imshow`) of the Over Sampling for input light profiles. If
             adaptive sub size is used, the sub size grid for a centre of (0.0, 0.0) is used.
-        over_sampling_sub_size_pixelization
-            Whether to make a 2D plot (via `imshow`) of the over sampling sub size for pixelizations.
+        over_sampling_pixelization
+            Whether to make a 2D plot (via `imshow`) of the Over Sampling for pixelizations.
         """
 
         if data:
@@ -125,7 +125,7 @@ class ImagingPlotterMeta(Plotter):
                 ),
             )
 
-        if over_sampling_sub_size:
+        if over_sampling:
             if self.dataset.over_sampling is None:
                 from autoarray.operators.over_sampling.uniform import (
                     OverSamplingUniform,
@@ -134,11 +134,11 @@ class ImagingPlotterMeta(Plotter):
                 over_sampling = OverSamplingUniform.from_adaptive_scheme(
                     grid=self.dataset.grid, name="PlotExample", centre=(0.0, 0.0)
                 )
-                title = title_str or f"Over Sampling Sub Size (Adaptive)"
+                title = title_str or f"Over Sampling (Adaptive)"
 
             else:
                 over_sampling = self.dataset.over_sampling
-                title = title_str or f"Over Sampling Sub Size"
+                title = title_str or f"Over Sampling"
 
             over_sampler = over_sampling.over_sampler_from(
                 mask=self.dataset.mask,
@@ -149,30 +149,30 @@ class ImagingPlotterMeta(Plotter):
                 visuals_2d=self.get_visuals_2d(),
                 auto_labels=AutoLabels(
                     title=title,
-                    filename="over_sampling_sub_size",
+                    filename="over_sampling",
                     cb_unit="",
                 ),
             )
 
-        if over_sampling_sub_size_non_uniform:
+        if over_sampling_non_uniform:
             if self.dataset.over_sampler_non_uniform is not None:
                 self.mat_plot_2d.plot_array(
                     array=self.dataset.over_sampler_non_uniform.sub_size,
                     visuals_2d=self.get_visuals_2d(),
                     auto_labels=AutoLabels(
-                        title=title_str or f"Over Sampling Sub Size Non Uniform",
-                        filename="over_sampling_sub_size_non_uniform",
+                        title=title_str or f"Over Sampling Non Uniform",
+                        filename="over_sampling_non_uniform",
                         cb_unit="",
                     ),
                 )
 
-        if over_sampling_sub_size_pixelization:
+        if over_sampling_pixelization:
             self.mat_plot_2d.plot_array(
                 array=self.dataset.over_sampler_pixelization.sub_size,
                 visuals_2d=self.get_visuals_2d(),
                 auto_labels=AutoLabels(
-                    title=title_str or f"Over Sampling Sub Size Pixelization",
-                    filename="over_sampling_sub_size_pixelization",
+                    title=title_str or f"Over Sampling Pixelization",
+                    filename="over_sampling_pixelization",
                     cb_unit="",
                 ),
             )
@@ -183,8 +183,8 @@ class ImagingPlotterMeta(Plotter):
         noise_map: bool = False,
         psf: bool = False,
         signal_to_noise_map: bool = False,
-        over_sampling_sub_size: bool = False,
-        over_sampling_sub_size_pixelization: bool = False,
+        over_sampling: bool = False,
+        over_sampling_pixelization: bool = False,
         auto_filename: str = "subplot_dataset",
     ):
         """
@@ -203,11 +203,11 @@ class ImagingPlotterMeta(Plotter):
             Whether to include a 2D plot (via `imshow`) of the psf.
         signal_to_noise_map
             Whether to include a 2D plot (via `imshow`) of the signal-to-noise map.
-        over_sampling_sub_size
-            Whether to include a 2D plot (via `imshow`) of the over sampling sub size. If adaptive sub size is used, the
+        over_sampling
+            Whether to include a 2D plot (via `imshow`) of the Over Sampling. If adaptive sub size is used, the
             sub size grid for a centre of (0.0, 0.0) is used.
-        over_sampling_sub_size_pixelization
-            Whether to include a 2D plot (via `imshow`) of the over sampling sub size for pixelizations.
+        over_sampling_pixelization
+            Whether to include a 2D plot (via `imshow`) of the Over Sampling for pixelizations.
         auto_filename
             The default filename of the output subplot if written to hard-disk.
         """
@@ -216,8 +216,8 @@ class ImagingPlotterMeta(Plotter):
             noise_map=noise_map,
             psf=psf,
             signal_to_noise_map=signal_to_noise_map,
-            over_sampling_sub_size=over_sampling_sub_size,
-            over_sampling_sub_size_pixelization=over_sampling_sub_size_pixelization,
+            over_sampling=over_sampling,
+            over_sampling_pixelization=over_sampling_pixelization,
             auto_labels=AutoLabels(filename=auto_filename),
         )
 
@@ -249,9 +249,9 @@ class ImagingPlotterMeta(Plotter):
 
         self.figures_2d(signal_to_noise_map=True)
 
-        self.figures_2d(over_sampling_sub_size=True)
-        self.figures_2d(over_sampling_sub_size_non_uniform=True)
-        self.figures_2d(over_sampling_sub_size_pixelization=True)
+        self.figures_2d(over_sampling=True)
+        self.figures_2d(over_sampling_non_uniform=True)
+        self.figures_2d(over_sampling_pixelization=True)
 
         self.mat_plot_2d.output.subplot_to_figure(auto_filename="subplot_dataset")
         self.close_subplot_figure()

--- a/autoarray/dataset/plot/imaging_plotters.py
+++ b/autoarray/dataset/plot/imaging_plotters.py
@@ -132,7 +132,9 @@ class ImagingPlotterMeta(Plotter):
                 )
 
                 over_sampling = OverSamplingUniform.from_adaptive_scheme(
-                    grid=self.dataset.grid, name="PlotExample", centre=(0.0, 0.0)
+                    grid=self.dataset.grids.uniform,
+                    name="PlotExample",
+                    centre=(0.0, 0.0),
                 )
                 title = title_str or f"Over Sampling (Adaptive)"
 
@@ -140,7 +142,7 @@ class ImagingPlotterMeta(Plotter):
                 over_sampling = self.dataset.over_sampling
                 title = title_str or f"Over Sampling"
 
-            over_sampler = over_sampling.uniform.over_sampler_from(
+            over_sampler = over_sampling.over_sampler_from(
                 mask=self.dataset.mask,
             )
 

--- a/autoarray/fit/fit_dataset.py
+++ b/autoarray/fit/fit_dataset.py
@@ -5,6 +5,8 @@ from typing import Dict, Optional
 
 import numpy as np
 
+from autoconf import cached_property
+
 from autoarray.dataset.grids import GridsInterface
 from autoarray.dataset.dataset_model import DatasetModel
 from autoarray.fit import fit_util
@@ -153,8 +155,19 @@ class FitDataset(AbstractFitInversion):
     def mask(self) -> Mask2D:
         return self.dataset.mask
 
-    @property
+    @cached_property
     def grids(self) -> GridsInterface:
+        offset = self.dataset_model.grid_offset
+
+        if offset[0] == 0.0 and offset[1] == 0.0:
+            return GridsInterface(
+                uniform=self.dataset.grids.uniform,
+                non_uniform=self.dataset.grids.non_uniform,
+                pixelization=self.dataset.grids.pixelization,
+                blurring=self.dataset.grids.blurring,
+                border_relocator=self.dataset.grids.border_relocator,
+            )
+
         def subtracted_from(grid, offset):
             if grid is None:
                 return None
@@ -179,6 +192,7 @@ class FitDataset(AbstractFitInversion):
             non_uniform=non_uniform,
             pixelization=pixelization,
             blurring=blurring,
+            border_relocator=self.dataset.grids.border_relocator,
         )
 
     @property

--- a/autoarray/fit/fit_dataset.py
+++ b/autoarray/fit/fit_dataset.py
@@ -154,7 +154,9 @@ class FitDataset(AbstractFitInversion):
 
     @property
     def grid(self) -> ty.Grid2DLike:
-        return self.dataset.grids.uniform.subtracted_from(offset=self.dataset_model.grid_offset)
+        return self.dataset.grids.uniform.subtracted_from(
+            offset=self.dataset_model.grid_offset
+        )
 
     @property
     def grid_pixelization(self) -> ty.Grid2DLike:
@@ -164,7 +166,7 @@ class FitDataset(AbstractFitInversion):
 
     @property
     def blurring_grid(self) -> ty.Grid2DLike:
-        return self.dataset.blurring_grid.subtracted_from(
+        return self.dataset.grids.blurring.subtracted_from(
             offset=self.dataset_model.grid_offset
         )
 

--- a/autoarray/fit/fit_dataset.py
+++ b/autoarray/fit/fit_dataset.py
@@ -5,6 +5,7 @@ from typing import Dict, Optional
 
 import numpy as np
 
+from autoarray.dataset.grids import GridsInterface
 from autoarray.dataset.dataset_model import DatasetModel
 from autoarray.fit import fit_util
 from autoarray.inversion.inversion.abstract import AbstractInversion
@@ -153,11 +154,32 @@ class FitDataset(AbstractFitInversion):
         return self.dataset.mask
 
     @property
-    def grids(self) -> ty.Grid2DLike:
-        return self.dataset.grids
-        # return self.dataset.grids.uniform.subtracted_from(
-        #     offset=self.dataset_model.grid_offset
-        # )
+    def grids(self) -> GridsInterface:
+        def subtracted_from(grid, offset):
+            if grid is None:
+                return None
+
+            return grid.subtracted_from(offset=offset)
+
+        uniform = subtracted_from(
+            grid=self.dataset.grids.uniform, offset=self.dataset_model.grid_offset
+        )
+        non_uniform = subtracted_from(
+            grid=self.dataset.grids.non_uniform, offset=self.dataset_model.grid_offset
+        )
+        pixelization = subtracted_from(
+            grid=self.dataset.grids.pixelization, offset=self.dataset_model.grid_offset
+        )
+        blurring = subtracted_from(
+            grid=self.dataset.grids.blurring, offset=self.dataset_model.grid_offset
+        )
+
+        return GridsInterface(
+            uniform=uniform,
+            non_uniform=non_uniform,
+            pixelization=pixelization,
+            blurring=blurring,
+        )
 
     @property
     def data(self) -> ty.DataLike:

--- a/autoarray/fit/fit_dataset.py
+++ b/autoarray/fit/fit_dataset.py
@@ -153,22 +153,11 @@ class FitDataset(AbstractFitInversion):
         return self.dataset.mask
 
     @property
-    def grid(self) -> ty.Grid2DLike:
-        return self.dataset.grids.uniform.subtracted_from(
-            offset=self.dataset_model.grid_offset
-        )
-
-    @property
-    def grid_pixelization(self) -> ty.Grid2DLike:
-        return self.dataset.grids.pixelization.subtracted_from(
-            offset=self.dataset_model.grid_offset
-        )
-
-    @property
-    def blurring_grid(self) -> ty.Grid2DLike:
-        return self.dataset.grids.blurring.subtracted_from(
-            offset=self.dataset_model.grid_offset
-        )
+    def grids(self) -> ty.Grid2DLike:
+        return self.dataset.grids
+        # return self.dataset.grids.uniform.subtracted_from(
+        #     offset=self.dataset_model.grid_offset
+        # )
 
     @property
     def data(self) -> ty.DataLike:

--- a/autoarray/fit/fit_dataset.py
+++ b/autoarray/fit/fit_dataset.py
@@ -154,11 +154,11 @@ class FitDataset(AbstractFitInversion):
 
     @property
     def grid(self) -> ty.Grid2DLike:
-        return self.dataset.grid.subtracted_from(offset=self.dataset_model.grid_offset)
+        return self.dataset.grids.uniform.subtracted_from(offset=self.dataset_model.grid_offset)
 
     @property
     def grid_pixelization(self) -> ty.Grid2DLike:
-        return self.dataset.grid_pixelization.subtracted_from(
+        return self.dataset.grids.pixelization.subtracted_from(
             offset=self.dataset_model.grid_offset
         )
 

--- a/autoarray/fixtures.py
+++ b/autoarray/fixtures.py
@@ -152,7 +152,9 @@ def make_imaging_7x7():
         data=make_image_7x7(),
         psf=make_psf_3x3(),
         noise_map=make_noise_map_7x7(),
-        over_sampling=aa.OverSamplingUniform(sub_size=1),
+        over_sampling=aa.OverSamplingDataset(
+            uniform=aa.OverSamplingUniform(sub_size=1)
+        ),
     )
 
 
@@ -161,7 +163,9 @@ def make_imaging_7x7_sub_2():
         data=make_image_7x7(),
         psf=make_psf_3x3(),
         noise_map=make_noise_map_7x7(),
-        over_sampling=aa.OverSamplingUniform(sub_size=2),
+        over_sampling=aa.OverSamplingDataset(
+            uniform=aa.OverSamplingUniform(sub_size=2)
+        ),
     )
 
 
@@ -170,7 +174,9 @@ def make_imaging_covariance_7x7():
         data=make_image_7x7(),
         psf=make_psf_3x3(),
         noise_covariance_matrix=make_noise_covariance_matrix_7x7(),
-        over_sampling=aa.OverSamplingUniform(sub_size=1),
+        over_sampling=aa.OverSamplingDataset(
+            uniform=aa.OverSamplingUniform(sub_size=1)
+        ),
     )
 
 
@@ -179,7 +185,9 @@ def make_imaging_7x7_no_blur():
         data=make_image_7x7(),
         psf=make_psf_3x3_no_blur(),
         noise_map=make_noise_map_7x7(),
-        over_sampling=aa.OverSamplingUniform(sub_size=1),
+        over_sampling=aa.OverSamplingDataset(
+            uniform=aa.OverSamplingUniform(sub_size=1)
+        ),
     )
 
 
@@ -188,7 +196,9 @@ def make_imaging_7x7_no_blur_sub_2():
         data=make_image_7x7(),
         psf=make_psf_3x3_no_blur(),
         noise_map=make_noise_map_7x7(),
-        over_sampling=aa.OverSamplingUniform(sub_size=2),
+        over_sampling=aa.OverSamplingDataset(
+            uniform=aa.OverSamplingUniform(sub_size=2)
+        ),
     )
 
 
@@ -225,7 +235,9 @@ def make_interferometer_7():
         uv_wavelengths=make_uv_wavelengths_7x2(),
         real_space_mask=make_mask_2d_7x7(),
         transformer_class=aa.TransformerDFT,
-        over_sampling_pixelization=aa.OverSamplingUniform(sub_size=1),
+        over_sampling=aa.OverSamplingDataset(
+            pixelization=aa.OverSamplingUniform(sub_size=1)
+        ),
     )
 
 
@@ -236,7 +248,9 @@ def make_interferometer_7_no_fft():
         uv_wavelengths=make_uv_wavelengths_7x2_no_fft(),
         real_space_mask=make_mask_2d_7x7(),
         transformer_class=aa.TransformerDFT,
-        over_sampling_pixelization=aa.OverSamplingUniform(sub_size=1),
+        over_sampling=aa.OverSamplingDataset(
+            pixelization=aa.OverSamplingUniform(sub_size=1)
+        ),
     )
 
 
@@ -247,7 +261,9 @@ def make_interferometer_7_grid():
         uv_wavelengths=make_uv_wavelengths_7x2(),
         real_space_mask=make_mask_2d_7x7(),
         transformer_class=aa.TransformerDFT,
-        over_sampling_pixelization=aa.OverSamplingUniform(sub_size=1),
+        over_sampling=aa.OverSamplingDataset(
+            pixelization=aa.OverSamplingUniform(sub_size=1)
+        ),
     )
 
 

--- a/autoarray/inversion/inversion/dataset_interface.py
+++ b/autoarray/inversion/inversion/dataset_interface.py
@@ -7,8 +7,7 @@ class DatasetInterface:
         convolver=None,
         transformer=None,
         w_tilde=None,
-        grid=None,
-        grid_pixelization=None,
+        grids=None,
         blurring_grid=None,
         noise_covariance_matrix=None,
     ):
@@ -74,11 +73,10 @@ class DatasetInterface:
         self.convolver = convolver
         self.transformer = transformer
         self.w_tilde = w_tilde
-        self.grid = grid
-        self.grid_pixelization = grid_pixelization
+        self.grids = grids
         self.blurring_grid = blurring_grid
         self.noise_covariance_matrix = noise_covariance_matrix
 
     @property
     def mask(self):
-        return self.grid.mask
+        return self.grids.uniform.mask

--- a/autoarray/inversion/inversion/dataset_interface.py
+++ b/autoarray/inversion/inversion/dataset_interface.py
@@ -3,12 +3,10 @@ class DatasetInterface:
         self,
         data,
         noise_map,
-        border_relocator=None,
+        grids=None,
         convolver=None,
         transformer=None,
         w_tilde=None,
-        grids=None,
-        blurring_grid=None,
         noise_covariance_matrix=None,
     ):
         """
@@ -51,30 +49,19 @@ class DatasetInterface:
         w_tilde
             The w_tilde matrix used by the w-tilde formalism to construct the data vector and
             curvature matrix during an inversion efficiently..
-        grid
-            The grid of (y,x) Cartesian coordinates that the image data is paired with, which is used for calculations
-            not associated with a pixelization (e.g. linear func objects which in PyAutoGalaxy and PyAutooLens represent
-            linear light profiles).
-        grid_pixelization
-            The grid of (y,x) Cartesian coordinates that the image data is paired with, which is used for calculations
-            associated with a pixelization.
-        blurring_grid
-            The grid of (y,x) Cartesian coordinates of every pixel in the image data which is outside the masked
-            region fitted but that is close enough to the masked region that its light is blurred into the mask
-            after PSF convolution. The blurring grid is used for linear func calculations and not pixelization
-            calculations.
+        grids
+            The grids of (y,x) Cartesian coordinates that the image data is paired with, which are used for evaluting
+            light profiles and calculations associated with a pixelization.
         noise_covariance_matrix
             A noise-map covariance matrix representing the covariance between noise in every `data` value, which
             can be used via a bespoke fit to account for correlated noise in the data.
         """
         self.data = data
         self.noise_map = noise_map
-        self.border_relocator = border_relocator
+        self.grids = grids
         self.convolver = convolver
         self.transformer = transformer
         self.w_tilde = w_tilde
-        self.grids = grids
-        self.blurring_grid = blurring_grid
         self.noise_covariance_matrix = noise_covariance_matrix
 
     @property

--- a/autoarray/mask/mask_2d_util.py
+++ b/autoarray/mask/mask_2d_util.py
@@ -1,10 +1,9 @@
 import numpy as np
-from typing import Tuple, Union
+from typing import Tuple
 import warnings
 
 from autoarray import exc
 from autoarray import numba_util
-from autoarray.structures.grids import grid_2d_util
 from autoarray import type as ty
 
 

--- a/autoarray/structures/decorators/abstract.py
+++ b/autoarray/structures/decorators/abstract.py
@@ -65,10 +65,6 @@ class AbstractMaker:
     def over_sampling(self) -> AbstractOverSampling:
         return self.grid.over_sampling
 
-    @property
-    def over_sampling_non_uniform(self) -> AbstractOverSampling:
-        return self.grid.over_sampling_non_uniform
-
     def via_grid_2d(self, result):
         raise NotImplementedError
 

--- a/autoarray/structures/decorators/to_grid.py
+++ b/autoarray/structures/decorators/to_grid.py
@@ -26,14 +26,12 @@ class GridMaker(AbstractMaker):
                 values=result,
                 mask=self.mask,
                 over_sampling=self.over_sampling,
-                over_sampling_non_uniform=self.over_sampling_non_uniform,
             )
         return [
             Grid2D(
                 values=res,
                 mask=self.mask,
                 over_sampling=self.over_sampling,
-                over_sampling_non_uniform=self.over_sampling_non_uniform,
             )
             for res in result
         ]

--- a/autoarray/structures/grids/uniform_2d.py
+++ b/autoarray/structures/grids/uniform_2d.py
@@ -29,7 +29,7 @@ class Grid2D(Structure):
         mask: Mask2D,
         store_native: bool = False,
         over_sampling: Optional[AbstractOverSampling] = None,
-        over_sampling_non_uniform : Optional[AbstractOverSampling] = None,
+        over_sampling_non_uniform: Optional[AbstractOverSampling] = None,
         *args,
         **kwargs,
     ):

--- a/autoarray/structures/grids/uniform_2d.py
+++ b/autoarray/structures/grids/uniform_2d.py
@@ -29,6 +29,7 @@ class Grid2D(Structure):
         mask: Mask2D,
         store_native: bool = False,
         over_sampling: Optional[AbstractOverSampling] = None,
+        over_sampling_non_uniform : Optional[AbstractOverSampling] = None,
         *args,
         **kwargs,
     ):
@@ -172,6 +173,7 @@ class Grid2D(Structure):
         grid_2d_util.check_grid_2d(grid_2d=values)
 
         self.over_sampling = over_sampling
+        self.over_sampling_non_uniform = over_sampling_non_uniform
 
     @classmethod
     def no_mask(

--- a/autoarray/structures/grids/uniform_2d.py
+++ b/autoarray/structures/grids/uniform_2d.py
@@ -713,7 +713,7 @@ class Grid2D(Structure):
 
     @cached_property
     def over_sampler(self) -> AbstractOverSampler:
-        return self.over_sampling.over_sampler_from(mask=self.mask)
+        return self.over_sampling.uniform.over_sampler_from(mask=self.mask)
 
     @property
     def flipped(self) -> "Grid2D":

--- a/autoarray/structures/grids/uniform_2d.py
+++ b/autoarray/structures/grids/uniform_2d.py
@@ -29,7 +29,6 @@ class Grid2D(Structure):
         mask: Mask2D,
         store_native: bool = False,
         over_sampling: Optional[AbstractOverSampling] = None,
-        over_sampling_non_uniform: Optional[AbstractOverSampling] = None,
         *args,
         **kwargs,
     ):
@@ -159,10 +158,6 @@ class Grid2D(Structure):
             The over sampling scheme, which divides the grid into a sub grid of smaller pixels when computing values
             (e.g. images) from the grid so as to approximate the 2D line integral of the amount of light that falls
             into each pixel.
-        over_sampling_non_uniform
-            The over sampling scheme when the grid input into a function is not a uniform grid. This is used
-            by **PyAutoLens** when the grid has been deflected and ray-traced and therefore some of the default
-            over sampling schemes are not appropriate.
         """
         values = grid_2d_util.convert_grid_2d(
             grid_2d=values,
@@ -177,7 +172,6 @@ class Grid2D(Structure):
         grid_2d_util.check_grid_2d(grid_2d=values)
 
         self.over_sampling = over_sampling
-        self.over_sampling_non_uniform = over_sampling_non_uniform
 
     @classmethod
     def no_mask(
@@ -187,7 +181,6 @@ class Grid2D(Structure):
         shape_native: Tuple[int, int] = None,
         origin: Tuple[float, float] = (0.0, 0.0),
         over_sampling: Optional[AbstractOverSampling] = None,
-        over_sampling_non_uniform: Optional[AbstractOverSampling] = None,
     ) -> "Grid2D":
         """
         Create a Grid2D (see *Grid2D.__new__*) by inputting the grid coordinates in 1D or 2D, automatically
@@ -235,7 +228,6 @@ class Grid2D(Structure):
             values=values,
             mask=mask,
             over_sampling=over_sampling,
-            over_sampling_non_uniform=over_sampling_non_uniform,
         )
 
     @classmethod
@@ -247,7 +239,6 @@ class Grid2D(Structure):
         pixel_scales: ty.PixelScales,
         origin: Tuple[float, float] = (0.0, 0.0),
         over_sampling: Optional[AbstractOverSampling] = None,
-        over_sampling_non_uniform: Optional[AbstractOverSampling] = None,
     ) -> "Grid2D":
         """
         Create a Grid2D (see *Grid2D.__new__*) by inputting the grid coordinates as 1D y and x values.
@@ -312,7 +303,6 @@ class Grid2D(Structure):
             pixel_scales=pixel_scales,
             origin=origin,
             over_sampling=over_sampling,
-            over_sampling_non_uniform=over_sampling_non_uniform,
         )
 
     @classmethod
@@ -323,7 +313,6 @@ class Grid2D(Structure):
         pixel_scales: ty.PixelScales,
         origin: Tuple[float, float] = (0.0, 0.0),
         over_sampling: Optional[AbstractOverSampling] = None,
-        over_sampling_non_uniform: Optional[AbstractOverSampling] = None,
     ) -> "Grid2D":
         """
         Create a Grid2D (see *Grid2D.__new__*) by inputting the grid coordinates as 2D y and x values.
@@ -369,7 +358,6 @@ class Grid2D(Structure):
             pixel_scales=pixel_scales,
             origin=origin,
             over_sampling=over_sampling,
-            over_sampling_non_uniform=over_sampling_non_uniform,
         )
 
     @classmethod
@@ -378,7 +366,6 @@ class Grid2D(Structure):
         extent: Tuple[float, float, float, float],
         shape_native: Tuple[int, int],
         over_sampling: Optional[AbstractOverSampling] = None,
-        over_sampling_non_uniform: Optional[AbstractOverSampling] = None,
     ) -> "Grid2D":
         """
         Create a Grid2D (see *Grid2D.__new__*) by inputting the extent of the (y,x) grid coordinates as an input
@@ -428,7 +415,6 @@ class Grid2D(Structure):
             values=grid_2d,
             pixel_scales=pixel_scales,
             over_sampling=over_sampling,
-            over_sampling_non_uniform=over_sampling_non_uniform,
         )
 
     @classmethod
@@ -438,7 +424,6 @@ class Grid2D(Structure):
         pixel_scales: ty.PixelScales,
         origin: Tuple[float, float] = (0.0, 0.0),
         over_sampling: Optional[AbstractOverSampling] = None,
-        over_sampling_non_uniform: Optional[AbstractOverSampling] = None,
     ) -> "Grid2D":
         """
         Create a `Grid2D` (see *Grid2D.__new__*) as a uniform grid of (y,x) values given an input `shape_native` and
@@ -468,7 +453,6 @@ class Grid2D(Structure):
             pixel_scales=pixel_scales,
             origin=origin,
             over_sampling=over_sampling,
-            over_sampling_non_uniform=over_sampling_non_uniform,
         )
 
     @classmethod
@@ -478,7 +462,6 @@ class Grid2D(Structure):
         shape_native: Tuple[int, int],
         buffer_around_corners: bool = False,
         over_sampling: Optional[AbstractOverSampling] = None,
-        over_sampling_non_uniform: Optional[AbstractOverSampling] = None,
     ) -> "Grid2D":
         """
         Create a Grid2D (see *Grid2D.__new__*) from an input bounding box with coordinates [y_min, y_max, x_min, x_max],
@@ -522,7 +505,6 @@ class Grid2D(Structure):
             pixel_scales=pixel_scales,
             origin=origin,
             over_sampling=over_sampling,
-            over_sampling_non_uniform=over_sampling_non_uniform,
         )
 
     @classmethod
@@ -530,7 +512,6 @@ class Grid2D(Structure):
         cls,
         mask: Mask2D,
         over_sampling: Optional[AbstractOverSampling] = None,
-        over_sampling_non_uniform: Optional[AbstractOverSampling] = None,
     ) -> "Grid2D":
         """
         Create a Grid2D (see *Grid2D.__new__*) from a mask, where only unmasked pixels are included in the grid (if the
@@ -554,7 +535,6 @@ class Grid2D(Structure):
             values=grid_1d,
             mask=mask,
             over_sampling=over_sampling,
-            over_sampling_non_uniform=over_sampling_non_uniform,
         )
 
     @classmethod
@@ -564,7 +544,6 @@ class Grid2D(Structure):
         pixel_scales: ty.PixelScales,
         origin: Tuple[float, float] = (0.0, 0.0),
         over_sampling: Optional[AbstractOverSampling] = None,
-        over_sampling_non_uniform: Optional[AbstractOverSampling] = None,
     ) -> "Grid2D":
         """
         Create a Grid2D (see *Grid2D.__new__*) from a mask, where only unmasked pixels are included in the grid (if the
@@ -585,7 +564,6 @@ class Grid2D(Structure):
             pixel_scales=pixel_scales,
             origin=origin,
             over_sampling=over_sampling,
-            over_sampling_non_uniform=over_sampling_non_uniform,
         )
 
     @classmethod
@@ -594,7 +572,6 @@ class Grid2D(Structure):
         mask: Mask2D,
         kernel_shape_native: Tuple[int, int],
         over_sampling: Optional[AbstractOverSampling] = None,
-        over_sampling_non_uniform: Optional[AbstractOverSampling] = None,
     ) -> "Grid2D":
         """
         Setup a blurring-grid from a mask, where a blurring grid consists of all pixels that are masked (and
@@ -683,7 +660,6 @@ class Grid2D(Structure):
         return cls.from_mask(
             mask=blurring_mask,
             over_sampling=over_sampling,
-            over_sampling_non_uniform=over_sampling_non_uniform,
         )
 
     def subtracted_from(self, offset: Tuple[(float, float), np.ndarray]) -> "Grid2D":
@@ -700,7 +676,6 @@ class Grid2D(Structure):
             values=self - np.array(offset),
             mask=mask,
             over_sampling=self.over_sampling,
-            over_sampling_non_uniform=self.over_sampling_non_uniform,
         )
 
     @property
@@ -716,7 +691,6 @@ class Grid2D(Structure):
             values=self,
             mask=self.mask,
             over_sampling=self.over_sampling,
-            over_sampling_non_uniform=self.over_sampling_non_uniform,
         )
 
     @property
@@ -734,7 +708,6 @@ class Grid2D(Structure):
             values=self,
             mask=self.mask,
             over_sampling=self.over_sampling,
-            over_sampling_non_uniform=self.over_sampling_non_uniform,
             store_native=True,
         )
 
@@ -777,7 +750,6 @@ class Grid2D(Structure):
             values=self - deflection_grid,
             mask=self.mask,
             over_sampling=self.over_sampling,
-            over_sampling_non_uniform=self.over_sampling_non_uniform,
         )
 
     def blurring_grid_via_kernel_shape_from(
@@ -837,7 +809,6 @@ class Grid2D(Structure):
         return Grid2D.from_mask(
             mask=mask,
             over_sampling=self.over_sampling,
-            over_sampling_non_uniform=self.over_sampling_non_uniform,
         )
 
     def squared_distances_to_coordinate_from(
@@ -1090,7 +1061,6 @@ class Grid2D(Structure):
         return Grid2D.from_mask(
             mask=padded_mask,
             over_sampling=self.over_sampling,
-            over_sampling_non_uniform=self.over_sampling_non_uniform,
         )
 
     @cached_property
@@ -1111,7 +1081,7 @@ class Grid2D(Structure):
         y_diff = self[:, 0][:-1] - self[:, 0][1:]
         y_diff = y_diff[y_diff != 0]
 
-        if any(y_diff - self.pixel_scales[0] > 1.0e-8):
+        if any(abs(y_diff - self.pixel_scales[0]) > 1.0e-8):
             return False
 
         return True

--- a/autoarray/structures/grids/uniform_2d.py
+++ b/autoarray/structures/grids/uniform_2d.py
@@ -713,7 +713,7 @@ class Grid2D(Structure):
 
     @cached_property
     def over_sampler(self) -> AbstractOverSampler:
-        return self.over_sampling.uniform.over_sampler_from(mask=self.mask)
+        return self.over_sampling.over_sampler_from(mask=self.mask)
 
     @property
     def flipped(self) -> "Grid2D":

--- a/autoarray/structures/grids/uniform_2d.py
+++ b/autoarray/structures/grids/uniform_2d.py
@@ -665,7 +665,7 @@ class Grid2D(Structure):
         )
 
     def subtracted_from(self, offset: Tuple[(float, float), np.ndarray]) -> "Grid2D":
-        if offset[0] == 0.0 and offset[1] != 0.0:
+        if offset[0] == 0.0 and offset[1] == 0.0:
             return self
 
         mask = Mask2D(

--- a/test_autoarray/dataset/abstract/test_dataset.py
+++ b/test_autoarray/dataset/abstract/test_dataset.py
@@ -167,8 +167,8 @@ def test__apply_over_sampling(image_7x7, noise_map_7x7):
     grid_sub_2 = dataset_7x7.grids.uniform
     grid_pixelization_sub_2 = dataset_7x7.grids.pixelization
 
-    dataset_7x7.__dict__["grid"][0][0] = 100.0
-    dataset_7x7.__dict__["grid_pixelization"][0][0] = 100.0
+    dataset_7x7.grids.__dict__["uniform"][0][0] = 100.0
+    dataset_7x7.grids.__dict__["pixelization"][0][0] = 100.0
 
     assert dataset_7x7.grids.uniform[0][0] == pytest.approx(100.0, 1.0e-4)
     assert dataset_7x7.grids.pixelization[0][0] == pytest.approx(100.0, 1.0e-4)
@@ -183,5 +183,5 @@ def test__apply_over_sampling(image_7x7, noise_map_7x7):
     assert dataset_7x7.over_sampling.uniform.sub_size == 4
     assert dataset_7x7.over_sampling.pixelization.sub_size == 4
 
-    assert dataset_7x7.grid[0][0] == pytest.approx(3.0, 1.0e-4)
+    assert dataset_7x7.grids.uniform[0][0] == pytest.approx(3.0, 1.0e-4)
     assert dataset_7x7.grids.pixelization[0][0] == pytest.approx(3.0, 1.0e-4)

--- a/test_autoarray/dataset/abstract/test_dataset.py
+++ b/test_autoarray/dataset/abstract/test_dataset.py
@@ -65,7 +65,9 @@ def test__grid__uses_mask_and_settings(
     masked_imaging_7x7 = ds.AbstractDataset(
         data=masked_image_7x7,
         noise_map=masked_noise_map_7x7,
-        over_sampling=aa.OverSamplingUniform(sub_size=2),
+        over_sampling=aa.OverSamplingDataset(
+            uniform=aa.OverSamplingUniform(sub_size=2)
+        ),
     )
 
     assert isinstance(masked_imaging_7x7.grid, aa.Grid2D)
@@ -75,7 +77,7 @@ def test__grid__uses_mask_and_settings(
     masked_imaging_7x7 = ds.AbstractDataset(
         data=masked_image_7x7,
         noise_map=masked_noise_map_7x7,
-        over_sampling=aa.OverSamplingIterate(),
+        over_sampling=aa.OverSamplingDataset(uniform=aa.OverSamplingIterate()),
     )
 
     assert isinstance(masked_imaging_7x7.grid.over_sampling, aa.OverSamplingIterate)
@@ -95,7 +97,9 @@ def test__grid_pixelization__uses_mask_and_settings(
     masked_imaging_7x7 = ds.AbstractDataset(
         data=masked_image_7x7,
         noise_map=masked_noise_map_7x7,
-        over_sampling_pixelization=aa.OverSamplingIterate(sub_steps=[2, 4]),
+        over_sampling=aa.OverSamplingDataset(
+            pixelization=aa.OverSamplingIterate(sub_steps=[2, 4])
+        ),
     )
 
     assert masked_imaging_7x7.grid_pixelization.over_sampling.sub_steps == [2, 4]
@@ -105,8 +109,10 @@ def test__grid_pixelization__uses_mask_and_settings(
     masked_imaging_7x7 = ds.AbstractDataset(
         data=masked_image_7x7,
         noise_map=masked_noise_map_7x7,
-        over_sampling=aa.OverSamplingUniform(sub_size=2),
-        over_sampling_pixelization=aa.OverSamplingUniform(sub_size=4),
+        over_sampling=aa.OverSamplingDataset(
+            uniform=aa.OverSamplingUniform(sub_size=2),
+            pixelization=aa.OverSamplingUniform(sub_size=4),
+        ),
     )
 
     assert isinstance(masked_imaging_7x7.grid_pixelization, aa.Grid2D)
@@ -117,8 +123,10 @@ def test__grid_settings__sub_size(image_7x7, noise_map_7x7):
     dataset_7x7 = ds.AbstractDataset(
         data=image_7x7,
         noise_map=noise_map_7x7,
-        over_sampling=aa.OverSamplingUniform(sub_size=2),
-        over_sampling_pixelization=aa.OverSamplingUniform(sub_size=4),
+        over_sampling=aa.OverSamplingDataset(
+            uniform=aa.OverSamplingUniform(sub_size=2),
+            pixelization=aa.OverSamplingUniform(sub_size=4),
+        ),
     )
 
     assert dataset_7x7.grid.over_sampling.sub_size == 2
@@ -147,8 +155,10 @@ def test__apply_over_sampling(image_7x7, noise_map_7x7):
     dataset_7x7 = ds.AbstractDataset(
         data=image_7x7,
         noise_map=noise_map_7x7,
-        over_sampling=aa.OverSamplingUniform(sub_size=2),
-        over_sampling_pixelization=aa.OverSamplingUniform(sub_size=2),
+        over_sampling=aa.OverSamplingDataset(
+            uniform=aa.OverSamplingUniform(sub_size=2),
+            pixelization=aa.OverSamplingUniform(sub_size=2),
+        ),
     )
 
     # The grid and grid_pixelizaiton are a cached_property which needs to be reset,
@@ -164,12 +174,14 @@ def test__apply_over_sampling(image_7x7, noise_map_7x7):
     assert dataset_7x7.grid_pixelization[0][0] == pytest.approx(100.0, 1.0e-4)
 
     dataset_7x7 = dataset_7x7.apply_over_sampling(
-        over_sampling=aa.OverSamplingUniform(sub_size=4),
-        over_sampling_pixelization=aa.OverSamplingUniform(sub_size=4),
+        over_sampling=aa.OverSamplingDataset(
+            uniform=aa.OverSamplingUniform(sub_size=4),
+            pixelization=aa.OverSamplingUniform(sub_size=4),
+        )
     )
 
-    assert dataset_7x7.over_sampling.sub_size == 4
-    assert dataset_7x7.over_sampling_pixelization.sub_size == 4
+    assert dataset_7x7.over_sampling.uniform.sub_size == 4
+    assert dataset_7x7.over_sampling.pixelization.sub_size == 4
 
     assert dataset_7x7.grid[0][0] == pytest.approx(3.0, 1.0e-4)
     assert dataset_7x7.grid_pixelization[0][0] == pytest.approx(3.0, 1.0e-4)

--- a/test_autoarray/dataset/abstract/test_dataset.py
+++ b/test_autoarray/dataset/abstract/test_dataset.py
@@ -154,7 +154,7 @@ def test__new_imaging_with_arrays_trimmed_via_kernel_shape():
 
 
 def test__apply_over_sampling(image_7x7, noise_map_7x7):
-    dataset_7x7 = ds.AbstractDataset(
+    dataset_7x7 = aa.Imaging(
         data=image_7x7,
         noise_map=noise_map_7x7,
         over_sampling=aa.OverSamplingDataset(

--- a/test_autoarray/dataset/abstract/test_dataset.py
+++ b/test_autoarray/dataset/abstract/test_dataset.py
@@ -70,9 +70,9 @@ def test__grid__uses_mask_and_settings(
         ),
     )
 
-    assert isinstance(masked_imaging_7x7.grid, aa.Grid2D)
-    assert (masked_imaging_7x7.grid == grid_2d_7x7).all()
-    assert (masked_imaging_7x7.grid.slim == grid_2d_7x7).all()
+    assert isinstance(masked_imaging_7x7.grids.uniform, aa.Grid2D)
+    assert (masked_imaging_7x7.grids.uniform == grid_2d_7x7).all()
+    assert (masked_imaging_7x7.grids.uniform.slim == grid_2d_7x7).all()
 
     masked_imaging_7x7 = ds.AbstractDataset(
         data=masked_image_7x7,
@@ -80,8 +80,8 @@ def test__grid__uses_mask_and_settings(
         over_sampling=aa.OverSamplingDataset(uniform=aa.OverSamplingIterate()),
     )
 
-    assert isinstance(masked_imaging_7x7.grid.over_sampling, aa.OverSamplingIterate)
-    assert (masked_imaging_7x7.grid == grid_2d_7x7).all()
+    assert isinstance(masked_imaging_7x7.grids.uniform.over_sampling, aa.OverSamplingIterate)
+    assert (masked_imaging_7x7.grids.uniform == grid_2d_7x7).all()
 
 
 def test__grid_pixelization__uses_mask_and_settings(
@@ -102,9 +102,9 @@ def test__grid_pixelization__uses_mask_and_settings(
         ),
     )
 
-    assert masked_imaging_7x7.grid_pixelization.over_sampling.sub_steps == [2, 4]
-    assert (masked_imaging_7x7.grid_pixelization == grid_2d_7x7).all()
-    assert (masked_imaging_7x7.grid_pixelization.slim == grid_2d_7x7).all()
+    assert masked_imaging_7x7.grids.pixelization.over_sampling.sub_steps == [2, 4]
+    assert (masked_imaging_7x7.grids.pixelization == grid_2d_7x7).all()
+    assert (masked_imaging_7x7.grids.pixelization.slim == grid_2d_7x7).all()
 
     masked_imaging_7x7 = ds.AbstractDataset(
         data=masked_image_7x7,
@@ -115,8 +115,8 @@ def test__grid_pixelization__uses_mask_and_settings(
         ),
     )
 
-    assert isinstance(masked_imaging_7x7.grid_pixelization, aa.Grid2D)
-    assert masked_imaging_7x7.grid_pixelization.over_sampling.sub_size == 4
+    assert isinstance(masked_imaging_7x7.grids.pixelization, aa.Grid2D)
+    assert masked_imaging_7x7.grids.pixelization.over_sampling.sub_size == 4
 
 
 def test__grid_settings__sub_size(image_7x7, noise_map_7x7):
@@ -129,8 +129,8 @@ def test__grid_settings__sub_size(image_7x7, noise_map_7x7):
         ),
     )
 
-    assert dataset_7x7.grid.over_sampling.sub_size == 2
-    assert dataset_7x7.grid_pixelization.over_sampling.sub_size == 4
+    assert dataset_7x7.grids.uniform.over_sampling.sub_size == 2
+    assert dataset_7x7.grids.pixelization.over_sampling.sub_size == 4
 
 
 def test__new_imaging_with_arrays_trimmed_via_kernel_shape():
@@ -164,14 +164,14 @@ def test__apply_over_sampling(image_7x7, noise_map_7x7):
     # The grid and grid_pixelizaiton are a cached_property which needs to be reset,
     # Which the code below tests.
 
-    grid_sub_2 = dataset_7x7.grid
-    grid_pixelization_sub_2 = dataset_7x7.grid_pixelization
+    grid_sub_2 = dataset_7x7.grids.uniform
+    grid_pixelization_sub_2 = dataset_7x7.grids.pixelization
 
     dataset_7x7.__dict__["grid"][0][0] = 100.0
     dataset_7x7.__dict__["grid_pixelization"][0][0] = 100.0
 
-    assert dataset_7x7.grid[0][0] == pytest.approx(100.0, 1.0e-4)
-    assert dataset_7x7.grid_pixelization[0][0] == pytest.approx(100.0, 1.0e-4)
+    assert dataset_7x7.grids.uniform[0][0] == pytest.approx(100.0, 1.0e-4)
+    assert dataset_7x7.grids.pixelization[0][0] == pytest.approx(100.0, 1.0e-4)
 
     dataset_7x7 = dataset_7x7.apply_over_sampling(
         over_sampling=aa.OverSamplingDataset(
@@ -184,4 +184,4 @@ def test__apply_over_sampling(image_7x7, noise_map_7x7):
     assert dataset_7x7.over_sampling.pixelization.sub_size == 4
 
     assert dataset_7x7.grid[0][0] == pytest.approx(3.0, 1.0e-4)
-    assert dataset_7x7.grid_pixelization[0][0] == pytest.approx(3.0, 1.0e-4)
+    assert dataset_7x7.grids.pixelization[0][0] == pytest.approx(3.0, 1.0e-4)

--- a/test_autoarray/dataset/abstract/test_dataset.py
+++ b/test_autoarray/dataset/abstract/test_dataset.py
@@ -80,7 +80,9 @@ def test__grid__uses_mask_and_settings(
         over_sampling=aa.OverSamplingDataset(uniform=aa.OverSamplingIterate()),
     )
 
-    assert isinstance(masked_imaging_7x7.grids.uniform.over_sampling, aa.OverSamplingIterate)
+    assert isinstance(
+        masked_imaging_7x7.grids.uniform.over_sampling, aa.OverSamplingIterate
+    )
     assert (masked_imaging_7x7.grids.uniform == grid_2d_7x7).all()
 
 

--- a/test_autoarray/dataset/abstract/test_dataset.py
+++ b/test_autoarray/dataset/abstract/test_dataset.py
@@ -169,6 +169,8 @@ def test__apply_over_sampling(image_7x7, noise_map_7x7):
     grid_sub_2 = dataset_7x7.grids.uniform
     grid_pixelization_sub_2 = dataset_7x7.grids.pixelization
 
+    print(dataset_7x7.grids.__dict__)
+
     dataset_7x7.grids.__dict__["uniform"][0][0] = 100.0
     dataset_7x7.grids.__dict__["pixelization"][0][0] = 100.0
 

--- a/test_autoarray/dataset/plot/test_imaging_plotters.py
+++ b/test_autoarray/dataset/plot/test_imaging_plotters.py
@@ -34,22 +34,22 @@ def test__individual_attributes_are_output(
         noise_map=True,
         psf=True,
         signal_to_noise_map=True,
-        over_sampling_sub_size=True,
-        over_sampling_sub_size_non_uniform=True,
-        over_sampling_sub_size_pixelization=True,
+        over_sampling=True,
+        over_sampling_non_uniform=True,
+        over_sampling_pixelization=True,
     )
 
     assert path.join(plot_path, "data.png") in plot_patch.paths
     assert path.join(plot_path, "noise_map.png") in plot_patch.paths
     assert path.join(plot_path, "psf.png") in plot_patch.paths
     assert path.join(plot_path, "signal_to_noise_map.png") in plot_patch.paths
-    assert path.join(plot_path, "over_sampling_sub_size.png") in plot_patch.paths
+    assert path.join(plot_path, "over_sampling.png") in plot_patch.paths
     assert (
-        path.join(plot_path, "over_sampling_sub_size_non_uniform.png")
+        path.join(plot_path, "over_sampling_non_uniform.png")
         in plot_patch.paths
     )
     assert (
-        path.join(plot_path, "over_sampling_sub_size_pixelization.png")
+        path.join(plot_path, "over_sampling_pixelization.png")
         in plot_patch.paths
     )
 

--- a/test_autoarray/dataset/plot/test_imaging_plotters.py
+++ b/test_autoarray/dataset/plot/test_imaging_plotters.py
@@ -19,6 +19,10 @@ def test__individual_attributes_are_output(
 ):
     visuals = aplt.Visuals2D(mask=mask_2d_7x7, positions=grid_2d_irregular_7x7_list)
 
+    imaging_7x7.apply_over_sampling(
+        over_sampling_non_uniform=aa.OverSamplingUniform(sub_size=1)
+    )
+
     dataset_plotter = aplt.ImagingPlotter(
         dataset=imaging_7x7,
         visuals_2d=visuals,
@@ -31,6 +35,7 @@ def test__individual_attributes_are_output(
         psf=True,
         signal_to_noise_map=True,
         over_sampling_sub_size=True,
+        over_sampling_sub_size_non_uniform=True,
         over_sampling_sub_size_pixelization=True,
     )
 
@@ -39,6 +44,10 @@ def test__individual_attributes_are_output(
     assert path.join(plot_path, "psf.png") in plot_patch.paths
     assert path.join(plot_path, "signal_to_noise_map.png") in plot_patch.paths
     assert path.join(plot_path, "over_sampling_sub_size.png") in plot_patch.paths
+    assert (
+        path.join(plot_path, "over_sampling_sub_size_non_uniform.png")
+        in plot_patch.paths
+    )
     assert (
         path.join(plot_path, "over_sampling_sub_size_pixelization.png")
         in plot_patch.paths

--- a/test_autoarray/dataset/plot/test_imaging_plotters.py
+++ b/test_autoarray/dataset/plot/test_imaging_plotters.py
@@ -19,7 +19,7 @@ def test__individual_attributes_are_output(
 ):
     visuals = aplt.Visuals2D(mask=mask_2d_7x7, positions=grid_2d_irregular_7x7_list)
 
-    imaging_7x7.apply_over_sampling(
+    imaging_7x7 = imaging_7x7.apply_over_sampling(
         over_sampling=aa.OverSamplingDataset(
             non_uniform=aa.OverSamplingUniform(sub_size=1)
         )

--- a/test_autoarray/dataset/plot/test_imaging_plotters.py
+++ b/test_autoarray/dataset/plot/test_imaging_plotters.py
@@ -44,14 +44,8 @@ def test__individual_attributes_are_output(
     assert path.join(plot_path, "psf.png") in plot_patch.paths
     assert path.join(plot_path, "signal_to_noise_map.png") in plot_patch.paths
     assert path.join(plot_path, "over_sampling.png") in plot_patch.paths
-    assert (
-        path.join(plot_path, "over_sampling_non_uniform.png")
-        in plot_patch.paths
-    )
-    assert (
-        path.join(plot_path, "over_sampling_pixelization.png")
-        in plot_patch.paths
-    )
+    assert path.join(plot_path, "over_sampling_non_uniform.png") in plot_patch.paths
+    assert path.join(plot_path, "over_sampling_pixelization.png") in plot_patch.paths
 
     plot_patch.paths = []
 

--- a/test_autoarray/dataset/plot/test_imaging_plotters.py
+++ b/test_autoarray/dataset/plot/test_imaging_plotters.py
@@ -20,7 +20,9 @@ def test__individual_attributes_are_output(
     visuals = aplt.Visuals2D(mask=mask_2d_7x7, positions=grid_2d_irregular_7x7_list)
 
     imaging_7x7.apply_over_sampling(
-        over_sampling_non_uniform=aa.OverSamplingUniform(sub_size=1)
+        over_sampling=aa.OverSamplingDataset(
+            non_uniform=aa.OverSamplingUniform(sub_size=1)
+        )
     )
 
     dataset_plotter = aplt.ImagingPlotter(

--- a/test_autoarray/fit/test_fit_dataset.py
+++ b/test_autoarray/fit/test_fit_dataset.py
@@ -74,5 +74,5 @@ def test__grid_offset_via_data_model(masked_imaging_7x7, model_image_7x7):
 
     assert fit.dataset_model.grid_offset == (1.0, 2.0)
 
-    assert fit.grid[0] == pytest.approx((0.0, -3.0), 1.0e-4)
-    assert fit.grid_pixelization[0] == pytest.approx((0.0, -3.0), 1.0e-4)
+    assert fit.grids.uniform[0] == pytest.approx((0.0, -3.0), 1.0e-4)
+    assert fit.grids.pixelization[0] == pytest.approx((0.0, -3.0), 1.0e-4)


### PR DESCRIPTION
Refactors over sampling and implements an additional form which computes lensed source emission on a non-uniform over sampled grid input by a user, as described in the following example:

https://github.com/Jammy2211/autolens_workspace/blob/main/scripts/imaging/advanced/chaining/examples/over_sample.py