### PR TITLE
fix: align hardcoded nnls_target_kappa fallback with yaml default

### DIFF
--- a/autoarray/inversion/inversion/inversion_util.py
+++ b/autoarray/inversion/inversion/inversion_util.py
@@ -292,13 +292,14 @@ def reconstruction_positive_only_from(
                 "nnls_target_kappa"
             ]
         except KeyError:
-            # jaxnnls's hardcoded default (1e-3) produces NaN in the relaxed-KKT
-            # backward pass on ill-conditioned curvature matrices, even after
-            # Jacobi preconditioning. 1e-2 is the smallest value empirically
-            # verified to produce finite gradients across MGE pipelines (see
-            # autolens_workspace_developer/jax_profiling/imaging/mge_gradients.py
-            # _diagnose_kappa).
-            target_kappa = 1.0e-2
+            # Workspaces ship their own general.yaml that shadows autoarray's;
+            # fall back to the same value autoarray's general.yaml declares.
+            # jaxnnls's own 1e-3 default produces NaN in the relaxed-KKT
+            # backward pass on ill-conditioned curvature matrices; 1e-11 is
+            # finite across all MGE/rectangular/delaunay pipelines (imaging +
+            # interferometer) with scale invariance verified over 5 orders of
+            # magnitude in noise.
+            target_kappa = 1.0e-11
 
         if use_jacobi:
             # Ill-conditioned Q makes jaxnnls's relaxed-KKT backward pass


### PR DESCRIPTION
## Summary
- Updates the hardcoded `target_kappa` fallback in `inversion_util.py:301` from `1.0e-2` to `1.0e-11` to match the yaml default introduced in #283.

## Context
Follow-up to #283. The yaml default in `autoarray/config/general.yaml` was lowered to `1.0e-11`, but every downstream workspace that ships its own `config/general.yaml` (autolens_workspace_test, autolens_workspace, autogalaxy_workspace, autofit_workspace) shadows autoarray's — and none of them declare `nnls_target_kappa`. As a result the try/except in `inversion_util.py` fell through to the hardcoded `1.0e-2`, silently ignoring #283.

Spotted when `autolens_workspace_test` smoke CI for https://github.com/PyAutoLabs/autolens_workspace_test/pull/28 reproduced the old pre-#283 log-likelihood `-3164.77281` on κ=1e-2 behaviour:
```
x: array([-3164.77281])      # CI actual (hardcoded 1e-2 in effect)
y: array(-3164.286252)       # Expected from κ=1e-11 local runs
```

## API Changes
No public API changes. Config fallback default only.

## Test plan
- [ ] CI green
- [x] `autolens_workspace_test` smoke CI should now produce `-3164.286252` and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)