### PR TITLE
Feature/noise scaling snr

### DIFF
--- a/autoarray/inversion/pixelization/mappers/abstract.py
+++ b/autoarray/inversion/pixelization/mappers/abstract.py
@@ -394,12 +394,16 @@ class AbstractMapper(LinearObj):
         )
 
     def extent_from(
-        self, values: np.ndarray = None, zoom_to_brightest: bool = True
+        self,
+        values: np.ndarray = None,
+        zoom_to_brightest: bool = True,
+        zoom_percent: Optional[float] = None,
     ) -> Tuple[float, float, float, float]:
         if zoom_to_brightest and values is not None:
-            zoom_percent = conf.instance["visualize"]["general"]["zoom"][
-                "inversion_percent"
-            ]
+            if zoom_percent is None:
+                zoom_percent = conf.instance["visualize"]["general"]["zoom"][
+                    "inversion_percent"
+                ]
 
             fractional_value = np.max(values) * zoom_percent
             fractional_bool = values > fractional_value

--- a/test_autoarray/dataset/imaging/test_dataset.py
+++ b/test_autoarray/dataset/imaging/test_dataset.py
@@ -1,3 +1,4 @@
+import copy
 import os
 from os import path
 
@@ -156,6 +157,21 @@ def test__apply_noise_scaling(imaging_7x7, mask_2d_7x7):
 
     assert masked_imaging_7x7.data.native[4, 4] == 0.0
     assert masked_imaging_7x7.noise_map.native[4, 4] == 1e5
+
+
+def test__apply_noise_scaling__use_signal_to_noise_value(imaging_7x7, mask_2d_7x7):
+    imaging_7x7 = copy.copy(imaging_7x7)
+
+    imaging_7x7.data[24] = 2.0
+
+    masked_imaging_7x7 = imaging_7x7.apply_noise_scaling(
+        mask=mask_2d_7x7, signal_to_noise_value=0.1
+    )
+
+    assert masked_imaging_7x7.data.native[3, 4] == 1.0
+    assert masked_imaging_7x7.noise_map.native[3, 4] == 10.0
+    assert masked_imaging_7x7.data.native[3, 3] == 2.0
+    assert masked_imaging_7x7.noise_map.native[3, 3] == 20.0
 
 
 def test__apply_mask__noise_covariance_matrix():

--- a/test_autoarray/dataset/imaging/test_dataset.py
+++ b/test_autoarray/dataset/imaging/test_dataset.py
@@ -165,7 +165,7 @@ def test__apply_noise_scaling__use_signal_to_noise_value(imaging_7x7, mask_2d_7x
     imaging_7x7.data[24] = 2.0
 
     masked_imaging_7x7 = imaging_7x7.apply_noise_scaling(
-        mask=mask_2d_7x7, signal_to_noise_value=0.1
+        mask=mask_2d_7x7, signal_to_noise_value=0.1, should_zero_data=False
     )
 
     assert masked_imaging_7x7.data.native[3, 4] == 1.0


### PR DESCRIPTION
        Apply a mask to the imaging dataset using noise scaling, whereby the maskmay zero the data and increase
        noise-map values to change how they enter the likelihood calculation.

        Given this data region is masked, it is likely thr data itself should not be included and therefore
        the masked data values are set to zero. This can be disabled by setting `should_zero_data=False`.

        Two forms of scaling are supported depending on whether the `signal_to_noise_value` is input:

        - `noise_value`: The noise-map values in the masked region are set to this value, typically a very large value,
        such that they are never included in the likelihood calculation.

        - `signal_to_noise_value`: The noise-map values in the masked region are set to values such that they give
        this signal-to-noise ratio. This overwrites the `noise_value` parameter.

        For certain modeling tasks, the mask defines regions of the data that are used to calculate the likelihood.
        For example, all data points in a mask may be used to create a pixel-grid, which is used in the likelihood.
        When data points are moved via `apply_mask`, they would be omitted from this grid entirely, which would
        lead to an incorrect likelihood calculation. Noise scaling retains these data points in the likelihood
        calculation, but ensures they do not contribute to the fit.

        This function can only be applied before actual masking.