### PR TITLE
Maks sure that the transform decorator does not overwrite keywords

### DIFF
--- a/autoarray/structures/decorators/transform.py
+++ b/autoarray/structures/decorators/transform.py
@@ -50,7 +50,7 @@ def transform(func):
         """
 
         if not kwargs.get("is_transformed"):
-            kwargs = {"is_transformed": True}
+            kwargs["is_transformed"] = True
 
             transformed_grid = obj.transformed_to_reference_frame_grid_from(
                 grid, **kwargs


### PR DESCRIPTION
Small fix to make sure that the transform decorator does not overwrite all the `**kwargs` passed into a function.