### PR TITLE
Feature/inversion noise map

### DIFF
--- a/autoarray/config/visualize/plots.yaml
+++ b/autoarray/config/visualize/plots.yaml
@@ -35,7 +35,7 @@ inversion:                                 # Settings for plots of inversions (e
   all_at_end_fits: true                    # Plot all individual plots listed below as .fits (even if False)?
   all_at_end_pdf: false                    # Plot all individual plots listed below as publication-quality .pdf (even if False)?
   data_subtracted: false                   # Plot individual plots of the data with the other inversion linear objects subtracted?
-  errors: false                            # Plot image of the errors of every mesh-pixel reconstructed value?
+  reconstruction_noise_map: false          # Plot image of the errors of every mesh-pixel reconstructed value?
   sub_pixels_per_image_pixels: false       # Plot the number of sub pixels per masked data pixels?
   mesh_pixels_per_image_pixels: false      # Plot the number of image-plane mesh pixels per masked data pixels?
   image_pixels_per_mesh_pixels: false      # Plot the number of image pixels in each pixel of the mesh?

--- a/autoarray/config/visualize/plots.yaml
+++ b/autoarray/config/visualize/plots.yaml
@@ -35,7 +35,7 @@ inversion:                                 # Settings for plots of inversions (e
   all_at_end_fits: true                    # Plot all individual plots listed below as .fits (even if False)?
   all_at_end_pdf: false                    # Plot all individual plots listed below as publication-quality .pdf (even if False)?
   data_subtracted: false                   # Plot individual plots of the data with the other inversion linear objects subtracted?
-  reconstruction_noise_map: false          # Plot image of the errors of every mesh-pixel reconstructed value?
+  reconstruction_noise_map: false          # Plot image of the noise of every mesh-pixel reconstructed value?
   sub_pixels_per_image_pixels: false       # Plot the number of sub pixels per masked data pixels?
   mesh_pixels_per_image_pixels: false      # Plot the number of image-plane mesh pixels per masked data pixels?
   image_pixels_per_mesh_pixels: false      # Plot the number of image pixels in each pixel of the mesh?

--- a/autoarray/inversion/inversion/abstract.py
+++ b/autoarray/inversion/inversion/abstract.py
@@ -758,16 +758,16 @@ class AbstractInversion:
                 raise exc.InversionException() from e
 
     @property
-    def errors_with_covariance(self) -> np.ndarray:
-        return np.linalg.inv(self.curvature_reg_matrix)
+    def reconstruction_noise_map_with_covariance(self) -> np.ndarray:
+        return np.sqrt(np.linalg.inv(self.curvature_reg_matrix))
 
     @property
-    def errors(self):
-        return np.diagonal(self.errors_with_covariance)
+    def reconstruction_noise_map(self):
+        return np.diagonal(self.reconstruction_noise_map_with_covariance)
 
     @property
-    def errors_dict(self) -> Dict[LinearObj, np.ndarray]:
-        return self.source_quantity_dict_from(source_quantity=self.errors)
+    def reconstruction_noise_map_dict(self) -> Dict[LinearObj, np.ndarray]:
+        return self.source_quantity_dict_from(source_quantity=self.reconstruction_noise_map)
 
     def regularization_weights_from(self, index: int) -> np.ndarray:
         linear_obj = self.linear_obj_list[index]

--- a/autoarray/inversion/inversion/abstract.py
+++ b/autoarray/inversion/inversion/abstract.py
@@ -791,7 +791,7 @@ class AbstractInversion:
 
         The noise-map of the reconstruction is the RMS standard deviation of the noise in every pixel of the
         reconstruction. This definition is identical to the `noise_map` attributes of dataset objects.
-        
+
         It is computed as the square root of the diagonal of the `reconstruction_noise_map_with_covariance` matrix,
         which is the same matrix used to solve for the reconstruction via the linear inversion.
 
@@ -804,7 +804,9 @@ class AbstractInversion:
 
     @property
     def reconstruction_noise_map_dict(self) -> Dict[LinearObj, np.ndarray]:
-        return self.source_quantity_dict_from(source_quantity=self.reconstruction_noise_map)
+        return self.source_quantity_dict_from(
+            source_quantity=self.reconstruction_noise_map
+        )
 
     def regularization_weights_from(self, index: int) -> np.ndarray:
         linear_obj = self.linear_obj_list[index]

--- a/autoarray/inversion/inversion/abstract.py
+++ b/autoarray/inversion/inversion/abstract.py
@@ -759,10 +759,47 @@ class AbstractInversion:
 
     @property
     def reconstruction_noise_map_with_covariance(self) -> np.ndarray:
+        """
+        Returns the noise-map of the reconstruction as a two dimension matrix which accounts for the covariance
+        of the noise between pixels.
+
+        The diagonal of this matrix is the noise-map of the reconstruction, which can be used for analysing the
+        reconstruction with noise properties that are representative of the fit and therefore should be used
+        for any scientific analysis (e.g. source reconstructions of strong lenses).
+
+        This noise-map is defined as the RMS standard deviation of the noise in every pixel of the reconstruction.
+        This definition is identical to the `noise_map` attributes of dataset objects.
+
+        It is computed as the square root of the inverse of the curvature matrix with regularization, which is the
+        same matrix used to solve for the reconstruction via the linear inversion.
+
+        Returns
+        -------
+        The noise-map of the reconstruction as a two dimension matrix which accounts for the covariance of the noise
+        between pixels.
+        """
         return np.sqrt(np.linalg.inv(self.curvature_reg_matrix))
 
     @property
     def reconstruction_noise_map(self):
+        """
+        Returns the noise-map of the reconstruction as a one dimensional ndarray, which does not account for the
+        covariance of the noise between pixels.
+
+        This matrix is representative of the noise properties of the fit and should be used for any scientific
+        analysis (e.g. source reconstructions of strong lenses).
+
+        The noise-map of the reconstruction is the RMS standard deviation of the noise in every pixel of the
+        reconstruction. This definition is identical to the `noise_map` attributes of dataset objects.
+        
+        It is computed as the square root of the diagonal of the `reconstruction_noise_map_with_covariance` matrix,
+        which is the same matrix used to solve for the reconstruction via the linear inversion.
+
+        Returns
+        -------
+        The noise-map of the reconstruction as a one dimensional ndarray, which does not account for the covariance
+        of the noise between pixels.
+        """
         return np.diagonal(self.reconstruction_noise_map_with_covariance)
 
     @property

--- a/autoarray/inversion/inversion/interferometer/lop.py
+++ b/autoarray/inversion/inversion/interferometer/lop.py
@@ -142,5 +142,5 @@ class InversionInterferometerMappingPyLops(AbstractInversionInterferometer):
         )
 
     @property
-    def errors(self):
+    def reconstruction_noise_map(self):
         return None

--- a/autoarray/inversion/inversion/mapper_valued.py
+++ b/autoarray/inversion/inversion/mapper_valued.py
@@ -29,7 +29,7 @@ class MapperValued:
             The `Mapper` object which pairs with the values, for example a `MapperVoronoi` object.
         values
             The values of each pixel of the mapper, which could be the `reconstruction` values of an `Inversion`,
-            but alternatively could be other quantities such as the errors on these values.
+            but alternatively could be other quantities such as the noise-map of these values.
         mesh_pixel_mask
             The mask of pixels that are omitted from the reconstruction when computing the image, for example to
             remove pixels with low signal-to-noise so they do not impact the magnification calculation.

--- a/autoarray/inversion/mock/mock_inversion.py
+++ b/autoarray/inversion/mock/mock_inversion.py
@@ -59,8 +59,8 @@ class MockInversion(AbstractInversion):
         self._mapped_reconstructed_data_dict = mapped_reconstructed_data_dict
         self._mapped_reconstructed_image_dict = mapped_reconstructed_image_dict
 
-        self._errors = reconstruction_noise_map
-        self._errors_dict = reconstruction_noise_map_dict
+        self._reconstruction_noise_map = reconstruction_noise_map
+        self._reconstruction_noise_map_dict = reconstruction_noise_map_dict
 
         self._regularization_term = regularization_term
         self._log_det_curvature_reg_matrix_term = log_det_curvature_reg_matrix_term
@@ -172,15 +172,15 @@ class MockInversion(AbstractInversion):
 
     @property
     def reconstruction_noise_map(self):
-        if self._errors is None:
+        if self._reconstruction_noise_map is None:
             return super().reconstruction_noise_map
-        return self._errors
+        return self._reconstruction_noise_map
 
     @property
     def reconstruction_noise_map_dict(self):
-        if self._errors_dict is None:
+        if self._reconstruction_noise_map_dict is None:
             return super().reconstruction_noise_map_dict
-        return self._errors_dict
+        return self._reconstruction_noise_map_dict
 
     @property
     def regularization_term(self):

--- a/autoarray/inversion/mock/mock_inversion.py
+++ b/autoarray/inversion/mock/mock_inversion.py
@@ -25,8 +25,8 @@ class MockInversion(AbstractInversion):
         reconstruction_dict: List[np.ndarray] = None,
         mapped_reconstructed_data_dict=None,
         mapped_reconstructed_image_dict=None,
-        errors: np.ndarray = None,
-        errors_dict: List[np.ndarray] = None,
+        reconstruction_noise_map: np.ndarray = None,
+        reconstruction_noise_map_dict: List[np.ndarray] = None,
         regularization_term=None,
         log_det_curvature_reg_matrix_term=None,
         log_det_regularization_matrix_term=None,
@@ -59,8 +59,8 @@ class MockInversion(AbstractInversion):
         self._mapped_reconstructed_data_dict = mapped_reconstructed_data_dict
         self._mapped_reconstructed_image_dict = mapped_reconstructed_image_dict
 
-        self._errors = errors
-        self._errors_dict = errors_dict
+        self._errors = reconstruction_noise_map
+        self._errors_dict = reconstruction_noise_map_dict
 
         self._regularization_term = regularization_term
         self._log_det_curvature_reg_matrix_term = log_det_curvature_reg_matrix_term
@@ -171,15 +171,15 @@ class MockInversion(AbstractInversion):
         return self._mapped_reconstructed_image_dict
 
     @property
-    def errors(self):
+    def reconstruction_noise_map(self):
         if self._errors is None:
-            return super().errors
+            return super().reconstruction_noise_map
         return self._errors
 
     @property
-    def errors_dict(self):
+    def reconstruction_noise_map_dict(self):
         if self._errors_dict is None:
-            return super().errors_dict
+            return super().reconstruction_noise_map_dict
         return self._errors_dict
 
     @property

--- a/autoarray/inversion/plot/inversion_plotters.py
+++ b/autoarray/inversion/plot/inversion_plotters.py
@@ -121,7 +121,7 @@ class InversionPlotter(Plotter):
         data_subtracted: bool = False,
         reconstructed_image: bool = False,
         reconstruction: bool = False,
-        errors: bool = False,
+        reconstruction_noise_map: bool = False,
         signal_to_noise_map: bool = False,
         regularization_weights: bool = False,
         sub_pixels_per_image_pixels: bool = False,
@@ -145,8 +145,8 @@ class InversionPlotter(Plotter):
             Whether to make a 2D plot (via `imshow`) of the mapper's reconstructed image data.
         reconstruction
             Whether to make a 2D plot (via `imshow` or `fill`) of the mapper's source-plane reconstruction.
-        errors
-            Whether to make a 2D plot (via `imshow` or `fill`) of the mapper's source-plane errors.
+        reconstruction_noise_map
+            Whether to make a 2D plot (via `imshow` or `fill`) of the mapper's source-plane noise-map.
         signal_to_noise_map
             Whether to make a 2D plot (via `imshow` or `fill`) of the mapper's source-plane signal-to-noise-map.
         sub_pixels_per_image_pixels
@@ -236,11 +236,11 @@ class InversionPlotter(Plotter):
             if vmax_custom:
                 self.mat_plot_2d.cmap.kwargs["vmax"] = None
 
-        if errors:
+        if reconstruction_noise_map:
             try:
                 mapper_plotter.plot_source_from(
-                    pixel_values=self.inversion.errors_dict[mapper_plotter.mapper],
-                    auto_labels=AutoLabels(title="Errors", filename="errors"),
+                    pixel_values=self.inversion.reconstruction_noise_map_dict[mapper_plotter.mapper],
+                    auto_labels=AutoLabels(title="Noise Map", filename="reconstruction_noise_map"),
                 )
 
             except TypeError:
@@ -250,7 +250,7 @@ class InversionPlotter(Plotter):
             try:
                 signal_to_noise_values = (
                     self.inversion.reconstruction_dict[mapper_plotter.mapper]
-                    / self.inversion.errors_dict[mapper_plotter.mapper]
+                    / self.inversion.reconstruction_noise_map_dict[mapper_plotter.mapper]
                 )
 
                 mapper_plotter.plot_source_from(
@@ -388,9 +388,9 @@ class InversionPlotter(Plotter):
         )
         self.set_title(label=None)
 
-        self.set_title(label="Errors (Unzoomed)")
+        self.set_title(label="Noise-Map (Unzoomed)")
         self.figures_2d_of_pixelization(
-            pixelization_index=mapper_index, errors=True, zoom_to_brightest=False
+            pixelization_index=mapper_index, reconstruction_noise_map=True, zoom_to_brightest=False
         )
 
         self.set_title(label="Regularization Weights (Unzoomed)")

--- a/autoarray/inversion/plot/inversion_plotters.py
+++ b/autoarray/inversion/plot/inversion_plotters.py
@@ -239,8 +239,12 @@ class InversionPlotter(Plotter):
         if reconstruction_noise_map:
             try:
                 mapper_plotter.plot_source_from(
-                    pixel_values=self.inversion.reconstruction_noise_map_dict[mapper_plotter.mapper],
-                    auto_labels=AutoLabels(title="Noise Map", filename="reconstruction_noise_map"),
+                    pixel_values=self.inversion.reconstruction_noise_map_dict[
+                        mapper_plotter.mapper
+                    ],
+                    auto_labels=AutoLabels(
+                        title="Noise Map", filename="reconstruction_noise_map"
+                    ),
                 )
 
             except TypeError:
@@ -250,7 +254,9 @@ class InversionPlotter(Plotter):
             try:
                 signal_to_noise_values = (
                     self.inversion.reconstruction_dict[mapper_plotter.mapper]
-                    / self.inversion.reconstruction_noise_map_dict[mapper_plotter.mapper]
+                    / self.inversion.reconstruction_noise_map_dict[
+                        mapper_plotter.mapper
+                    ]
                 )
 
                 mapper_plotter.plot_source_from(
@@ -390,7 +396,9 @@ class InversionPlotter(Plotter):
 
         self.set_title(label="Noise-Map (Unzoomed)")
         self.figures_2d_of_pixelization(
-            pixelization_index=mapper_index, reconstruction_noise_map=True, zoom_to_brightest=False
+            pixelization_index=mapper_index,
+            reconstruction_noise_map=True,
+            zoom_to_brightest=False,
         )
 
         self.set_title(label="Regularization Weights (Unzoomed)")

--- a/test_autoarray/inversion/inversion/test_abstract.py
+++ b/test_autoarray/inversion/inversion/test_abstract.py
@@ -636,7 +636,9 @@ def test__reconstruction_noise_map():
 
     inversion = aa.m.MockInversion(curvature_reg_matrix=curvature_reg_matrix)
 
-    assert inversion.errors_with_covariance == pytest.approx(
-        np.array([[2.5, -1.0, -0.5], [-1.0, 1.0, 0.0], [-0.5, 0.0, 0.5]]), 1.0e-2
+    assert inversion.reconstruction_noise_map_with_covariance[0, 0] == pytest.approx(
+        np.sqrt(2.5), 1.0e-2
     )
-    assert inversion.reconstruction_noise_map == pytest.approx(np.array([2.5, 1.0, 0.5]), 1.0e-3)
+    assert inversion.reconstruction_noise_map == pytest.approx(
+        np.sqrt(np.array([2.5, 1.0, 0.5])), 1.0e-3
+    )

--- a/test_autoarray/inversion/inversion/test_abstract.py
+++ b/test_autoarray/inversion/inversion/test_abstract.py
@@ -631,7 +631,7 @@ def test__determinant_of_positive_definite_matrix_via_cholesky():
     )
 
 
-def test__errors_and_errors_with_covariance():
+def test__reconstruction_noise_map():
     curvature_reg_matrix = np.array([[1.0, 1.0, 1.0], [1.0, 2.0, 1.0], [1.0, 1.0, 3.0]])
 
     inversion = aa.m.MockInversion(curvature_reg_matrix=curvature_reg_matrix)
@@ -639,4 +639,4 @@ def test__errors_and_errors_with_covariance():
     assert inversion.errors_with_covariance == pytest.approx(
         np.array([[2.5, -1.0, -0.5], [-1.0, 1.0, 0.0], [-0.5, 0.0, 0.5]]), 1.0e-2
     )
-    assert inversion.errors == pytest.approx(np.array([2.5, 1.0, 0.5]), 1.0e-3)
+    assert inversion.reconstruction_noise_map == pytest.approx(np.array([2.5, 1.0, 0.5]), 1.0e-3)

--- a/test_autoarray/inversion/plot/test_inversion_plotters.py
+++ b/test_autoarray/inversion/plot/test_inversion_plotters.py
@@ -37,13 +37,13 @@ def test__individual_attributes_are_output_for_all_mappers(
         pixelization_index=0,
         reconstructed_image=True,
         reconstruction=True,
-        errors=True,
+        reconstruction_noise_map=True,
         regularization_weights=True,
     )
 
     assert path.join(plot_path, "reconstructed_image.png") in plot_patch.paths
     assert path.join(plot_path, "reconstruction.png") in plot_patch.paths
-    assert path.join(plot_path, "errors.png") in plot_patch.paths
+    assert path.join(plot_path, "reconstruction_noise_map.png") in plot_patch.paths
     assert path.join(plot_path, "regularization_weights.png") in plot_patch.paths
 
     pytest.importorskip(
@@ -66,7 +66,7 @@ def test__individual_attributes_are_output_for_all_mappers(
         sub_pixels_per_image_pixels=True,
         mesh_pixels_per_image_pixels=True,
         image_pixels_per_mesh_pixel=True,
-        errors=True,
+        reconstruction_noise_map=True,
         signal_to_noise_map=True,
         regularization_weights=True,
     )
@@ -76,7 +76,7 @@ def test__individual_attributes_are_output_for_all_mappers(
     assert path.join(plot_path, "sub_pixels_per_image_pixels.png") in plot_patch.paths
     assert path.join(plot_path, "mesh_pixels_per_image_pixels.png") in plot_patch.paths
     assert path.join(plot_path, "image_pixels_per_mesh_pixel.png") in plot_patch.paths
-    assert path.join(plot_path, "errors.png") in plot_patch.paths
+    assert path.join(plot_path, "reconstruction_noise_map.png") in plot_patch.paths
     assert path.join(plot_path, "signal_to_noise_map.png") in plot_patch.paths
     assert path.join(plot_path, "regularization_weights.png") in plot_patch.paths
 
@@ -85,12 +85,12 @@ def test__individual_attributes_are_output_for_all_mappers(
     inversion_plotter.figures_2d_of_pixelization(
         pixelization_index=0,
         reconstructed_image=True,
-        errors=True,
+        reconstruction_noise_map=True,
     )
 
     assert path.join(plot_path, "reconstructed_image.png") in plot_patch.paths
     assert path.join(plot_path, "reconstruction.png") not in plot_patch.paths
-    assert path.join(plot_path, "errors.png") in plot_patch.paths
+    assert path.join(plot_path, "reconstruction_noise_map.png") in plot_patch.paths
 
 
 def test__inversion_subplot_of_mapper__is_output_for_all_inversions(


### PR DESCRIPTION
The previous inversion API called the errors in a mesh source reconstruction as the property `errors`, which were defined as the variance in each mesh pixel.

This was confusing, as the `errors` were defined differently from the `noise_map` used throughout the code in dataset objects, and the errors required a `np.sqrt` to become the RMS standard deviation values like the `noise_map`.

This PR renames the inversion `errors` to the `reconstruction_noise_map` and includes the `np.sqrt` such that they are RMS standard deviations consistent with dataset objects.