### PR TITLE
Feature/apply scaling

### DIFF
--- a/autoarray/dataset/imaging/dataset.py
+++ b/autoarray/dataset/imaging/dataset.py
@@ -336,7 +336,7 @@ class Imaging(AbstractDataset):
 
         return dataset
 
-    def apply_noise_scaling(self, mask: Mask2D) -> "Imaging":
+    def apply_noise_scaling(self, mask: Mask2D, noise_value : float = 1e8) -> "Imaging":
         """
         Apply a mask to the imaging dataset using noise scaling, whereby the mask increases noise-map values to be
         extremely large such that they are never included in the likelihood calculation, but it does
@@ -363,7 +363,7 @@ class Imaging(AbstractDataset):
         )
 
         noise_map = self.noise_map.native
-        noise_map[mask == False] = 1.0e8
+        noise_map[mask == False] = noise_value
         noise_map = Array2D.no_mask(
             values=noise_map,
             shape_native=self.data.shape_native,

--- a/autoarray/dataset/imaging/dataset.py
+++ b/autoarray/dataset/imaging/dataset.py
@@ -356,11 +356,19 @@ class Imaging(AbstractDataset):
             The 2D mask that is applied to the image and noise-map, to scale the noise-map values to large values.
         """
         data = np.where(np.invert(mask), 0.0, self.data.native)
-        data = Array2D(values=data, mask=mask)
+        data = Array2D.no_mask(
+            values=data,
+            shape_native=self.data.shape_native,
+            pixel_scales=self.data.pixel_scales,
+        )
 
         noise_map = self.noise_map.native
         noise_map[mask == False] = 1.0e8
-        noise_map = Array2D(values=noise_map, mask=mask)
+        noise_map = Array2D.no_mask(
+            values=noise_map,
+            shape_native=self.data.shape_native,
+            pixel_scales=self.data.pixel_scales,
+        )
 
         dataset = Imaging(
             data=data,

--- a/autoarray/mask/mask_2d.py
+++ b/autoarray/mask/mask_2d.py
@@ -622,6 +622,7 @@ class Mask2D(Mask):
         hdu: int = 0,
         origin: Tuple[float, float] = (0.0, 0.0),
         resized_mask_shape: Tuple[int, int] = None,
+        invert: bool = False,
     ) -> "Mask2D":
         """
         Loads the image from a .fits file.
@@ -639,10 +640,13 @@ class Mask2D(Mask):
         """
         pixel_scales = geometry_util.convert_pixel_scales_2d(pixel_scales=pixel_scales)
 
+        mask = array_2d_util.numpy_array_2d_via_fits_from(file_path=file_path, hdu=hdu)
+
+        if invert:
+            mask = np.invert(mask.astype("bool"))
+
         mask = Mask2D(
-            mask=array_2d_util.numpy_array_2d_via_fits_from(
-                file_path=file_path, hdu=hdu
-            ),
+            mask=mask,
             pixel_scales=pixel_scales,
             origin=origin,
         )

--- a/autoarray/plot/wrap/base/title.py
+++ b/autoarray/plot/wrap/base/title.py
@@ -4,7 +4,7 @@ from autoarray.plot.wrap.base.abstract import AbstractMatWrap
 
 
 class Title(AbstractMatWrap):
-    def __init__(self, prefix: str = None, disable_log10_label : bool = False, **kwargs):
+    def __init__(self, prefix: str = None, disable_log10_label: bool = False, **kwargs):
         """
         The settings used to customize the figure's title.
 

--- a/test_autoarray/dataset/imaging/test_dataset.py
+++ b/test_autoarray/dataset/imaging/test_dataset.py
@@ -149,6 +149,15 @@ def test__apply_mask(imaging_7x7, mask_2d_7x7, psf_3x3):
     assert masked_imaging_7x7.w_tilde.lengths.shape == (9,)
 
 
+def test__apply_noise_scaling(imaging_7x7, mask_2d_7x7):
+    masked_imaging_7x7 = imaging_7x7.apply_noise_scaling(mask=mask_2d_7x7)
+
+    print(masked_imaging_7x7.data.native)
+
+    assert masked_imaging_7x7.data.native[4, 4] == 0.0
+    assert masked_imaging_7x7.noise_map.native[4, 4] == 1e8
+
+
 def test__apply_mask__noise_covariance_matrix():
     image = aa.Array2D.ones(shape_native=(2, 2), pixel_scales=(1.0, 1.0))
 

--- a/test_autoarray/dataset/imaging/test_dataset.py
+++ b/test_autoarray/dataset/imaging/test_dataset.py
@@ -150,12 +150,10 @@ def test__apply_mask(imaging_7x7, mask_2d_7x7, psf_3x3):
 
 
 def test__apply_noise_scaling(imaging_7x7, mask_2d_7x7):
-    masked_imaging_7x7 = imaging_7x7.apply_noise_scaling(mask=mask_2d_7x7)
-
-    print(masked_imaging_7x7.data.native)
+    masked_imaging_7x7 = imaging_7x7.apply_noise_scaling(mask=mask_2d_7x7, noise_value=1e5)
 
     assert masked_imaging_7x7.data.native[4, 4] == 0.0
-    assert masked_imaging_7x7.noise_map.native[4, 4] == 1e8
+    assert masked_imaging_7x7.noise_map.native[4, 4] == 1e5
 
 
 def test__apply_mask__noise_covariance_matrix():


### PR DESCRIPTION
AutoLens has for many years preprocessed data with a noise scaling technique which sets the image data values to zeros and noise map values to very large values (e.g. 1e8).

This was done outside the source code via the workspace.

Moving forward, it will be cleaner to do this in modeling script and thus the functionality has been added to `Imaging` via
the method `apply_noise_scaling`.