### PR TITLE
fix: handle off-centre masks in convolver and blurring grid

### DIFF
--- a/autoarray/operators/convolver.py
+++ b/autoarray/operators/convolver.py
@@ -116,8 +116,14 @@ class ConvolverState:
             s1 + s2 - 1 for s1, s2 in zip(mask_shape, self.kernel.shape_native)
         )
         import scipy.fft
+        from autoarray.mask.mask_2d_util import required_shape_for_kernel
 
-        fft_shape = tuple(scipy.fft.next_fast_len(s, real=True) for s in full_shape)
+        min_blur_shape = required_shape_for_kernel(mask, self.kernel.shape_native)
+
+        fft_shape = tuple(
+            scipy.fft.next_fast_len(max(s, r), real=True)
+            for s, r in zip(full_shape, min_blur_shape)
+        )
 
         self.fft_shape = fft_shape
         self.mask = mask.resized_from(self.fft_shape, pad_value=1)

--- a/autoarray/structures/grids/uniform_2d.py
+++ b/autoarray/structures/grids/uniform_2d.py
@@ -710,7 +710,7 @@ class Grid2D(Structure):
         """
 
         blurring_mask = mask.derive_mask.blurring_from(
-            kernel_shape_native=kernel_shape_native
+            kernel_shape_native=kernel_shape_native, allow_padding=True
         )
 
         return cls.from_mask(


### PR DESCRIPTION
## Summary
- Convolver `fft_shape` now accounts for asymmetric mask positions via `required_shape_for_kernel`, preventing `MaskException` when the blurring region extends beyond the image edge
- `Grid2D.blurring()` passes `allow_padding=True` so off-centre masks pad gracefully instead of raising

## Context
15 Euclid datasets with off-centre masks (recentered lens positions) failed with `MaskException: The input mask is too small for the kernel shape`. The PSF kernel footprint extended beyond the image boundary on the crowded side.

## Test plan
- [x] Existing `test_fit_imaging.py` tests pass (45/45)
- [x] New unit test in PyAutoLens verifies padded vs non-padded likelihoods match
- [x] Integration test in `autolens_workspace_test` convolution script passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)