### PR TITLE
Feature/visualization title

### DIFF
--- a/autoarray/dataset/plot/interferometer_plotters.py
+++ b/autoarray/dataset/plot/interferometer_plotters.py
@@ -164,6 +164,9 @@ class InterferometerPlotter(Plotter):
             )
 
         if amplitudes_vs_uv_distances:
+            print(self.mat_plot_2d.title.prefix)
+            print(self.mat_plot_1d.title.prefix)
+
             self.mat_plot_1d.plot_yx(
                 y=self.dataset.amplitudes,
                 x=self.dataset.uv_distances / 10**3.0,

--- a/autoarray/inversion/inversion/interferometer/lop.py
+++ b/autoarray/inversion/inversion/interferometer/lop.py
@@ -58,7 +58,9 @@ class InversionInterferometerMappingPyLops(AbstractInversionInterferometer):
                 epsNRs=[1.0],
                 data=self.data.ordered_1d,
                 Weight=pylops.Diagonal(diag=self.noise_map.weight_list_ordered_1d),
-                NRegs=[pylops.MatrixMult(sparse.bsr_matrix(self.regularization_matrix))],
+                NRegs=[
+                    pylops.MatrixMult(sparse.bsr_matrix(self.regularization_matrix))
+                ],
                 M=MOp,
                 tol=self.settings.tolerance,
                 atol=self.settings.tolerance,
@@ -71,13 +73,14 @@ class InversionInterferometerMappingPyLops(AbstractInversionInterferometer):
                 epsNRs=[1.0],
                 y=self.data.ordered_1d,
                 Weight=pylops.Diagonal(diag=self.noise_map.weight_list_ordered_1d),
-                NRegs=[pylops.MatrixMult(sparse.bsr_matrix(self.regularization_matrix))],
+                NRegs=[
+                    pylops.MatrixMult(sparse.bsr_matrix(self.regularization_matrix))
+                ],
                 M=MOp,
                 tol=self.settings.tolerance,
                 atol=self.settings.tolerance,
                 **dict(maxiter=self.settings.maxiter),
             )[0]
-
 
     @property
     @profile_func

--- a/autoarray/plot/wrap/base/title.py
+++ b/autoarray/plot/wrap/base/title.py
@@ -4,7 +4,7 @@ from autoarray.plot.wrap.base.abstract import AbstractMatWrap
 
 
 class Title(AbstractMatWrap):
-    def __init__(self, **kwargs):
+    def __init__(self, prefix : str = None, **kwargs):
         """
         The settings used to customize the figure's title.
 
@@ -13,16 +13,25 @@ class Title(AbstractMatWrap):
         - plt.title: https://matplotlib.org/3.3.2/api/_as_gen/matplotlib.pyplot.title.html
 
         The title will automatically be set if not specified, using the name of the function used to plot the data.
+        
+        Parameters
+        ----------
+        prefix
+            A string that is added before the title, for example to put the name of the dataset and galaxy in the title.
         """
 
         super().__init__(**kwargs)
 
+        self.prefix = prefix
         self.manual_label = self.kwargs.get("label")
 
     def set(self, auto_title=None, use_log10: bool = False):
         config_dict = self.config_dict
 
         label = auto_title if self.manual_label is None else self.manual_label
+
+        if self.prefix is not None:
+            label = f"{self.prefix} {label}"
 
         if use_log10:
             label = f"{label} (log10)"

--- a/autoarray/plot/wrap/base/title.py
+++ b/autoarray/plot/wrap/base/title.py
@@ -4,7 +4,7 @@ from autoarray.plot.wrap.base.abstract import AbstractMatWrap
 
 
 class Title(AbstractMatWrap):
-    def __init__(self, prefix : str = None, **kwargs):
+    def __init__(self, prefix: str = None, **kwargs):
         """
         The settings used to customize the figure's title.
 
@@ -13,7 +13,7 @@ class Title(AbstractMatWrap):
         - plt.title: https://matplotlib.org/3.3.2/api/_as_gen/matplotlib.pyplot.title.html
 
         The title will automatically be set if not specified, using the name of the function used to plot the data.
-        
+
         Parameters
         ----------
         prefix

--- a/test_autoarray/inversion/inversion/test_factory.py
+++ b/test_autoarray/inversion/inversion/test_factory.py
@@ -147,7 +147,10 @@ def test__inversion_imaging__via_regularizations(
     )
     assert inversion.mapped_reconstructed_image == pytest.approx(np.ones(9), 1.0e-4)
 
-    pytest.importorskip("autoarray.util.nn.nn_py", reason="Voronoi C library not installed, see util.nn README.md")
+    pytest.importorskip(
+        "autoarray.util.nn.nn_py",
+        reason="Voronoi C library not installed, see util.nn README.md",
+    )
 
     mapper = copy.copy(voronoi_mapper_9_3x3)
     mapper.regularization = regularization_constant
@@ -219,10 +222,8 @@ def test__inversion_imaging__via_linear_obj_func_and_mapper(
 
 
 def test__inversion_imaging__via_linear_obj_func_and_mapper__force_edge_pixels_to_zero(
-    masked_imaging_7x7_no_blur,
-    delaunay_mapper_9_3x3
+    masked_imaging_7x7_no_blur, delaunay_mapper_9_3x3
 ):
-
     mask = masked_imaging_7x7_no_blur.mask
 
     grid = aa.Grid2D.from_mask(mask=mask)
@@ -621,7 +622,10 @@ def test__inversion_matrices__x2_mappers(
     ).all()
 
     operated_mapping_matrix = np.hstack(
-        [rectangular_mapper_7x7_3x3.mapping_matrix, delaunay_mapper_9_3x3.mapping_matrix]
+        [
+            rectangular_mapper_7x7_3x3.mapping_matrix,
+            delaunay_mapper_9_3x3.mapping_matrix,
+        ]
     )
 
     assert inversion.operated_mapping_matrix == pytest.approx(

--- a/test_autoarray/inversion/pixelization/mappers/test_factory.py
+++ b/test_autoarray/inversion/pixelization/mappers/test_factory.py
@@ -114,8 +114,10 @@ def test__delaunay_mapper():
 
 
 def test__voronoi_mapper():
-
-    pytest.importorskip("autoarray.util.nn.nn_py", reason="Voronoi C library not installed, see util.nn README.md")
+    pytest.importorskip(
+        "autoarray.util.nn.nn_py",
+        reason="Voronoi C library not installed, see util.nn README.md",
+    )
 
     mask = aa.Mask2D(
         mask=[

--- a/test_autoarray/inversion/pixelization/mappers/test_voronoi.py
+++ b/test_autoarray/inversion/pixelization/mappers/test_voronoi.py
@@ -25,7 +25,10 @@ def test__pix_indexes_for_sub_slim_index__matches_util(grid_2d_7x7):
         source_plane_data_grid=grid_2d_7x7,
         source_plane_mesh_grid=source_plane_mesh_grid,
     )
-    pytest.importorskip("autoarray.util.nn.nn_py", reason="Voronoi C library not installed, see util.nn README.md")
+    pytest.importorskip(
+        "autoarray.util.nn.nn_py",
+        reason="Voronoi C library not installed, see util.nn README.md",
+    )
 
     mapper = aa.Mapper(
         mapper_grids=mapper_grids, over_sampler=over_sampler, regularization=None

--- a/test_autoarray/inversion/plot/test_inversion_plotters.py
+++ b/test_autoarray/inversion/plot/test_inversion_plotters.py
@@ -46,7 +46,10 @@ def test__individual_attributes_are_output_for_all_mappers(
     assert path.join(plot_path, "errors.png") in plot_patch.paths
     assert path.join(plot_path, "regularization_weights.png") in plot_patch.paths
 
-    pytest.importorskip("autoarray.util.nn.nn_py", reason="Voronoi C library not installed, see util.nn README.md")
+    pytest.importorskip(
+        "autoarray.util.nn.nn_py",
+        reason="Voronoi C library not installed, see util.nn README.md",
+    )
 
     plot_patch.paths = []
 

--- a/test_autoarray/inversion/plot/test_mapper_plotters.py
+++ b/test_autoarray/inversion/plot/test_mapper_plotters.py
@@ -136,7 +136,10 @@ def test__figure_2d(
 
     assert path.join(plot_path, "mapper1.png") in plot_patch.paths
 
-    pytest.importorskip("autoarray.util.nn.nn_py", reason="Voronoi C library not installed, see util.nn README.md")
+    pytest.importorskip(
+        "autoarray.util.nn.nn_py",
+        reason="Voronoi C library not installed, see util.nn README.md",
+    )
 
     plot_patch.paths = []
 
@@ -184,7 +187,10 @@ def test__subplot_image_and_mapper(
     mapper_plotter.subplot_image_and_mapper(image=imaging_7x7.data)
     assert path.join(plot_path, "subplot_image_and_mapper.png") in plot_patch.paths
 
-    pytest.importorskip("autoarray.util.nn.nn_py", reason="Voronoi C library not installed, see util.nn README.md")
+    pytest.importorskip(
+        "autoarray.util.nn.nn_py",
+        reason="Voronoi C library not installed, see util.nn README.md",
+    )
 
     plot_patch.paths = []
 

--- a/test_autoarray/util/test_nn.py
+++ b/test_autoarray/util/test_nn.py
@@ -3,9 +3,12 @@ import numpy as np
 
 import pytest
 
-def test__returning_weights_correct():
 
-    pytest.importorskip("autoarray.util.nn.nn_py", reason="Voronoi C library not installed, see util.nn README.md")
+def test__returning_weights_correct():
+    pytest.importorskip(
+        "autoarray.util.nn.nn_py",
+        reason="Voronoi C library not installed, see util.nn README.md",
+    )
 
     from autoarray.util.nn import nn_py
 
@@ -59,10 +62,11 @@ def test__returning_weights_correct():
     assert (weights == weights_answer).all()
 
 
-
 def test__nn_interpolation_correct():
-
-    pytest.importorskip("autoarray.util.nn.nn_py", reason="Voronoi C library not installed, see util.nn README.md")
+    pytest.importorskip(
+        "autoarray.util.nn.nn_py",
+        reason="Voronoi C library not installed, see util.nn README.md",
+    )
 
     from autoarray.util.nn import nn_py
 


### PR DESCRIPTION
Allows you input into all `Analysis` objects a `title_prefix` which is appended before the title of all visualization, so that the name of a dataset or object can be included:

`analysis = al.AnalysisImaging(dataset=dataset, title_prefix="Lens Name")`

![image](https://github.com/user-attachments/assets/71b7ae2a-ffb8-4ae5-9a66-164a7dfab0c1)
