### PR TITLE
docs: audit-driven URL fixes across docs, READMEs, and docstrings

### DIFF
--- a/autoarray/inversion/pixelization.py
+++ b/autoarray/inversion/pixelization.py
@@ -22,13 +22,13 @@ class Pixelization:
         For the simplest case, we have a 2D image whose pixel centres are defined on a (y,x) grid of Cartesian
         coordinates, which are paired with the ``Mesh`` of the ``Pixelization``:
 
-        .. image:: https://github.com/Jammy2211/PyAutoGalaxy/blob/main/docs/api/images/pixelization_image_plane/data_image_plane.png?raw=true
+        .. image:: https://github.com/PyAutoLabs/PyAutoGalaxy/blob/main/docs/api/images/pixelization_image_plane/data_image_plane.png?raw=true
           :width: 240
 
-        .. image:: https://github.com/Jammy2211/PyAutoGalaxy/blob/main/docs/api/images/pixelization_image_plane/grid_image_plane.png?raw=true
+        .. image:: https://github.com/PyAutoLabs/PyAutoGalaxy/blob/main/docs/api/images/pixelization_image_plane/grid_image_plane.png?raw=true
           :width: 240
 
-        .. image:: https://github.com/Jammy2211/PyAutoGalaxy/blob/main/docs/api/images/pixelization_image_plane/image_plane_mesh.png?raw=true
+        .. image:: https://github.com/PyAutoLabs/PyAutoGalaxy/blob/main/docs/api/images/pixelization_image_plane/image_plane_mesh.png?raw=true
           :width: 240
 
         The visual above shows:
@@ -53,13 +53,13 @@ class Pixelization:
 
         The images below use the same image, which has had a 2.5" circular mask applied to it:
 
-        .. image:: https://github.com/Jammy2211/PyAutoGalaxy/blob/main/docs/api/images/pixelization_masked_image_plane/data_image_plane.png?raw=true
+        .. image:: https://github.com/PyAutoLabs/PyAutoGalaxy/blob/main/docs/api/images/pixelization_masked_image_plane/data_image_plane.png?raw=true
           :width: 240
 
-        .. image:: https://github.com/Jammy2211/PyAutoGalaxy/blob/main/docs/api/images/pixelization_masked_image_plane/grid_image_plane.png?raw=true
+        .. image:: https://github.com/PyAutoLabs/PyAutoGalaxy/blob/main/docs/api/images/pixelization_masked_image_plane/grid_image_plane.png?raw=true
           :width: 240
 
-        .. image:: https://github.com/Jammy2211/PyAutoGalaxy/blob/main/docs/api/images/pixelization_masked_image_plane/image_plane_mesh.png?raw=true
+        .. image:: https://github.com/PyAutoLabs/PyAutoGalaxy/blob/main/docs/api/images/pixelization_masked_image_plane/image_plane_mesh.png?raw=true
           :width: 240
 
         The behaviour is analogous to the non-masked case, however only unmasked pixel's in the image's (y,x) grid
@@ -73,13 +73,13 @@ class Pixelization:
         In the strong lensing package **PyAutoLens**, gravitational lensing deflects the observed image's (y,x)
         grid of coordinates and the ``mesh`` is overlaid in the source-plane:
 
-        .. image:: https://github.com/Jammy2211/PyAutoGalaxy/blob/main/docs/api/images/pixelization_masked_source_plane/data_image_plane.png?raw=true
+        .. image:: https://github.com/PyAutoLabs/PyAutoGalaxy/blob/main/docs/api/images/pixelization_masked_source_plane/data_image_plane.png?raw=true
           :width: 240
 
-        .. image:: https://github.com/Jammy2211/PyAutoGalaxy/blob/main/docs/api/images/pixelization_masked_source_plane/grid_image_plane.png?raw=true
+        .. image:: https://github.com/PyAutoLabs/PyAutoGalaxy/blob/main/docs/api/images/pixelization_masked_source_plane/grid_image_plane.png?raw=true
           :width: 240
 
-        .. image:: https://github.com/Jammy2211/PyAutoGalaxy/blob/main/docs/api/images/pixelization_masked_source_plane/source_plane_mesh.png?raw=true
+        .. image:: https://github.com/PyAutoLabs/PyAutoGalaxy/blob/main/docs/api/images/pixelization_masked_source_plane/source_plane_mesh.png?raw=true
           :width: 240
 
         The red points, highlighted throughout all visuals above, show that after gravitational lensing the points

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,7 @@ import datetime
 #
 # This file only contains a selection of the most common options. For a full
 # list see the documentation:
-# https://www.sphinx-doc.org/en/main/usage/configuration.html
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 # -- Path setup --------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Doc-only URL cleanup driven by the new `admin_jammy/software/url_check/` audit tool (Jammy2211/admin_jammy#21). Fixes the user-reported `hhttps://` typo in `overview_2_new_user_guide.md` plus ~20 mechanical URL rewrites covering:

- Renamed GitHub orgs: `Jammy2211/<workspace>` → `PyAutoLabs/<workspace>`; `Jammy2211|rhayes777/<library>` → `PyAutoLabs/<library>`
- Removed `release` branch on workspaces: `/blob/release/` → `/blob/main/`, `/tree/release/` → `/tree/main/`
- nautilus sampler moved orgs: `joshspeagle/nautilus` → `johannesulf/nautilus`
- PyAutoBuild moved orgs: `rhayes777/PyAutoBuild` → `PyAutoLabs/PyAutoBuild`
- Dead Code of Conduct links: bokeh CoC → `/docs/CODE_OF_CONDUCT.md`; numfocus → `numfocus.org/code-of-conduct`
- Sphinx-doc: `/en/main` → `/en/master`
- pyautofit.readthedocs.io renames: `cookbook_1_basics` → `cookbooks/model`, `overview/model_fit` → `overview/the_basics`, `overview/result` → `cookbooks/result`, etc.
- Workspace notebook reorganisations: `overview/simple/fit.ipynb` → `overview/overview_1_the_basics.ipynb`, `modeling/imaging/features/<x>.ipynb` → `imaging/features/<x>/modeling.ipynb`, etc.
- Colab badge URL: workspace-root `start_here.ipynb` → `notebooks/<type>/start_here.ipynb` (the bare-root file never existed)

No source-code behaviour changes — only docstring and `.md / .rst / Python-comment` text. CRLF line endings preserved (no whitespace churn).

## Test plan

- [x] `python -m pytest test_<library>` passes
- [x] `python -c "import <library>"` succeeds (verifies docstring edits don't break parsing)
- [ ] Audit re-run after this PR + paired PRs merge

## Related

- Tool PR: Jammy2211/admin_jammy#21
- Issue: PyAutoLabs/PyAutoLens#508
- Workspace-phase follow-up: HowToFit, HowToGalaxy, HowToLens, autofit_workspace, autogalaxy_workspace, autolens_workspace (URLs in symlinked workspace files were SCANNED but not FIXED in this phase)