### PR TITLE
refactor: reduce magic in transform decorator

### DIFF
--- a/autoarray/abstract_ndarray.py
+++ b/autoarray/abstract_ndarray.py
@@ -77,6 +77,14 @@ class AbstractNDArray(ABC):
         self.use_jax = xp is not np
 
     @property
+    def is_transformed(self) -> bool:
+        return self._is_transformed
+
+    @is_transformed.setter
+    def is_transformed(self, value: bool):
+        self._is_transformed = value
+
+    @property
     def _xp(self):
         if self.use_jax:
             import jax.numpy as jnp

--- a/autoarray/structures/decorators/transform.py
+++ b/autoarray/structures/decorators/transform.py
@@ -20,19 +20,40 @@ def transform(func=None, *, rotate_back=False):
         @transform(rotate_back=True)
         def deflections_yx_2d_from(self, grid, xp=np, **kwargs): ...
 
-    When ``rotate_back=True``, after the decorated function returns its result the decorator automatically
-    rotates the output vector back from the profile's reference frame to the original observer frame.
-    This eliminates the need for deflection methods to manually call
-    ``self.rotated_grid_from_reference_frame_from``.
+    **Frame conventions and rotate_back**
+
+    This decorator transforms the input grid into the profile's reference frame (centred on the
+    profile centre and rotated by its position angle) before calling the decorated function.
+
+    For **scalar** quantities (convergence, potential), the returned value is frame-invariant — no
+    back-rotation is needed, so use ``@transform`` without ``rotate_back``.
+
+    For **vector** quantities (e.g. deflection angles), whether back-rotation is needed depends on
+    which frame the returned components are expressed in:
+
+    - If the function computes vector components using the rotated grid coordinates (i.e. the
+      components are expressed in the profile's frame), they must be rotated back to the observer
+      frame before use in ray-tracing. Set ``rotate_back=True`` for this case.
+
+    - If the function reconstructs observer-frame components from scalar quantities (e.g. computing
+      a radial deflection magnitude and converting to Cartesian using observer-frame geometry), the
+      result is already in the observer frame and ``rotate_back`` should remain ``False``.
+
+    When ``rotate_back=True``, the decorator calls ``obj.rotated_grid_from_reference_frame_from``
+    on the result after evaluation, applying the inverse rotation by the profile's position angle.
+
+    For **spin-2** quantities (shear), the transformation law uses twice the profile angle. This
+    is not handled by ``rotate_back`` — shear methods must apply the 2-theta rotation manually.
 
     Parameters
     ----------
     func
         A function where the input grid is the grid whose coordinates are transformed.
     rotate_back
-        If ``True``, the result is rotated back from the profile's reference frame after evaluation.
-        Use this for functions that return vector quantities (e.g. deflection angles) computed in the
-        profile's rotated frame.
+        If ``True``, the result is rotated back from the profile's reference frame after
+        evaluation. Use this when the decorated function returns vector components that were
+        computed in the profile's rotated coordinate basis and need to be expressed in the
+        original observer frame.
 
     Returns
     -------

--- a/autoarray/structures/decorators/transform.py
+++ b/autoarray/structures/decorators/transform.py
@@ -7,61 +7,90 @@ from autoarray.structures.grids.irregular_2d import Grid2DIrregular
 from autoarray.structures.grids.uniform_2d import Grid2D
 
 
-def transform(func):
+def transform(func=None, *, rotate_back=False):
     """
     Checks whether the input Grid2D of (y,x) coordinates have previously been transformed. If they have not
     been transformed then they are transformed.
+
+    Can be used with or without arguments::
+
+        @transform
+        def convergence_2d_from(self, grid, xp=np, **kwargs): ...
+
+        @transform(rotate_back=True)
+        def deflections_yx_2d_from(self, grid, xp=np, **kwargs): ...
+
+    When ``rotate_back=True``, after the decorated function returns its result the decorator automatically
+    rotates the output vector back from the profile's reference frame to the original observer frame.
+    This eliminates the need for deflection methods to manually call
+    ``self.rotated_grid_from_reference_frame_from``.
 
     Parameters
     ----------
     func
         A function where the input grid is the grid whose coordinates are transformed.
+    rotate_back
+        If ``True``, the result is rotated back from the profile's reference frame after evaluation.
+        Use this for functions that return vector quantities (e.g. deflection angles) computed in the
+        profile's rotated frame.
 
     Returns
     -------
         A function that can accept cartesian or transformed coordinates
     """
 
-    @wraps(func)
-    def wrapper(
-        obj: object,
-        grid: Union[np.ndarray, Grid2D, Grid2DIrregular, Grid1D],
-        xp=np,
-        *args,
-        **kwargs,
-    ) -> Union[np.ndarray, Grid2D, Grid2DIrregular]:
-        """
-        This decorator checks whether the input grid has been transformed to the reference frame of the class
-        that owns the function. If it has not been transformed, it is transformed.
+    def decorator(func):
+        @wraps(func)
+        def wrapper(
+            obj: object,
+            grid: Union[np.ndarray, Grid2D, Grid2DIrregular, Grid1D],
+            xp=np,
+            *args,
+            **kwargs,
+        ) -> Union[np.ndarray, Grid2D, Grid2DIrregular]:
+            """
+            This decorator checks whether the input grid has been transformed to the reference frame of the class
+            that owns the function. If it has not been transformed, it is transformed.
 
-        A function call which uses this decorator often has many subsequent function calls which also use the
-        decorator. To ensure the grid is only transformed once, the `is_transformed` keyword is used to track
-        whether the grid has been transformed.
+            The transform state is tracked via the ``is_transformed`` property on the grid object itself.
+            When a decorated function calls another decorated function with the same (already-transformed)
+            grid, the flag prevents the grid from being transformed a second time.
 
-        Parameters
-        ----------
-        obj
-            An object whose function uses grid_like inputs to compute quantities at every coordinate on the grid.
-        grid
-            The (y, x) coordinates in the original reference frame of the grid.
+            Parameters
+            ----------
+            obj
+                An object whose function uses grid_like inputs to compute quantities at every coordinate on the grid.
+            grid
+                The (y, x) coordinates in the original reference frame of the grid.
 
-        Returns
-        -------
-            A grid_like object whose coordinates may be transformed.
-        """
+            Returns
+            -------
+                A grid_like object whose coordinates may be transformed.
+            """
 
-        if not kwargs.get("is_transformed"):
-            kwargs["is_transformed"] = True
+            if not getattr(grid, "is_transformed", False):
+                transformed_grid = obj.transformed_to_reference_frame_grid_from(
+                    grid, xp, **kwargs
+                )
+                transformed_grid.is_transformed = True
 
-            transformed_grid = obj.transformed_to_reference_frame_grid_from(
-                grid, xp, **kwargs
-            )
+                result = func(obj, transformed_grid, xp, *args, **kwargs)
 
-            result = func(obj, transformed_grid, xp, *args, **kwargs)
+            else:
+                result = func(obj, grid, xp, *args, **kwargs)
 
-        else:
-            result = func(obj, grid, xp, *args, **kwargs)
+            if rotate_back:
+                result = obj.rotated_grid_from_reference_frame_from(
+                    grid=result, xp=xp
+                )
 
-        return result
+            return result
 
-    return wrapper
+        return wrapper
+
+    if func is not None:
+        # Called without arguments: @transform
+        return decorator(func)
+
+    # Called with arguments: @transform(rotate_back=True)
+    return decorator


### PR DESCRIPTION
## Summary

Reduce the implicit "magic" in the `@aa.grid_dec.transform` decorator while keeping its DRY benefits. This is Phase 1+2 of the refactor described in #271.

**Phase 1:** The `is_transformed` flag now lives as a property on the grid object itself (`grid.is_transformed`) instead of being threaded through `**kwargs`. This makes transform state explicit, inspectable, and impossible to lose through missed kwarg propagation.

**Phase 2:** Added `rotate_back` parameter to `@aa.grid_dec.transform(rotate_back=True)`. When enabled, the decorator automatically rotates vector outputs (e.g. deflection angles) back from the profile's reference frame to the observer frame — eliminating the need for deflection methods to manually call `self.rotated_grid_from_reference_frame_from(...)`.

## API Changes

- `@aa.grid_dec.transform` now accepts an optional `rotate_back=True` keyword argument. Existing usage without arguments is fully backward-compatible.
- `grid.is_transformed` is now a public readable/writable property on all grid objects (`Grid2D`, `Grid2DIrregular`, `Grid1D`).

See full details below.

## Test Plan
- [x] 725 PyAutoArray tests pass
- [x] 834 PyAutoGalaxy tests pass (including 12 new regression tests)
- [x] Exact numerical regression values locked in for Isothermal, NFW, PowerLaw

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `AbstractNDArray.is_transformed` — public property (getter/setter) exposing transform state on grid objects
- `transform(rotate_back=True)` — optional parameter on the transform decorator for automatic back-rotation of vector outputs

### Changed Behaviour
- `@aa.grid_dec.transform` now reads/writes `grid.is_transformed` instead of `kwargs["is_transformed"]`. The kwarg-based approach is no longer used.

### Migration
- Before: `kwargs.get("is_transformed")` to check transform state
- After: `grid.is_transformed` to check transform state
- No action needed for most users — the decorator handles this internally

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)