### PR TITLE
Pin nufftax >=0.4.0,<0.5.0 on Python 3.12+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,12 +56,12 @@ jax = ["autoconf[jax]"]
 optional = [
     "autoarray[jax]",
     "numba",
-    "nufftax",
+    "nufftax>=0.4.0,<0.5.0; python_version >= '3.12'",
     "pynufft",
     "tensorflow-probability==0.25.0"
 ]
 test = ["pytest"]
-dev = ["pytest", "black", "numba", "nufftax", "pynufft==2022.2.2"]
+dev = ["pytest", "black", "numba", "nufftax>=0.4.0,<0.5.0; python_version >= '3.12'", "pynufft==2022.2.2"]
 
 [tool.pytest.ini_options]
 testpaths = ["test_autoarray"]


### PR DESCRIPTION
## Summary

- Replaces the bare `nufftax` entry in `[optional]` and `[dev]` with `nufftax>=0.4.0,<0.5.0; python_version >= '3.12'`.
- Combined with the JAX floor bump in PyAutoConf, this stops pip from producing installs that resolve cleanly but crash at runtime on `pallas.triton.CompilerParams`.

## Why

nufftax under-declares its JAX requirement. Its 0.4.0 metadata says `jax>=0.4.0`, but the wheel actually uses Pallas Triton APIs introduced in JAX 0.7.0. The Python 3.12 marker matches nufftax's own `requires-python = ">=3.12"`.

## Test plan

- [x] PyAutoArray full unit tests pass on JAX 0.9.2 with new pin (821 passed)
- [x] `test_transformer.py` (the nufftax-using path) passes
- [ ] CI green on Python 3.12 / 3.13
- [ ] TestPyPI rehearsal (via PyAutoBuild PR)

## Depends on

PyAutoConf companion PR (JAX floor bump) — cross-reference to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)