### PR TITLE
fix: pin autoconf dependency version and update homepage URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 keywords = ["cli"]
 dependencies = [
-    "autoconf",
+    "autoconf==2026.4.13.3",
     "astropy>=5.0,<=7.2.0",
     "decorator>=4.0.0",
     "dill>=0.3.1.1",
@@ -35,7 +35,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/Jammy2211/PyAutoArray"
+Homepage = "https://github.com/PyAutoLabs/PyAutoArray"
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
## Summary
- Pin `autoconf` to exact version (`==2026.4.13.3`) so pip cannot resolve to the wrong PyPI package (GNU autoconf 0.7.7)
- Update homepage URL from `Jammy2211/PyAutoArray` to `PyAutoLabs/PyAutoArray`
- The release workflow will auto-update the pinned version via sed

## Test plan
- [ ] `pip install` resolves `autoconf` to the correct PyAuto package
- [ ] Release workflow sed pattern matches and updates the pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)