### PR TITLE
build: raise caps on scipy, astropy, scikit-image, scikit-learn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,13 +23,13 @@ classifiers = [
 keywords = ["cli"]
 dependencies = [
     "autoconf",
-    "astropy>=5.0,<=6.1.2",
+    "astropy>=5.0,<=7.2.0",
     "decorator>=4.0.0",
     "dill>=0.3.1.1",
     "matplotlib>=3.7.0",
-    "scipy<=1.15.2",
-    "scikit-image<=0.24.0",
-    "scikit-learn<=1.5.1",
+    "scipy<=1.17.1",
+    "scikit-image<=0.26.0",
+    "scikit-learn<=1.8.0",
     "tqdm"
 ]
 


### PR DESCRIPTION
## Summary
Raise caps: scipy <=1.15.2 → <=1.17.1, astropy <=6.1.2 → <=7.2.0, scikit-image <=0.24.0 → <=0.26.0, scikit-learn <=1.5.1 → <=1.8.0.

Part of cross-ecosystem dependency sweep (PyAutoLabs/PyAutoConf#87).

## API Changes
None — internal changes only.

## Test Plan
- [x] PyAutoArray unit tests pass (727/727)
- [x] Full stack tests pass (3,070 across 5 repos)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)