### PR TITLE
Voronoi Test Skipping

### DIFF
--- a/autoarray/util/nn/nn_py.py
+++ b/autoarray/util/nn/nn_py.py
@@ -106,5 +106,3 @@ try:
 except OSError:
     print("natural neighbour interpolation not loaded.")
     raise ImportError
-
-natural_interpolation_weights

--- a/autoarray/util/nn/nn_py.py
+++ b/autoarray/util/nn/nn_py.py
@@ -105,4 +105,6 @@ try:
 
 except OSError:
     print("natural neighbour interpolation not loaded.")
-    pass
+    raise ImportError
+
+natural_interpolation_weights

--- a/test_autoarray/inversion/inversion/test_factory.py
+++ b/test_autoarray/inversion/inversion/test_factory.py
@@ -60,7 +60,6 @@ def test__inversion_imaging__via_mapper(
     masked_imaging_7x7_no_blur,
     rectangular_mapper_7x7_3x3,
     delaunay_mapper_9_3x3,
-    voronoi_mapper_9_3x3,
 ):
     inversion = aa.Inversion(
         dataset=masked_imaging_7x7_no_blur,
@@ -148,48 +147,43 @@ def test__inversion_imaging__via_regularizations(
     )
     assert inversion.mapped_reconstructed_image == pytest.approx(np.ones(9), 1.0e-4)
 
-    # Have to do this because NN library is optional.
+    pytest.importorskip("autoarray.util.nn.nn_py", reason="Voronoi C library not installed, see util.nn README.md")
 
-    try:
-        mapper = copy.copy(voronoi_mapper_9_3x3)
-        mapper.regularization = regularization_constant
+    mapper = copy.copy(voronoi_mapper_9_3x3)
+    mapper.regularization = regularization_constant
 
-        inversion = aa.Inversion(
-            dataset=masked_imaging_7x7_no_blur,
-            linear_obj_list=[mapper],
-            settings=aa.SettingsInversion(use_w_tilde=True),
-        )
+    inversion = aa.Inversion(
+        dataset=masked_imaging_7x7_no_blur,
+        linear_obj_list=[mapper],
+        settings=aa.SettingsInversion(use_w_tilde=True),
+    )
 
-        assert isinstance(inversion.linear_obj_list[0], aa.MapperVoronoi)
-        assert inversion.log_det_curvature_reg_matrix_term == pytest.approx(
-            10.66505, 1.0e-4
-        )
-        assert inversion.mapped_reconstructed_image == pytest.approx(np.ones(9), 1.0e-4)
+    assert isinstance(inversion.linear_obj_list[0], aa.MapperVoronoi)
+    assert inversion.log_det_curvature_reg_matrix_term == pytest.approx(
+        10.66505, 1.0e-4
+    )
+    assert inversion.mapped_reconstructed_image == pytest.approx(np.ones(9), 1.0e-4)
 
-        mapper = copy.copy(voronoi_mapper_9_3x3)
-        mapper.regularization = regularization_constant_split
+    mapper = copy.copy(voronoi_mapper_9_3x3)
+    mapper.regularization = regularization_constant_split
 
-        inversion = aa.Inversion(
-            dataset=masked_imaging_7x7_no_blur,
-            linear_obj_list=[mapper],
-            settings=aa.SettingsInversion(use_w_tilde=True),
-        )
+    inversion = aa.Inversion(
+        dataset=masked_imaging_7x7_no_blur,
+        linear_obj_list=[mapper],
+        settings=aa.SettingsInversion(use_w_tilde=True),
+    )
 
-        assert isinstance(inversion.linear_obj_list[0], aa.MapperVoronoi)
-        assert inversion.log_det_curvature_reg_matrix_term == pytest.approx(
-            10.37955, 1.0e-4
-        )
-        assert inversion.mapped_reconstructed_image == pytest.approx(np.ones(9), 1.0e-4)
-
-    except AttributeError:
-        pass
+    assert isinstance(inversion.linear_obj_list[0], aa.MapperVoronoi)
+    assert inversion.log_det_curvature_reg_matrix_term == pytest.approx(
+        10.37955, 1.0e-4
+    )
+    assert inversion.mapped_reconstructed_image == pytest.approx(np.ones(9), 1.0e-4)
 
 
 def test__inversion_imaging__via_linear_obj_func_and_mapper(
     masked_imaging_7x7_no_blur,
     rectangular_mapper_7x7_3x3,
     delaunay_mapper_9_3x3,
-    voronoi_mapper_9_3x3,
 ):
     mask = masked_imaging_7x7_no_blur.mask
 
@@ -226,8 +220,9 @@ def test__inversion_imaging__via_linear_obj_func_and_mapper(
 
 def test__inversion_imaging__via_linear_obj_func_and_mapper__force_edge_pixels_to_zero(
     masked_imaging_7x7_no_blur,
-    voronoi_mapper_9_3x3,
+    delaunay_mapper_9_3x3
 ):
+
     mask = masked_imaging_7x7_no_blur.mask
 
     grid = aa.Grid2D.from_mask(mask=mask)
@@ -241,7 +236,7 @@ def test__inversion_imaging__via_linear_obj_func_and_mapper__force_edge_pixels_t
 
     inversion = aa.Inversion(
         dataset=masked_imaging_7x7_no_blur,
-        linear_obj_list=[linear_obj, voronoi_mapper_9_3x3],
+        linear_obj_list=[linear_obj, delaunay_mapper_9_3x3],
         settings=aa.SettingsInversion(
             use_w_tilde=False,
             no_regularization_add_to_curvature_diag_value=False,
@@ -250,12 +245,12 @@ def test__inversion_imaging__via_linear_obj_func_and_mapper__force_edge_pixels_t
     )
 
     assert isinstance(inversion.linear_obj_list[0], aa.m.MockLinearObj)
-    assert isinstance(inversion.linear_obj_list[1], aa.MapperVoronoi)
+    assert isinstance(inversion.linear_obj_list[1], aa.MapperDelaunay)
     assert isinstance(inversion, aa.InversionImagingMapping)
 
     inversion = aa.Inversion(
         dataset=masked_imaging_7x7_no_blur,
-        linear_obj_list=[linear_obj, voronoi_mapper_9_3x3],
+        linear_obj_list=[linear_obj, delaunay_mapper_9_3x3],
         settings=aa.SettingsInversion(
             use_w_tilde=False,
             use_positive_only_solver=True,
@@ -265,7 +260,7 @@ def test__inversion_imaging__via_linear_obj_func_and_mapper__force_edge_pixels_t
     )
 
     assert isinstance(inversion.linear_obj_list[0], aa.m.MockLinearObj)
-    assert isinstance(inversion.linear_obj_list[1], aa.MapperVoronoi)
+    assert isinstance(inversion.linear_obj_list[1], aa.MapperDelaunay)
     assert isinstance(inversion, aa.InversionImagingMapping)
     assert inversion.reconstruction == pytest.approx(
         np.array([2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]), 1.0e-4
@@ -273,17 +268,17 @@ def test__inversion_imaging__via_linear_obj_func_and_mapper__force_edge_pixels_t
 
 
 def test__inversion_imaging__compare_mapping_and_w_tilde_values(
-    masked_imaging_7x7, voronoi_mapper_9_3x3
+    masked_imaging_7x7, delaunay_mapper_9_3x3
 ):
     inversion_w_tilde = aa.Inversion(
         dataset=masked_imaging_7x7,
-        linear_obj_list=[voronoi_mapper_9_3x3],
+        linear_obj_list=[delaunay_mapper_9_3x3],
         settings=aa.SettingsInversion(use_w_tilde=True),
     )
 
     inversion_mapping = aa.Inversion(
         dataset=masked_imaging_7x7,
-        linear_obj_list=[voronoi_mapper_9_3x3],
+        linear_obj_list=[delaunay_mapper_9_3x3],
         settings=aa.SettingsInversion(use_w_tilde=False),
     )
 
@@ -304,8 +299,6 @@ def test__inversion_imaging__compare_mapping_and_w_tilde_values(
 def test__inversion_imaging__linear_obj_func_and_non_func_give_same_terms(
     masked_imaging_7x7_no_blur,
     rectangular_mapper_7x7_3x3,
-    delaunay_mapper_9_3x3,
-    voronoi_mapper_9_3x3,
 ):
     masked_imaging_7x7_no_blur = copy.copy(masked_imaging_7x7_no_blur)
     masked_imaging_7x7_no_blur.data[4] = 2.0
@@ -351,7 +344,6 @@ def test__inversion_imaging__linear_obj_func_with_w_tilde(
     masked_imaging_7x7,
     rectangular_mapper_7x7_3x3,
     delaunay_mapper_9_3x3,
-    voronoi_mapper_9_3x3,
 ):
     masked_imaging_7x7 = copy.copy(masked_imaging_7x7)
     masked_imaging_7x7.data[4] = 2.0
@@ -408,7 +400,6 @@ def test__inversion_imaging__linear_obj_func_with_w_tilde(
             linear_obj,
             delaunay_mapper_9_3x3,
             linear_obj_1,
-            voronoi_mapper_9_3x3,
             linear_obj_2,
         ],
         settings=aa.SettingsInversion(use_w_tilde=False),
@@ -421,7 +412,6 @@ def test__inversion_imaging__linear_obj_func_with_w_tilde(
             linear_obj,
             delaunay_mapper_9_3x3,
             linear_obj_1,
-            voronoi_mapper_9_3x3,
             linear_obj_2,
         ],
         settings=aa.SettingsInversion(use_w_tilde=True),
@@ -439,7 +429,6 @@ def test__inversion_imaging__linear_obj_func_with_w_tilde__include_preload_data_
     masked_imaging_7x7,
     rectangular_mapper_7x7_3x3,
     delaunay_mapper_9_3x3,
-    voronoi_mapper_9_3x3,
 ):
     masked_imaging_7x7 = copy.copy(masked_imaging_7x7)
     masked_imaging_7x7.data[4] = 2.0
@@ -474,7 +463,6 @@ def test__inversion_imaging__linear_obj_func_with_w_tilde__include_preload_data_
             linear_obj,
             delaunay_mapper_9_3x3,
             linear_obj_1,
-            voronoi_mapper_9_3x3,
             linear_obj_2,
         ],
         settings=aa.SettingsInversion(use_w_tilde=False),
@@ -491,7 +479,6 @@ def test__inversion_imaging__linear_obj_func_with_w_tilde__include_preload_data_
             linear_obj,
             delaunay_mapper_9_3x3,
             linear_obj_1,
-            voronoi_mapper_9_3x3,
             linear_obj_2,
         ],
         preloads=preloads,
@@ -510,7 +497,6 @@ def test__inversion_imaging__linear_obj_func_with_w_tilde__include_preload_mappe
     masked_imaging_7x7,
     rectangular_mapper_7x7_3x3,
     delaunay_mapper_9_3x3,
-    voronoi_mapper_9_3x3,
 ):
     masked_imaging_7x7 = copy.copy(masked_imaging_7x7)
     masked_imaging_7x7.data[4] = 2.0
@@ -545,7 +531,6 @@ def test__inversion_imaging__linear_obj_func_with_w_tilde__include_preload_mappe
             linear_obj,
             delaunay_mapper_9_3x3,
             linear_obj_1,
-            voronoi_mapper_9_3x3,
             linear_obj_2,
         ],
         settings=aa.SettingsInversion(use_w_tilde=False),
@@ -562,7 +547,6 @@ def test__inversion_imaging__linear_obj_func_with_w_tilde__include_preload_mappe
             linear_obj,
             delaunay_mapper_9_3x3,
             linear_obj_1,
-            voronoi_mapper_9_3x3,
             linear_obj_2,
         ],
         preloads=preloads,
@@ -582,7 +566,6 @@ def test__inversion_interferometer__via_mapper(
     interferometer_7_no_fft,
     rectangular_mapper_7x7_3x3,
     delaunay_mapper_9_3x3,
-    voronoi_mapper_9_3x3,
 ):
     inversion = aa.Inversion(
         dataset=interferometer_7_no_fft,
@@ -620,12 +603,12 @@ def test__inversion_interferometer__via_mapper(
 def test__inversion_matrices__x2_mappers(
     masked_imaging_7x7_no_blur,
     rectangular_mapper_7x7_3x3,
-    voronoi_mapper_9_3x3,
+    delaunay_mapper_9_3x3,
     regularization_constant,
 ):
     inversion = aa.Inversion(
         dataset=masked_imaging_7x7_no_blur,
-        linear_obj_list=[rectangular_mapper_7x7_3x3, voronoi_mapper_9_3x3],
+        linear_obj_list=[rectangular_mapper_7x7_3x3, delaunay_mapper_9_3x3],
     )
 
     assert (
@@ -634,11 +617,11 @@ def test__inversion_matrices__x2_mappers(
     ).all()
     assert (
         inversion.operated_mapping_matrix[0:9, 9:18]
-        == voronoi_mapper_9_3x3.mapping_matrix
+        == delaunay_mapper_9_3x3.mapping_matrix
     ).all()
 
     operated_mapping_matrix = np.hstack(
-        [rectangular_mapper_7x7_3x3.mapping_matrix, voronoi_mapper_9_3x3.mapping_matrix]
+        [rectangular_mapper_7x7_3x3.mapping_matrix, delaunay_mapper_9_3x3.mapping_matrix]
     )
 
     assert inversion.operated_mapping_matrix == pytest.approx(
@@ -655,7 +638,7 @@ def test__inversion_matrices__x2_mappers(
         linear_obj=rectangular_mapper_7x7_3x3
     )
     regularization_matrix_of_reg_1 = regularization_constant.regularization_matrix_from(
-        linear_obj=voronoi_mapper_9_3x3
+        linear_obj=delaunay_mapper_9_3x3
     )
 
     assert (
@@ -674,7 +657,7 @@ def test__inversion_matrices__x2_mappers(
     assert inversion.reconstruction_dict[rectangular_mapper_7x7_3x3] == pytest.approx(
         reconstruction_0, 1.0e-4
     )
-    assert inversion.reconstruction_dict[voronoi_mapper_9_3x3] == pytest.approx(
+    assert inversion.reconstruction_dict[delaunay_mapper_9_3x3] == pytest.approx(
         reconstruction_1, 1.0e-4
     )
     assert inversion.reconstruction == pytest.approx(
@@ -685,7 +668,7 @@ def test__inversion_matrices__x2_mappers(
         rectangular_mapper_7x7_3x3
     ] == pytest.approx(0.5 * np.ones(9), 1.0e-4)
     assert inversion.mapped_reconstructed_data_dict[
-        voronoi_mapper_9_3x3
+        delaunay_mapper_9_3x3
     ] == pytest.approx(0.5 * np.ones(9), 1.0e-4)
     assert inversion.mapped_reconstructed_image == pytest.approx(np.ones(9), 1.0e-4)
 

--- a/test_autoarray/inversion/pixelization/mappers/test_factory.py
+++ b/test_autoarray/inversion/pixelization/mappers/test_factory.py
@@ -114,6 +114,9 @@ def test__delaunay_mapper():
 
 
 def test__voronoi_mapper():
+
+    pytest.importorskip("autoarray.util.nn.nn_py", reason="Voronoi C library not installed, see util.nn README.md")
+
     mask = aa.Mask2D(
         mask=[
             [True, True, True, True, True],
@@ -150,8 +153,6 @@ def test__voronoi_mapper():
 
     assert (mapper.source_plane_mesh_grid == image_plane_mesh_grid).all()
     assert mapper.source_plane_mesh_grid.origin == pytest.approx((0.0, 0.0), 1.0e-4)
-
-    print(mapper.mapping_matrix)
 
     assert mapper.mapping_matrix == pytest.approx(
         np.array(

--- a/test_autoarray/inversion/pixelization/mappers/test_voronoi.py
+++ b/test_autoarray/inversion/pixelization/mappers/test_voronoi.py
@@ -1,4 +1,5 @@
-import numpy as np
+import pytest
+
 import autoarray as aa
 
 
@@ -24,23 +25,20 @@ def test__pix_indexes_for_sub_slim_index__matches_util(grid_2d_7x7):
         source_plane_data_grid=grid_2d_7x7,
         source_plane_mesh_grid=source_plane_mesh_grid,
     )
+    pytest.importorskip("autoarray.util.nn.nn_py", reason="Voronoi C library not installed, see util.nn README.md")
 
-    try:
-        mapper = aa.Mapper(
-            mapper_grids=mapper_grids, over_sampler=over_sampler, regularization=None
-        )
+    mapper = aa.Mapper(
+        mapper_grids=mapper_grids, over_sampler=over_sampler, regularization=None
+    )
 
-        (
-            pix_indexes_for_sub_slim_index_util,
-            sizes,
-            weights,
-        ) = aa.util.mapper.pix_size_weights_voronoi_nn_from(
-            grid=grid_2d_7x7, mesh_grid=source_plane_mesh_grid
-        )
+    (
+        pix_indexes_for_sub_slim_index_util,
+        sizes,
+        weights,
+    ) = aa.util.mapper.pix_size_weights_voronoi_nn_from(
+        grid=grid_2d_7x7, mesh_grid=source_plane_mesh_grid
+    )
 
-        assert (
-            mapper.pix_indexes_for_sub_slim_index == pix_indexes_for_sub_slim_index_util
-        ).all()
-
-    except AttributeError:
-        pass
+    assert (
+        mapper.pix_indexes_for_sub_slim_index == pix_indexes_for_sub_slim_index_util
+    ).all()

--- a/test_autoarray/inversion/plot/test_inversion_plotters.py
+++ b/test_autoarray/inversion/plot/test_inversion_plotters.py
@@ -46,6 +46,8 @@ def test__individual_attributes_are_output_for_all_mappers(
     assert path.join(plot_path, "errors.png") in plot_patch.paths
     assert path.join(plot_path, "regularization_weights.png") in plot_patch.paths
 
+    pytest.importorskip("autoarray.util.nn.nn_py", reason="Voronoi C library not installed, see util.nn README.md")
+
     plot_patch.paths = []
 
     inversion_plotter = aplt.InversionPlotter(
@@ -88,12 +90,12 @@ def test__individual_attributes_are_output_for_all_mappers(
 
 def test__inversion_subplot_of_mapper__is_output_for_all_inversions(
     imaging_7x7,
-    voronoi_inversion_9_3x3,
+    rectangular_inversion_7x7_3x3,
     plot_path,
     plot_patch,
 ):
     inversion_plotter = aplt.InversionPlotter(
-        inversion=voronoi_inversion_9_3x3,
+        inversion=rectangular_inversion_7x7_3x3,
         visuals_2d=aplt.Visuals2D(indexes=[0], pix_indexes=[1]),
         mat_plot_2d=aplt.MatPlot2D(output=aplt.Output(path=plot_path, format="png")),
     )

--- a/test_autoarray/inversion/plot/test_mapper_plotters.py
+++ b/test_autoarray/inversion/plot/test_mapper_plotters.py
@@ -136,7 +136,7 @@ def test__figure_2d(
 
     assert path.join(plot_path, "mapper1.png") in plot_patch.paths
 
-    pytest.importorskip("autoarray.util.nn.nn_py")
+    pytest.importorskip("autoarray.util.nn.nn_py", reason="Voronoi C library not installed, see util.nn README.md")
 
     plot_patch.paths = []
 
@@ -184,7 +184,7 @@ def test__subplot_image_and_mapper(
     mapper_plotter.subplot_image_and_mapper(image=imaging_7x7.data)
     assert path.join(plot_path, "subplot_image_and_mapper.png") in plot_patch.paths
 
-    pytest.importorskip("autoarray.util.nn.nn_py")
+    pytest.importorskip("autoarray.util.nn.nn_py", reason="Voronoi C library not installed, see util.nn README.md")
 
     plot_patch.paths = []
 

--- a/test_autoarray/inversion/plot/test_mapper_plotters.py
+++ b/test_autoarray/inversion/plot/test_mapper_plotters.py
@@ -136,6 +136,8 @@ def test__figure_2d(
 
     assert path.join(plot_path, "mapper1.png") in plot_patch.paths
 
+    pytest.importorskip("autoarray.util.nn.nn_py")
+
     plot_patch.paths = []
 
     mapper_plotter = aplt.MapperPlotter(
@@ -181,6 +183,8 @@ def test__subplot_image_and_mapper(
 
     mapper_plotter.subplot_image_and_mapper(image=imaging_7x7.data)
     assert path.join(plot_path, "subplot_image_and_mapper.png") in plot_patch.paths
+
+    pytest.importorskip("autoarray.util.nn.nn_py")
 
     plot_patch.paths = []
 

--- a/test_autoarray/util/test_nn.py
+++ b/test_autoarray/util/test_nn.py
@@ -1,9 +1,14 @@
 import autoarray as aa
 import numpy as np
-from autoarray.util.nn import nn_py
 
+import pytest
 
 def test__returning_weights_correct():
+
+    pytest.importorskip("autoarray.util.nn.nn_py", reason="Voronoi C library not installed, see util.nn README.md")
+
+    from autoarray.util.nn import nn_py
+
     mesh_grid = aa.Grid2D.no_mask(
         values=[
             [1.0, 1.0],
@@ -26,39 +31,41 @@ def test__returning_weights_correct():
 
     max_nneighbours = int(30)
 
-    try:
-        weights, neighbour_indexes = nn_py.natural_interpolation_weights(
-            mesh_grid[:, 1],
-            mesh_grid[:, 0],
-            interpolate_grid[:, 1],
-            interpolate_grid[:, 0],
-            max_nneighbours,
-        )
+    weights, neighbour_indexes = nn_py.natural_interpolation_weights(
+        mesh_grid[:, 1],
+        mesh_grid[:, 0],
+        interpolate_grid[:, 1],
+        interpolate_grid[:, 0],
+        max_nneighbours,
+    )
 
-        weights_answer = np.zeros((2, max_nneighbours))
-        weights_answer[0][:4] = 0.25
-        weights_answer[1][:4] = 0.25
+    weights_answer = np.zeros((2, max_nneighbours))
+    weights_answer[0][:4] = 0.25
+    weights_answer[1][:4] = 0.25
 
-        indexes_answer = np.zeros((2, max_nneighbours), dtype=np.intc) - 1
-        indexes_answer[0][0] = 7
-        indexes_answer[0][1] = 1
-        indexes_answer[0][2] = 0
-        indexes_answer[0][3] = 8
+    indexes_answer = np.zeros((2, max_nneighbours), dtype=np.intc) - 1
+    indexes_answer[0][0] = 7
+    indexes_answer[0][1] = 1
+    indexes_answer[0][2] = 0
+    indexes_answer[0][3] = 8
 
-        indexes_answer[1][0] = 8
-        indexes_answer[1][1] = 2
-        indexes_answer[1][2] = 1
-        indexes_answer[1][3] = 3
+    indexes_answer[1][0] = 8
+    indexes_answer[1][1] = 2
+    indexes_answer[1][2] = 1
+    indexes_answer[1][3] = 3
 
-        assert (neighbour_indexes == indexes_answer).all()
+    assert (neighbour_indexes == indexes_answer).all()
 
-        assert (weights == weights_answer).all()
+    assert (weights == weights_answer).all()
 
-    except AttributeError:
-        pass
 
 
 def test__nn_interpolation_correct():
+
+    pytest.importorskip("autoarray.util.nn.nn_py", reason="Voronoi C library not installed, see util.nn README.md")
+
+    from autoarray.util.nn import nn_py
+
     mesh_grid = aa.Grid2D.no_mask(
         values=[
             [1.0, 1.0],
@@ -83,18 +90,14 @@ def test__nn_interpolation_correct():
         pixel_scales=1.0,
     )
 
-    try:
-        interpolated_values = nn_py.natural_interpolation(
-            mesh_grid[:, 1],
-            mesh_grid[:, 0],
-            input_values,
-            interpolate_grid[:, 1],
-            interpolate_grid[:, 0],
-        )
+    interpolated_values = nn_py.natural_interpolation(
+        mesh_grid[:, 1],
+        mesh_grid[:, 0],
+        input_values,
+        interpolate_grid[:, 1],
+        interpolate_grid[:, 0],
+    )
 
-        answer = np.array([5.0, 4.5, 1.0])
+    answer = np.array([5.0, 4.5, 1.0])
 
-        assert (interpolated_values == answer).all()
-
-    except AttributeError:
-        pass
+    assert (interpolated_values == answer).all()


### PR DESCRIPTION
Updates unit tests so that if a user does not have the Voronoi NN library installed, pytest skips the appropriate tests.