### PR TITLE
Guarantee GaussianKernel regularization matrix is PD

### DIFF
--- a/autoarray/inversion/regularization/gaussian_kernel.py
+++ b/autoarray/inversion/regularization/gaussian_kernel.py
@@ -115,4 +115,19 @@ class GaussianKernel(AbstractRegularization):
             xp=xp,
         )
 
-        return self.coefficient * xp.linalg.inv(covariance_matrix)
+        regularization_matrix = self.coefficient * xp.linalg.inv(covariance_matrix)
+
+        # inv() loses exact symmetry and can introduce tiny negative eigenvalues
+        # when the covariance matrix is near-singular (e.g. scale >> pixel
+        # spacing). Symmetrise and add a trace-scaled diagonal jitter so the
+        # downstream cholesky in log_det_regularization_matrix_term cannot
+        # fail on floating-point noise.
+        regularization_matrix = 0.5 * (regularization_matrix + regularization_matrix.T)
+        N = regularization_matrix.shape[0]
+        diag_mean = xp.mean(xp.diag(regularization_matrix))
+        jitter = 1e-8 * xp.abs(diag_mean)
+        regularization_matrix = regularization_matrix + xp.eye(
+            N, dtype=regularization_matrix.dtype
+        ) * jitter
+
+        return regularization_matrix


### PR DESCRIPTION
## Summary
- Symmetrise and add trace-scaled diagonal jitter to the inverted covariance matrix in `GaussianKernel.regularization_matrix_from` so downstream `cholesky(regularization_matrix_reduced)` in `log_det_regularization_matrix_term` cannot fail on floating-point noise.
- Root cause: when the Gaussian `scale` is large relative to pixel spacing, `cov = exp(-d²/(2·scale²)) + 1e-8·I` is numerically near rank-1. `xp.linalg.inv(cov)` then returns a matrix that is mathematically PD but in floating point is slightly asymmetric with tiny negative eigenvalues, crashing the cholesky in `FitDataset.log_evidence`. This reliably reproduced under `PYAUTOFIT_TEST_MODE=2` for 3 autogalaxy pixelization scripts with `LogUniformPrior(1e-6, 1e6)` on `scale`.
- Uses the same `xp` dispatching as the rest of the module, so the fix works for both the numpy and JAX backends without branching.

## Test plan
- [x] Repro the pre-fix LinAlgError with `PYAUTOFIT_TEST_MODE=2` + wiped output dir
- [x] Post-fix: 3 previously failing scripts (`autogalaxy imaging/features/pixelization/modeling.py`, `interferometer/features/pixelization/modeling.py`, `howtogalaxy/chapter_4_pixelizations/tutorial_5_model_fit.py`) all exit 0
- [x] No-regression: autolens pixelization `imaging/features/pixelization/modeling.py` still passes
- [x] `pytest test_autoarray/inversion/regularizations/` — 33 passed (including `test_gaussian_kernel.py`)

Paired with the SLOW-skip PRs on `autogalaxy_workspace` and `autolens_workspace` under the same branch name.

Generated with [Claude Code](https://claude.com/claude-code)