### PR TITLE
fix: suppress CLI noise from escape sequences and third-party warnings

### DIFF
--- a/autoarray/inversion/inversion/imaging/inversion_imaging_util.py
+++ b/autoarray/inversion/inversion/imaging/inversion_imaging_util.py
@@ -74,7 +74,7 @@ def data_vector_via_psf_weighted_data_from(
     vals: np.ndarray,  # (nnz,) float64 mapping weights incl sub_fraction
     S: int,  # number of source pixels
 ) -> np.ndarray:
-    """
+    r"""
     Returns the data vector `D` from the `psf_weighted_data` matrix (see `psf_weighted_data_from`), which encodes the
     the 1D image `d` and 1D noise-map values `\sigma` (see Warren & Dye 2003).
 
@@ -107,7 +107,7 @@ def data_vector_via_psf_weighted_data_from(
 def data_vector_via_blurred_mapping_matrix_from(
     blurred_mapping_matrix: np.ndarray, image: np.ndarray, noise_map: np.ndarray
 ) -> np.ndarray:
-    """
+    r"""
     Returns the data vector `D` from a blurred mapping matrix `f` and the 1D image `d` and 1D noise-map $\sigma$`
     (see Warren & Dye 2003).
 

--- a/autoarray/inversion/inversion/imaging_numba/inversion_imaging_numba_util.py
+++ b/autoarray/inversion/inversion/imaging_numba/inversion_imaging_numba_util.py
@@ -344,7 +344,7 @@ def psf_precision_value_from(
 def data_vector_via_blurred_mapping_matrix_from(
     blurred_mapping_matrix: np.ndarray, image: np.ndarray, noise_map: np.ndarray
 ) -> np.ndarray:
-    """
+    r"""
     Returns the data vector `D` from a blurred mapping matrix `f` and the 1D image `d` and 1D noise-map $\sigma$`
     (see Warren & Dye 2003).
 
@@ -381,7 +381,7 @@ def data_vector_via_psf_weighted_data_from(
     pix_lengths: np.ndarray,
     pix_pixels: int,
 ) -> np.ndarray:
-    """
+    r"""
     Returns the data vector `D` from the `psf_weighted_data` matrix (see `psf_weighted_data_from`), which encodes the
     the 1D image `d` and 1D noise-map values `\sigma` (see Warren & Dye 2003).
 

--- a/autoarray/inversion/inversion/inversion_util.py
+++ b/autoarray/inversion/inversion/inversion_util.py
@@ -84,7 +84,7 @@ def curvature_matrix_via_mapping_matrix_from(
     settings: "Settings" = Settings(),
     xp=np,
 ) -> np.ndarray:
-    """
+    r"""
     Returns the curvature matrix `F` from a blurred mapping matrix `f` and the 1D noise-map $\sigma$
      (see Warren & Dye 2003).
 

--- a/autoarray/mask/mask_2d.py
+++ b/autoarray/mask/mask_2d.py
@@ -54,7 +54,7 @@ class Mask2D(Mask):
         *args,
         **kwargs,
     ):
-        """
+        r"""
         A 2D mask, used for masking values which are associated with a a uniform rectangular grid of pixels.
 
         When applied to 2D data with the same shape, values in the mask corresponding to ``False`` entries are

--- a/autoarray/operators/over_sampling/over_sampler.py
+++ b/autoarray/operators/over_sampling/over_sampler.py
@@ -13,7 +13,7 @@ from autoarray.operators.over_sampling import over_sample_util
 
 class OverSampler:
     def __init__(self, mask: Mask2D, sub_size: Union[int, Array2D]):
-        """
+        r"""
          Over samples grid calculations using a uniform sub-grid.
 
         When a 2D grid of (y,x) coordinates is input into a function, the result is evaluated at every coordinate

--- a/autoarray/structures/arrays/uniform_2d.py
+++ b/autoarray/structures/arrays/uniform_2d.py
@@ -36,7 +36,7 @@ class AbstractArray2D(Structure):
         *args,
         **kwargs,
     ):
-        """
+        r"""
         A uniform 2D array of values, which are paired with a 2D mask of pixels.
 
         The ``Array2D`, like all data structures (e.g. ``Grid2D``, ``VectorYX2D``) has in-built functionality which:

--- a/autoarray/structures/grids/uniform_2d.py
+++ b/autoarray/structures/grids/uniform_2d.py
@@ -33,7 +33,7 @@ class Grid2D(Structure):
         *args,
         **kwargs,
     ):
-        """
+        r"""
         A grid of 2D (y,x) coordinates, which are paired to a uniform 2D mask of pixels. Each entry
         on the grid corresponds to the (y,x) coordinates at the centre of a pixel of an unmasked pixel.
 

--- a/autoarray/structures/vectors/uniform.py
+++ b/autoarray/structures/vectors/uniform.py
@@ -26,7 +26,7 @@ class VectorYX2D(AbstractVectorYX2D):
         mask: Mask2D,
         store_native: bool = False,
     ):
-        """
+        r"""
         A collection of (y,x) vectors which are located on a regular 2D grid of (y,x) coordinates.
 
         The vectors are paired to a uniform 2D mask of pixels. Each vector corresponds to a value at

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,3 +59,7 @@ dev = ["pytest", "black", "numba", "pynufft==2022.2.2"]
 
 [tool.pytest.ini_options]
 testpaths = ["test_autoarray"]
+filterwarnings = [
+    "ignore:cuda_plugin_extension:UserWarning",
+    "ignore::DeprecationWarning:jax",
+]


### PR DESCRIPTION
## Summary
Suppress CLI noise during test collection by converting docstrings containing ASCII art and LaTeX math to raw strings, and adding pytest warning filters for JAX CUDA plugin and deprecation warnings.

## API Changes
None — internal changes only.

## Test Plan
- [x] All 727 unit tests pass
- [x] `pytest --co` produces zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)