### PR TITLE
fix: add _mappings_sizes_weights_split to InterpolatorRectangular

### DIFF
--- a/autoarray/inversion/mesh/interpolator/rectangular.py
+++ b/autoarray/inversion/mesh/interpolator/rectangular.py
@@ -305,3 +305,10 @@ class InterpolatorRectangular(AbstractInterpolator):
         sizes = 4 * self._xp.ones(len(mappings), dtype="int")
 
         return mappings, sizes, weights
+
+    @cached_property
+    def _mappings_sizes_weights_split(self):
+        # Rectangular pixelizations use bilinear interpolation which already factors
+        # in the 4-corner neighbourhood, so no separate split-cross calculation is
+        # needed — split regularization reuses the same mappings.
+        return self._mappings_sizes_weights


### PR DESCRIPTION
## Summary

- The `_mappings_sizes_weights_split` cached property exists on `InterpolatorKNN` and `InterpolatorDelaunay`, but was missing from `InterpolatorRectangular`.
- Any rectangular mesh + split regularization (`ConstantSplit`, `AdaptSplit`, `AdaptSplitZeroth`) combination raised `AttributeError` at runtime.
- Rectangular pixelizations use bilinear interpolation which already factors in the 4-corner neighbourhood, so split regularization reuses the same mapping arrays.

## Test plan

- [ ] Run a rectangular mesh + `ConstantSplit` regularization fit from the autolens_workspace and confirm the inversion completes without error
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)