### PR TITLE
Adjust numpy to jax.numpy imports for files used for the MGE Sersic

### DIFF
--- a/autoarray/abstract_ndarray.py
+++ b/autoarray/abstract_ndarray.py
@@ -4,14 +4,8 @@ from copy import copy
 
 from abc import ABC
 from abc import abstractmethod
-import numpy as np
 
-import os
-
-if os.environ.get("USE_JAX") == "1":
-    from jax import numpy as np
-
-from autoarray.numpy_wrapper import numpy as npw, register_pytree_node, Array
+from autoarray.numpy_wrapper import np, register_pytree_node, Array
 
 from typing import TYPE_CHECKING
 
@@ -337,7 +331,7 @@ class AbstractNDArray(ABC):
 
     def __setitem__(self, key, value):
         if isinstance(key, (np.ndarray, AbstractNDArray, Array)):
-            self._array = npw.where(key, value, self._array)
+            self._array = np.where(key, value, self._array)
         else:
             self._array[key] = value
 

--- a/autoarray/fit/fit_util.py
+++ b/autoarray/fit/fit_util.py
@@ -1,8 +1,6 @@
 from functools import wraps
 
-import numpy as np
-
-from autoarray.numpy_wrapper import numpy as npw
+from autoarray.numpy_wrapper import np
 from autoarray.mask.abstract_mask import Mask
 
 from autoarray import type as ty
@@ -99,7 +97,7 @@ def noise_normalization_from(*, noise_map: ty.DataLike) -> float:
     noise_map
         The masked noise-map of the dataset.
     """
-    return npw.sum(npw.log(2 * np.pi * noise_map**2.0))
+    return np.sum(np.log(2 * np.pi * noise_map**2.0))
 
 
 def normalized_residual_map_complex_from(

--- a/autoarray/geometry/geometry_util.py
+++ b/autoarray/geometry/geometry_util.py
@@ -1,5 +1,5 @@
 from typing import Tuple, Union
-from autoarray.numpy_wrapper import np
+from autoarray.numpy_wrapper import np, use_jax
 
 from autoarray import numba_util
 from autoarray import type as ty
@@ -382,15 +382,18 @@ def transform_grid_2d_to_reference_frame(
     grid
         The 2d grid of (y, x) coordinates which are transformed to a new reference frame.
     """
-    shifted_grid_2d = grid_2d - np.array(centre)
-    radius = np.sqrt(np.sum(shifted_grid_2d**2.0, 1))
+    if use_jax:
+        shifted_grid_2d = grid_2d.array - np.array(centre)
+    else:
+        shifted_grid_2d = grid_2d - np.array(centre)
+    radius = np.sqrt(np.sum(shifted_grid_2d**2.0, axis=1))
     theta_coordinate_to_profile = np.arctan2(
         shifted_grid_2d[:, 0], shifted_grid_2d[:, 1]
     ) - np.radians(angle)
-    return np.vstack(
-        radius
-        * (np.sin(theta_coordinate_to_profile), np.cos(theta_coordinate_to_profile))
-    ).T
+    return np.vstack([
+        radius * np.sin(theta_coordinate_to_profile),
+        radius * np.cos(theta_coordinate_to_profile)
+    ]).T
 
 
 def transform_grid_2d_from_reference_frame(

--- a/autoarray/mask/abstract_mask.py
+++ b/autoarray/mask/abstract_mask.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from abc import ABC
 import logging
-import numpy as np
+
+from autoarray.numpy_wrapper import np, use_jax
 from pathlib import Path
 from typing import Dict, Union
 
@@ -116,7 +117,7 @@ class Mask(AbstractNDArray, ABC):
         """
         The total number of unmasked pixels (values are `False`) in the mask.
         """
-        return int(np.size(self._array) - np.sum(self._array))
+        return (np.size(self._array) - np.sum(self._array)).astype(int)
 
     @property
     def is_all_true(self) -> bool:

--- a/autoarray/mask/derive/indexes_2d.py
+++ b/autoarray/mask/derive/indexes_2d.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import logging
-import numpy as np
-from autoarray.numpy_wrapper import register_pytree_node_class
+
+from autoarray.numpy_wrapper import np, register_pytree_node_class
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/autoarray/numpy_wrapper.py
+++ b/autoarray/numpy_wrapper.py
@@ -1,65 +1,14 @@
 import logging
 
-import numpy as np
 from os import environ
-
-
-def unwrap_arrays(args):
-    from autoarray.abstract_ndarray import AbstractNDArray
-
-    for arg in args:
-        if isinstance(arg, AbstractNDArray):
-            yield arg.array
-        elif isinstance(arg, (list, tuple)):
-            yield type(arg)(unwrap_arrays(arg))
-        else:
-            yield arg
-
-
-class Callable:
-    def __init__(self, func):
-        self.func = func
-
-    def __call__(self, *args, **kwargs):
-        from autoarray.abstract_ndarray import AbstractNDArray
-
-        try:
-            first_argument = args[0]
-        except IndexError:
-            first_argument = None
-
-        args = unwrap_arrays(args)
-        result = self.func(*args, **kwargs)
-        if isinstance(first_argument, AbstractNDArray) and not isinstance(
-            result, float
-        ):
-            return first_argument.with_new_array(result)
-        return result
-
-
-class Numpy:
-    def __init__(self, jnp):
-        self.jnp = jnp
-
-    def __getattr__(self, item):
-        try:
-            attribute = getattr(self.jnp, item)
-        except AttributeError as e:
-            logging.debug(e)
-            attribute = getattr(np, item)
-        if callable(attribute):
-            return Callable(attribute)
-        return attribute
-
 
 use_jax = environ.get("USE_JAX", "0") == "1"
 
 if use_jax:
     try:
-        import jax.numpy as jnp
-        from jax import jit
+        import jax
+        from jax import numpy as np, jit
 
-        numpy = Numpy(jnp)
 
         print("JAX mode enabled")
     except ImportError:
@@ -67,7 +16,7 @@ if use_jax:
             "JAX is not installed. Please install it with `pip install jax`."
         )
 else:
-    numpy = Numpy(np)
+    import numpy as np
 
     def jit(function, *_, **__):
         return function

--- a/autoarray/operators/over_sampling/over_sample_util.py
+++ b/autoarray/operators/over_sampling/over_sample_util.py
@@ -1,7 +1,5 @@
-from autoarray.numpy_wrapper import register_pytree_node_class
+from autoarray.numpy_wrapper import np, register_pytree_node_class, use_jax
 
-
-import numpy as np
 from typing import List, Tuple
 
 from autoarray.mask.mask_2d import Mask2D
@@ -324,7 +322,11 @@ def sub_size_radial_bins_from(
     for i in range(radial_grid.shape[0]):
         for j in range(len(radial_list)):
             if radial_grid[i] < radial_list[j]:
-                sub_size[i] = sub_size_list[j]
+                if use_jax:
+                    # while this makes it run, it is very, very slow
+                    sub_size = sub_size.at[i].set(sub_size_list[j])
+                else:
+                    sub_size[i] = sub_size_list[j]
                 break
 
     return sub_size
@@ -403,12 +405,21 @@ def grid_2d_slim_over_sampled_via_mask_from(
 
                 for y1 in range(sub):
                     for x1 in range(sub):
-                        grid_slim[sub_index, 0] = -(
-                            y_scaled - y_sub_half + y1 * y_sub_step + (y_sub_step / 2.0)
-                        )
-                        grid_slim[sub_index, 1] = (
-                            x_scaled - x_sub_half + x1 * x_sub_step + (x_sub_step / 2.0)
-                        )
+                        if use_jax:
+                            # while this makes it run, it is very, very slow
+                            grid_slim = grid_slim.at[sub_index, 0].set(-(
+                                y_scaled - y_sub_half + y1 * y_sub_step + (y_sub_step / 2.0)
+                            ))
+                            grid_slim = grid_slim.at[sub_index, 1].set(
+                                x_scaled - x_sub_half + x1 * x_sub_step + (x_sub_step / 2.0)
+                            )
+                        else:
+                            grid_slim[sub_index, 0] = -(
+                                y_scaled - y_sub_half + y1 * y_sub_step + (y_sub_step / 2.0)
+                            )
+                            grid_slim[sub_index, 1] = (
+                                x_scaled - x_sub_half + x1 * x_sub_step + (x_sub_step / 2.0)
+                            )
                         sub_index += 1
 
                 index += 1

--- a/autoarray/operators/over_sampling/uniform.py
+++ b/autoarray/operators/over_sampling/uniform.py
@@ -1,4 +1,4 @@
-import numpy as np
+from autoarray.numpy_wrapper import np
 from typing import List, Tuple, Union
 
 from autoconf import conf
@@ -188,7 +188,7 @@ class OverSamplingUniform(AbstractOverSampling):
         sub_size = np.zeros(grid.shape_slim)
 
         for centre in centre_list:
-            radial_grid = grid.distances_to_coordinate_from(coordinate=centre)
+            radial_grid = grid.distances_to_coordinate_from(coordinate=centre).array
 
             sub_size_of_centre = over_sample_util.sub_size_radial_bins_from(
                 radial_grid=np.array(radial_grid),
@@ -379,7 +379,7 @@ class OverSamplerUniform(AbstractOverSampler):
         grid = over_sample_util.grid_2d_slim_over_sampled_via_mask_from(
             mask_2d=np.array(self.mask),
             pixel_scales=self.mask.pixel_scales,
-            sub_size=np.array(self.sub_size).astype("int"),
+            sub_size=np.array(self.sub_size.array).astype("int"),
             origin=self.mask.origin,
         )
 

--- a/autoarray/structures/decorators/relocate_radial.py
+++ b/autoarray/structures/decorators/relocate_radial.py
@@ -1,6 +1,6 @@
 import os
 
-from autofit.jax_wrapper import numpy as np
+from autofit.jax_wrapper import numpy as np, use_jax
 from functools import wraps
 
 from typing import Union
@@ -59,7 +59,7 @@ def relocate_to_radial_minimum(func):
         -------
             The grid_like object whose coordinates are radially moved from (0.0, 0.0).
         """
-        if os.environ.get("USE_JAX", "0") == "1":
+        if use_jax:
             return func(obj, grid, *args, **kwargs)
 
         try:

--- a/autoarray/structures/decorators/to_grid.py
+++ b/autoarray/structures/decorators/to_grid.py
@@ -1,4 +1,4 @@
-import numpy as np
+from autoarray.numpy_wrapper import np
 from functools import wraps
 
 from typing import List, Union

--- a/autoarray/structures/decorators/to_vector_yx.py
+++ b/autoarray/structures/decorators/to_vector_yx.py
@@ -1,4 +1,4 @@
-import numpy as np
+from autoarray.numpy_wrapper import np
 from functools import wraps
 
 from typing import List, Union

--- a/autoarray/structures/decorators/transform.py
+++ b/autoarray/structures/decorators/transform.py
@@ -1,6 +1,5 @@
-import numpy as np
+from autoarray.numpy_wrapper import np
 from functools import wraps
-
 from typing import Union
 
 from autoarray.structures.grids.uniform_1d import Grid1D

--- a/autoarray/structures/grids/uniform_2d.py
+++ b/autoarray/structures/grids/uniform_2d.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import numpy as np
+from autoarray.numpy_wrapper import np, use_jax
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
@@ -824,9 +824,14 @@ class Grid2D(Structure):
         coordinate
             The (y,x) coordinate from which the squared distance of every grid (y,x) coordinate is computed.
         """
-        squared_distances = np.square(self[:, 0] - coordinate[0]) + np.square(
-            self[:, 1] - coordinate[1]
-        )
+        if use_jax:
+            squared_distances = np.square(self.array[:, 0] - coordinate[0]) + np.square(
+                self.array[:, 1] - coordinate[1]
+            )
+        else:
+            squared_distances = np.square(self[:, 0] - coordinate[0]) + np.square(
+                self[:, 1] - coordinate[1]
+            )
         return Array2D(values=squared_distances, mask=self.mask)
 
     def distances_to_coordinate_from(
@@ -840,8 +845,9 @@ class Grid2D(Structure):
         coordinate
             The (y,x) coordinate from which the distance of every grid (y,x) coordinate is computed.
         """
+        squared_distance = self.squared_distances_to_coordinate_from(coordinate=coordinate)
         distances = np.sqrt(
-            self.squared_distances_to_coordinate_from(coordinate=coordinate)
+            squared_distance.array
         )
         return Array2D(values=distances, mask=self.mask)
 


### PR DESCRIPTION
These files are all used by the Sersic profile's MGE deflection angles.  This wholesale replacement of numpy for jax.numpy solves many of the issues around the array wrappers (e.g. "Grid2d").  The `numpy_wrapper` is just a simple file that can be imported to provide the correct `np` and an optional `use_jax` bool in case further `if` blocks are needed.

Thankfully, with the full replacement much of the control flow `if` blocks seem to work without modification!