### PR TITLE
Add should_simulate utility for auto-simulation with small datasets

### DIFF
--- a/autoarray/util/__init__.py
+++ b/autoarray/util/__init__.py
@@ -29,3 +29,4 @@ from autoarray.inversion.inversion.interferometer import (
 
 from autoarray.operators import transformer_util as transformer
 from autoarray.util import misc_util as misc
+from autoarray.util import dataset_util as dataset

--- a/autoarray/util/dataset_util.py
+++ b/autoarray/util/dataset_util.py
@@ -1,0 +1,24 @@
+import os
+import shutil
+
+
+def should_simulate(dataset_path):
+    """
+    Returns True if the dataset at ``dataset_path`` needs to be simulated.
+
+    When ``PYAUTO_WORKSPACE_SMALL_DATASETS=1`` is active, any existing dataset
+    is deleted so the simulator re-creates it at the reduced resolution.  This
+    avoids shape mismatches between full-resolution FITS files on disk and the
+    15x15 mask/grid cap applied by the env var.
+
+    Use this as a drop-in replacement for ``not path.exists(dataset_path)`` in
+    the workspace auto-simulation pattern::
+
+        if aa.util.dataset.should_simulate(dataset_path):
+            subprocess.run([sys.executable, "scripts/.../simulator.py"], check=True)
+    """
+    if os.environ.get("PYAUTO_WORKSPACE_SMALL_DATASETS") == "1":
+        if os.path.exists(dataset_path):
+            shutil.rmtree(dataset_path)
+
+    return not os.path.exists(dataset_path)


### PR DESCRIPTION
## Summary
Adds `autoarray.util.dataset_util.should_simulate(dataset_path)` — a drop-in replacement for `not path.exists(dataset_path)` in workspace auto-simulation blocks. When `PYAUTO_WORKSPACE_SMALL_DATASETS=1` is active, it deletes existing datasets so they are re-simulated at the reduced 15x15 resolution, preventing shape mismatches.

## API Changes
### Added
- `autoarray.util.dataset_util.should_simulate(dataset_path)` — returns True if dataset needs simulation; auto-deletes stale datasets when small-datasets env var is toggled
- Exposed as `aa.util.dataset.should_simulate()`

## Test Plan
- [x] PyAutoArray unit tests pass (722 passed)
- [x] Manual verification of should_simulate behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)