### PR TITLE
perf: skip savefig rendering in PYAUTO_FAST_PLOTS mode

### DIFF
--- a/autoarray/plot/utils.py
+++ b/autoarray/plot/utils.py
@@ -12,6 +12,9 @@ import numpy as np
 logger = logging.getLogger(__name__)
 
 
+_FAST_PLOTS = os.environ.get("PYAUTO_FAST_PLOTS") == "1"
+
+
 def tight_layout():
     """Call ``plt.tight_layout()`` unless fast-plot mode is active.
 
@@ -19,7 +22,7 @@ def tight_layout():
     is skipped.  All figure creation, data computation, and rendering
     still execute — only the final spacing adjustment is bypassed.
     """
-    if os.environ.get("PYAUTO_FAST_PLOTS") == "1":
+    if _FAST_PLOTS:
         return
     plt.tight_layout()
 
@@ -338,6 +341,10 @@ def subplot_save(fig, output_path, output_filename, output_format=None):
     if _output_mode_save(fig, output_filename):
         return
 
+    if _FAST_PLOTS:
+        plt.close(fig)
+        return
+
     if output_format == "show" or not output_path:
         plt.show()
     else:
@@ -506,6 +513,10 @@ def save_figure(
         dpi = int(conf.instance["visualize"]["general"]["general"]["dpi"])
 
     if _output_mode_save(fig, filename):
+        return
+
+    if _FAST_PLOTS:
+        plt.close(fig)
         return
 
     formats = format if isinstance(format, (list, tuple)) else [format]


### PR DESCRIPTION
## Summary
When `PYAUTO_FAST_PLOTS=1`, skip `fig.savefig()` in `save_figure()` and `subplot_save()`. All figure creation, data computation, and matplotlib drawing calls still execute — only the final rendering-to-file is bypassed. This saves ~2s per subplot figure by avoiding font discovery, text metrics, and PNG encoding.

Also caches the env var lookup at module import time (`_FAST_PLOTS` flag).

## API Changes
None — internal changes only. The `PYAUTO_FAST_PLOTS` env var now additionally skips file output (previously it only skipped `tight_layout()`).

## Test Plan
- [x] All 722 PyAutoArray tests pass
- [x] `imaging/simulator.py` drops from 9.0s to 6.4s (subplot_tracer: 1.8s → 0.33s)
- [x] Normal behavior unchanged without the env var

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `autoarray.plot.utils.save_figure()` — when `PYAUTO_FAST_PLOTS=1`, closes the figure immediately without calling `fig.savefig()`
- `autoarray.plot.utils.subplot_save()` — same behaviour as above
- `autoarray.plot.utils._FAST_PLOTS` — new module-level bool, cached at import time from `os.environ.get("PYAUTO_FAST_PLOTS") == "1"`

### Migration
No migration needed — this is gated behind an opt-in environment variable.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)