### PR TITLE
fix: guard zoom_array against non-autoarray mask objects

### DIFF
--- a/autoarray/plot/utils.py
+++ b/autoarray/plot/utils.py
@@ -105,7 +105,7 @@ def zoom_array(array):
     except Exception:
         zoom_around_mask = False
 
-    if zoom_around_mask and hasattr(array, "mask") and not array.mask.is_all_false:
+    if zoom_around_mask and hasattr(array, "mask") and hasattr(array.mask, "is_all_false") and not array.mask.is_all_false:
         from autoarray.mask.derive.zoom_2d import Zoom2D
 
         return Zoom2D(mask=array.mask).array_2d_from(array=array, buffer=1)


### PR DESCRIPTION
## Summary

Fix `zoom_array` in `autoarray/plot/utils.py` to handle objects that have a `.mask` attribute but aren't autoarray `Mask` instances (e.g. `numpy.ma.MaskedArray`). Previously, passing such an array would crash with `AttributeError: 'numpy.ndarray' object has no attribute 'is_all_false'`.

This was the root cause of ~200 cascading failures in the Apr 10 release build — workspace simulator scripts that produce plain numpy arrays for plotting triggered this crash, which prevented dataset generation, which caused all downstream scripts to fail with missing data.

Relates to #269.

## API Changes
None — internal changes only.

## Test Plan
- [x] `test_autoarray/` — 727 passed
- [ ] Release build re-run after merge to verify cascade is resolved

<details>
<summary>Full API Changes (for automation & release notes)</summary>

No public API changes. Internal guard added to `zoom_array()` in `autoarray/plot/utils.py`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)