### PR TITLE
fix: bump scipy cap to <=1.15.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "decorator>=4.0.0",
     "dill>=0.3.1.1",
     "matplotlib>=3.7.0",
-    "scipy<=1.14.0",
+    "scipy<=1.15.2",
     "scikit-image<=0.24.0",
     "scikit-learn<=1.5.1",
     "tqdm"


### PR DESCRIPTION
## Summary
- Bumps scipy upper bound from `<=1.14.0` to `<=1.15.2`
- The hard cap at 1.14.0 caused PyAutoGalaxy CI to fail: when jax pulled in scipy 1.17.1 and autofit forced a downgrade, pip's resolver backtracked into building scipy from source, which failed due to missing OpenBLAS on the CI runner
- All 6 PyAutoGalaxy CI runs on April 12 are affected
- Companion PR: PyAutoLabs/PyAutoFit#1196

## Test plan
- [x] Verified full install chain locally: PyAutoConf → PyAutoFit → PyAutoArray → PyAutoGalaxy (including optional deps) resolves without conflict
- [ ] PyAutoGalaxy CI passes after both this PR and the matching PyAutoFit PR are merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)