### PR TITLE
refactor: rename env vars to PYAUTO_* prefix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,10 +45,10 @@ black autoarray/
 
 ### Plot Output Mode
 
-Set `PYAUTOARRAY_OUTPUT_MODE=1` to capture every figure produced by a script into numbered PNG files in `./output_mode/<script_name>/`. This is useful for visually inspecting all plots from an integration test without needing a display.
+Set `PYAUTO_OUTPUT_MODE=1` to capture every figure produced by a script into numbered PNG files in `./output_mode/<script_name>/`. This is useful for visually inspecting all plots from an integration test without needing a display.
 
 ```bash
-PYAUTOARRAY_OUTPUT_MODE=1 python scripts/my_script.py
+PYAUTO_OUTPUT_MODE=1 python scripts/my_script.py
 # -> ./output_mode/my_script/0_fit.png, 1_tracer.png, ...
 ```
 

--- a/autoarray/inversion/mesh/image_mesh/hilbert.py
+++ b/autoarray/inversion/mesh/image_mesh/hilbert.py
@@ -12,7 +12,7 @@ from autoarray.inversion.mesh.image_mesh.abstract_weighted import (
 from autoarray.structures.grids.irregular_2d import Grid2DIrregular
 
 from autoarray import exc
-from autoconf.test_mode import is_test_mode
+from autoconf.test_mode import skip_checks
 
 
 def gilbert2d(width, height):
@@ -331,7 +331,7 @@ class Hilbert(AbstractImageMeshWeighted):
             an exception is raised.
         """
 
-        if is_test_mode():
+        if skip_checks():
             return
 
         if image_mesh_min_mesh_pixels_per_pixel is not None:
@@ -398,7 +398,7 @@ class Hilbert(AbstractImageMeshWeighted):
             an exception is raised.
         """
 
-        if is_test_mode():
+        if skip_checks():
             return
 
         if image_mesh_adapt_background_percent_threshold is not None:

--- a/autoarray/mask/mask_2d.py
+++ b/autoarray/mask/mask_2d.py
@@ -360,7 +360,7 @@ class Mask2D(Mask):
             and visa versa.
         """
 
-        if os.environ.get("PYAUTO_WORKSPACE_SMALL_DATASETS") == "1":
+        if os.environ.get("PYAUTO_SMALL_DATASETS") == "1":
             if shape_native[0] > 15 or shape_native[1] > 15:
                 shape_native = (15, 15)
                 pixel_scales = 0.6

--- a/autoarray/operators/over_sampling/over_sample_util.py
+++ b/autoarray/operators/over_sampling/over_sample_util.py
@@ -232,7 +232,7 @@ def over_sample_size_via_radial_bins_from(
     """
     Returns an adaptive sub-grid size based on the radial distance of every pixel from the centre of the mask.
 
-    When ``PYAUTO_WORKSPACE_SMALL_DATASETS=1`` returns a uniform size-2 array
+    When ``PYAUTO_SMALL_DATASETS=1`` returns a uniform size-2 array
     immediately, skipping the expensive radial-bin computation and numba JIT.
 
     The adaptive sub-grid size is computed as follows:
@@ -269,7 +269,7 @@ def over_sample_size_via_radial_bins_from(
 
     import os
 
-    if os.environ.get("PYAUTO_WORKSPACE_SMALL_DATASETS") == "1":
+    if os.environ.get("PYAUTO_SMALL_DATASETS") == "1":
         return Array2D(values=np.full(grid.shape_slim, 2.0), mask=grid.mask)
 
     if centre_list is None:

--- a/autoarray/plot/output.py
+++ b/autoarray/plot/output.py
@@ -193,7 +193,7 @@ class Output:
                 os.makedirs(output_path, exist_ok=True)
 
             if not self.bypass:
-                if os.environ.get("PYAUTOARRAY_OUTPUT_MODE") == "1":
+                if os.environ.get("PYAUTO_OUTPUT_MODE") == "1":
                     return self.to_figure_output_mode(filename=filename)
 
                 if format == "show":
@@ -222,7 +222,7 @@ class Output:
             if format != "show":
                 os.makedirs(output_path, exist_ok=True)
 
-            if os.environ.get("PYAUTOARRAY_OUTPUT_MODE") == "1":
+            if os.environ.get("PYAUTO_OUTPUT_MODE") == "1":
                 return self.to_figure_output_mode(filename=filename)
 
             if format == "show":
@@ -237,7 +237,7 @@ class Output:
         """Save the current figure as a numbered PNG snapshot in *output mode*.
 
         Output mode is activated by setting the environment variable
-        ``PYAUTOARRAY_OUTPUT_MODE=1``.  Each call increments a global counter
+        ``PYAUTO_OUTPUT_MODE=1``.  Each call increments a global counter
         so that figures are saved as ``0_filename.png``, ``1_filename.png``,
         etc. in a sub-directory named after the running script.  This is useful
         for collecting a sequence of figures during automated testing or

--- a/autoarray/plot/utils.py
+++ b/autoarray/plot/utils.py
@@ -299,13 +299,13 @@ def set_with_color_values(ax, cmap, color_values, norm=None):
 def _output_mode_save(fig, filename):
     import matplotlib.pyplot as plt
 
-    """If ``PYAUTOARRAY_OUTPUT_MODE=1``, save *fig* to a numbered file in
+    """If ``PYAUTO_OUTPUT_MODE=1``, save *fig* to a numbered file in
     ``./output_mode/<script_name>/`` and return ``True``.  Otherwise return
     ``False`` so the caller can proceed with normal saving.
 
     The counter is stored as a function attribute to avoid a global variable.
     """
-    if os.environ.get("PYAUTOARRAY_OUTPUT_MODE") != "1":
+    if os.environ.get("PYAUTO_OUTPUT_MODE") != "1":
         return False
 
     import sys

--- a/autoarray/structures/grids/uniform_2d.py
+++ b/autoarray/structures/grids/uniform_2d.py
@@ -171,7 +171,7 @@ class Grid2D(Structure):
 
         grid_2d_util.check_grid_2d(grid_2d=values)
 
-        if os.environ.get("PYAUTO_WORKSPACE_SMALL_DATASETS") == "1":
+        if os.environ.get("PYAUTO_SMALL_DATASETS") == "1":
             over_sample_size = 2
 
         self._over_sample_size = over_sample_size
@@ -490,7 +490,7 @@ class Grid2D(Structure):
         origin
             The origin of the grid's mask.
         """
-        if os.environ.get("PYAUTO_WORKSPACE_SMALL_DATASETS") == "1":
+        if os.environ.get("PYAUTO_SMALL_DATASETS") == "1":
             if shape_native[0] > 15 or shape_native[1] > 15:
                 shape_native = (15, 15)
                 pixel_scales = 0.6

--- a/autoarray/util/dataset_util.py
+++ b/autoarray/util/dataset_util.py
@@ -6,7 +6,7 @@ def should_simulate(dataset_path):
     """
     Returns True if the dataset at ``dataset_path`` needs to be simulated.
 
-    When ``PYAUTO_WORKSPACE_SMALL_DATASETS=1`` is active, any existing dataset
+    When ``PYAUTO_SMALL_DATASETS=1`` is active, any existing dataset
     is deleted so the simulator re-creates it at the reduced resolution.  This
     avoids shape mismatches between full-resolution FITS files on disk and the
     15x15 mask/grid cap applied by the env var.
@@ -17,7 +17,7 @@ def should_simulate(dataset_path):
         if aa.util.dataset.should_simulate(dataset_path):
             subprocess.run([sys.executable, "scripts/.../simulator.py"], check=True)
     """
-    if os.environ.get("PYAUTO_WORKSPACE_SMALL_DATASETS") == "1":
+    if os.environ.get("PYAUTO_SMALL_DATASETS") == "1":
         if os.path.exists(dataset_path):
             shutil.rmtree(dataset_path)
 


### PR DESCRIPTION
## Summary
Rename environment variables to the unified `PYAUTO_*` prefix and switch mesh validation checks from `is_test_mode()` to `skip_checks()`.

Depends on: rhayes777/PyAutoConf#86

## API Changes
Three env var renames. Hilbert mesh validation now controlled by `PYAUTO_SKIP_CHECKS` instead of `PYAUTOFIT_TEST_MODE`. See full details below.

## Test Plan
- [x] All 727 PyAutoArray tests pass
- [x] CLAUDE.md documentation updated

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `PYAUTOARRAY_OUTPUT_MODE` renamed to `PYAUTO_OUTPUT_MODE` (plot/output.py, plot/utils.py)
- `PYAUTO_WORKSPACE_SMALL_DATASETS` renamed to `PYAUTO_SMALL_DATASETS` (grids, masks, over_sampling, dataset_util)
- `check_adapt_pixelisation()` and `check_adapt_background_pixels()` now check `PYAUTO_SKIP_CHECKS` instead of `is_test_mode()`

### Migration
- Before: `PYAUTOARRAY_OUTPUT_MODE=1` → After: `PYAUTO_OUTPUT_MODE=1`
- Before: `PYAUTO_WORKSPACE_SMALL_DATASETS=1` → After: `PYAUTO_SMALL_DATASETS=1`

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)