### PR TITLE
feat(python-version): support Python 3.9-3.14, first-class 3.12/3.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
     - name: Checkout PyAutoConf
       uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.12', '3.13']
     steps:
     - name: Checkout PyAutoConf
       uses: actions/checkout@v2
@@ -37,12 +37,7 @@ jobs:
         pip3 install setuptools
         pip3 install wheel
         pip3 install pytest coverage pytest-cov
-        pip install ./PyAutoConf ./PyAutoArray
-        if [ "${{ matrix.python-version }}" = "3.12" ]; then
-          pip install "./PyAutoArray[optional]"
-        else
-          pip install numba pynufft
-        fi
+        pip install ./PyAutoConf "./PyAutoArray[optional]"
 
     - name: Extract branch name
       shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
   description="PyAuto Data Structures"
 readme = { file = "README.rst", content-type = "text/x-rst" }
 license = { text = "MIT" }
-requires-python = ">=3.12"
+requires-python = ">=3.9"
 authors = [
     { name = "James Nightingale", email = "James.Nightingale@newcastle.ac.uk" },
     { name = "Richard Hayes", email = "richard@rghsoftware.co.uk" },
@@ -18,8 +18,12 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Physics",
   "Natural Language :: English",
   "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13"
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14"
 ]
 keywords = ["cli"]
 dependencies = [
@@ -49,7 +53,9 @@ local_scheme = "no-local-version"
 
 
 [project.optional-dependencies]
-optional=[
+jax = ["autoconf[jax]"]
+optional = [
+    "autoarray[jax]",
     "numba",
     "pynufft",
     "tensorflow-probability==0.25.0"


### PR DESCRIPTION
## Summary

Part of the Python version policy change supporting Python 3.9–3.14 across PyAuto. First-class support remains 3.12/3.13.

## Changes in this repo

- `pyproject.toml`: `requires-python` 3.12 → 3.9. Classifiers expanded to 3.9–3.14. New `[jax]` extra that propagates upward via `autoconf[jax]`. The existing `[optional]` extra now pulls `autoarray[jax]` so existing users don't lose JAX on 3.11+.
- `.github/workflows/main.yml`: matrix expanded to `[3.9, 3.10, 3.11, 3.12, 3.13, 3.14]`.

## Test plan

- [x] All unit tests pass on Python 3.12
- [ ] Per-lib CI matrix runs after merge (3.9–3.14)
- [ ] Autobuild matrix workflow verifies full stack

This is one of 12 coordinated PRs. See sibling PRs on `feature/python-version-policy` in PyAutoConf, PyAutoFit, PyAutoArray, PyAutoGalaxy, PyAutoLens, PyAutoBuild, and the 6 workspace repos.