### PR TITLE
Changes needed for critical curve calculations

### DIFF
--- a/autoarray/geometry/geometry_2d.py
+++ b/autoarray/geometry/geometry_2d.py
@@ -13,6 +13,8 @@ from autoarray.geometry.abstract_2d import AbstractGeometry2D
 from autoarray import type as ty
 from autoarray.geometry import geometry_util
 
+from autofit.jax_wrapper import use_jax
+
 logging.basicConfig()
 logger = logging.getLogger(__name__)
 
@@ -234,7 +236,7 @@ class Geometry2D(AbstractGeometry2D):
         from autoarray.structures.grids.uniform_2d import Grid2D
 
         grid_pixels_2d = geometry_util.grid_pixels_2d_slim_from(
-            grid_scaled_2d_slim=np.array(grid_scaled_2d),
+            grid_scaled_2d_slim=np.array(grid_scaled_2d.array),
             shape_native=self.shape_native,
             pixel_scales=self.pixel_scales,
             origin=self.origin,

--- a/autoarray/mask/mask_2d_util.py
+++ b/autoarray/mask/mask_2d_util.py
@@ -5,6 +5,7 @@ import warnings
 from autoarray import exc
 from autoarray import numba_util
 from autoarray import type as ty
+from autoarray.numpy_wrapper import use_jax, np as jnp
 
 
 @numba_util.jit()
@@ -66,15 +67,18 @@ def total_pixels_2d_from(mask_2d: np.ndarray) -> int:
 
     total_regular_pixels = total_regular_pixels_from(mask=mask)
     """
+    if use_jax:
+        return (~mask_2d.astype(bool)).sum()
 
-    total_regular_pixels = 0
+    else:
+        total_regular_pixels = 0
 
-    for y in range(mask_2d.shape[0]):
-        for x in range(mask_2d.shape[1]):
-            if not mask_2d[y, x]:
-                total_regular_pixels += 1
+        for y in range(mask_2d.shape[0]):
+            for x in range(mask_2d.shape[1]):
+                if not mask_2d[y, x]:
+                    total_regular_pixels += 1
 
-    return total_regular_pixels
+        return total_regular_pixels
 
 
 @numba_util.jit()
@@ -1052,15 +1056,17 @@ def native_index_for_slim_index_2d_from(
 
     native_index_for_slim_index_2d = native_index_for_slim_index_2d_from(mask_2d=mask_2d)
     """
+    if use_jax:
+        return jnp.stack(jnp.nonzero(~mask_2d.astype(bool))).T
+    else:
+        total_pixels = total_pixels_2d_from(mask_2d=mask_2d)
+        native_index_for_slim_index_2d = np.zeros(shape=(total_pixels, 2))
+        slim_index = 0
 
-    total_pixels = total_pixels_2d_from(mask_2d=mask_2d)
-    native_index_for_slim_index_2d = np.zeros(shape=(total_pixels, 2))
-    slim_index = 0
+        for y in range(mask_2d.shape[0]):
+            for x in range(mask_2d.shape[1]):
+                if not mask_2d[y, x]:
+                    native_index_for_slim_index_2d[slim_index, :] = y, x
+                    slim_index += 1
 
-    for y in range(mask_2d.shape[0]):
-        for x in range(mask_2d.shape[1]):
-            if not mask_2d[y, x]:
-                native_index_for_slim_index_2d[slim_index, :] = y, x
-                slim_index += 1
-
-    return native_index_for_slim_index_2d
+        return native_index_for_slim_index_2d

--- a/autoarray/operators/over_sampling/over_sample_util.py
+++ b/autoarray/operators/over_sampling/over_sample_util.py
@@ -1,4 +1,4 @@
-from autoarray.numpy_wrapper import np, register_pytree_node_class, use_jax
+from autoarray.numpy_wrapper import np, register_pytree_node_class, use_jax, jit
 
 from typing import List, Tuple
 
@@ -504,9 +504,14 @@ def binned_array_2d_from(
 
                 for y1 in range(sub):
                     for x1 in range(sub):
-                        binned_array_2d_slim[index] += (
-                            array_2d[sub_index] * sub_fraction[index]
-                        )
+                        if use_jax:
+                            binned_array_2d_slim = binned_array_2d_slim.at[index].add(
+                                array_2d[sub_index] * sub_fraction[index]
+                            )
+                        else:
+                            binned_array_2d_slim[index] += (
+                                array_2d[sub_index] * sub_fraction[index]
+                            )
                         sub_index += 1
 
                 index += 1

--- a/autoarray/operators/over_sampling/uniform.py
+++ b/autoarray/operators/over_sampling/uniform.py
@@ -439,9 +439,9 @@ class OverSamplerUniform(AbstractOverSampler):
             pass
 
         binned_array_2d = over_sample_util.binned_array_2d_from(
-            array_2d=np.array(array),
+            array_2d=np.array(array.array),
             mask_2d=np.array(self.mask),
-            sub_size=np.array(self.sub_size).astype("int"),
+            sub_size=np.array(self.sub_size.array).astype("int"),
         )
 
         return Array2D(

--- a/autoarray/structures/grids/uniform_2d.py
+++ b/autoarray/structures/grids/uniform_2d.py
@@ -1009,10 +1009,16 @@ class Grid2D(Structure):
         The (y,x) minimum values of the grid in scaled units, buffed such that their extent is further than the grid's
         extent.
         """
-        return (
-            np.amin(self[:, 0]).astype("float"),
-            np.amin(self[:, 1]).astype("float"),
-        )
+        if use_jax:
+            return (
+                np.amin(self.array[:, 0]).astype("float"),
+                np.amin(self.array[:, 1]).astype("float"),
+            )
+        else:
+            return (
+                np.amin(self[:, 0]).astype("float"),
+                np.amin(self[:, 1]).astype("float"),
+            )
 
     @property
     def scaled_maxima(self) -> Tuple:
@@ -1020,10 +1026,16 @@ class Grid2D(Structure):
         The (y,x) maximum values of the grid in scaled units, buffed such that their extent is further than the grid's
         extent.
         """
-        return (
-            np.amax(self[:, 0]).astype("float"),
-            np.amax(self[:, 1]).astype("float"),
-        )
+        if use_jax:
+            return (
+                np.amax(self.array[:, 0]).astype("float"),
+                np.amax(self.array[:, 1]).astype("float"),
+            )
+        else:
+            return (
+                np.amax(self[:, 0]).astype("float"),
+                np.amax(self[:, 1]).astype("float"),
+            )
 
     def extent_with_buffer_from(self, buffer: float = 1.0e-8) -> List[float]:
         """

--- a/autoarray/structures/vectors/uniform.py
+++ b/autoarray/structures/vectors/uniform.py
@@ -1,5 +1,6 @@
 import logging
-import numpy as np
+# import numpy as np
+from autofit.jax_wrapper import numpy as np, use_jax
 from typing import List, Optional, Tuple, Union
 
 from autoarray.structures.arrays.uniform_2d import Array2D
@@ -394,8 +395,12 @@ class VectorYX2D(AbstractVectorYX2D):
         """
         Returns the magnitude of every vector which are computed as sqrt(y**2 + x**2).
         """
+        if use_jax:
+            s = self.array
+        else:
+            s = self
         return Array2D(
-            values=np.sqrt(self[:, 0] ** 2.0 + self[:, 1] ** 2.0), mask=self.mask
+            values=np.sqrt(s[:, 0] ** 2.0 + s[:, 1] ** 2.0), mask=self.mask
         )
 
     @property


### PR DESCRIPTION
These changes are mostly needed to speed up the (and make jit'able) the various functions within `deflections.py` (in PyAutoGalaxy).  While not all these changes are needed for the final "jax" method, they make the previous method compatible when jax arrays are used.