### PR TITLE
interferometer: enable sparse_operator for nufftax TransformerNUFFT

### DIFF
--- a/autoarray/dataset/interferometer/dataset.py
+++ b/autoarray/dataset/interferometer/dataset.py
@@ -258,29 +258,6 @@ class Interferometer(AbstractDataset):
             enabling efficient pixelized source reconstruction via the sparse linear algebra formalism.
         """
 
-        if isinstance(self.transformer, TransformerNUFFT):
-            raise NotImplementedError(
-                "\n--------------------\n"
-                "`apply_sparse_operator` is not yet supported with the default "
-                "`TransformerNUFFT` (nufftax-backed) transformer.\n\n"
-                "The sparse-operator path consumes the dirty image returned by "
-                "`transformer.image_from(use_adjoint_scaling=True)` together with "
-                "the NUFFT precision operator; their relative scale matters. The "
-                "new `TransformerNUFFT` returns the strict mathematical adjoint "
-                "(matching `TransformerDFT`), whereas the legacy pynufft adjoint "
-                "applies an internal Kaiser-Bessel kernel deconvolution. The two "
-                "scales differ by a non-constant factor, so feeding the new "
-                "dirty image into the existing sparse-operator solver would "
-                "silently give wrong answers.\n\n"
-                "Workarounds:\n"
-                "  - Build the dataset with `transformer_class=TransformerDFT` "
-                "(the JAX-likelihood scripts do this today), or\n"
-                "  - Build the dataset with "
-                "`transformer_class=TransformerNUFFTPyNUFFT` to keep the legacy "
-                "pynufft adjoint scale (requires `pip install pynufft`).\n"
-                "----------------------"
-            )
-
         if nufft_precision_operator is None:
 
             logger.info(

--- a/autoarray/operators/transformer.py
+++ b/autoarray/operators/transformer.py
@@ -646,11 +646,11 @@ class TransformerNUFFT:
         deconvolution). The structure of the dirty image is the same, and
         the values match `TransformerDFT.image_from` exactly.
 
-        **Scale-sensitive callers**: `Interferometer.apply_sparse_operator`
-        consumes the dirty-image scale together with a precision operator; it
-        is currently incompatible with this class and raises
-        `NotImplementedError`. Use `TransformerDFT` or
-        `TransformerNUFFTPyNUFFT` if you need the sparse-operator path.
+        `use_adjoint_scaling` is accepted for API compatibility with the
+        legacy class and is otherwise unused (the nufftax adjoint is already
+        the mathematical adjoint; no extra normalisation is needed). This
+        matches `TransformerDFT.image_from` semantics so the sparse-operator
+        path is scale-consistent across both transformers.
         """
         n_y, n_x = self.real_space_mask.shape_native
         n_modes = (n_x, n_y)  # nufftax wants (n1, n2) = (N_x, N_y)
@@ -668,9 +668,6 @@ class TransformerNUFFT:
             c = visibilities.array * np.conj(self._shift)
             f = _nufftax.nufft2d1(self._x, self._y, c, n_modes, self.eps, +1)
             image = np.array(np.asarray(f)[::-1, :].real)
-
-        if use_adjoint_scaling:
-            image = image * self.adjoint_scaling
 
         return Array2D(values=image, mask=self.real_space_mask)
 

--- a/test_autoarray/dataset/interferometer/test_dataset.py
+++ b/test_autoarray/dataset/interferometer/test_dataset.py
@@ -201,6 +201,38 @@ def test__transformer__nufft_class__returns_transformer_nufft_instance(
     assert type(interferometer_7.transformer) == transformer.TransformerNUFFT
 
 
+def test__apply_sparse_operator__dft_and_nufft_dirty_image_match(mask_2d_7x7):
+    n_visibilities = 5
+    rng = np.random.default_rng(seed=0)
+    data = aa.Visibilities(
+        visibilities=rng.normal(size=(n_visibilities, 2)).astype(np.float64)
+    )
+    noise_map = aa.VisibilitiesNoiseMap(
+        visibilities=np.ones((n_visibilities, 2), dtype=np.float64)
+    )
+    uv_wavelengths = rng.normal(size=(n_visibilities, 2)).astype(np.float64)
+
+    dataset_dft = aa.Interferometer(
+        data=data,
+        noise_map=noise_map,
+        uv_wavelengths=uv_wavelengths,
+        real_space_mask=mask_2d_7x7,
+        transformer_class=transformer.TransformerDFT,
+    ).apply_sparse_operator(use_jax=False)
+
+    dataset_nufft = aa.Interferometer(
+        data=data,
+        noise_map=noise_map,
+        uv_wavelengths=uv_wavelengths,
+        real_space_mask=mask_2d_7x7,
+        transformer_class=transformer.TransformerNUFFT,
+    ).apply_sparse_operator(use_jax=False)
+
+    assert dataset_nufft.sparse_operator.dirty_image == pytest.approx(
+        dataset_dft.sparse_operator.dirty_image, 1.0e-4
+    )
+
+
 def test__different_interferometer_without_mock_objects__customize_constructor_inputs(
     mask_2d_7x7,
 ):

--- a/test_autoarray/inversion/inversion/interferometer/test_interferometer.py
+++ b/test_autoarray/inversion/inversion/interferometer/test_interferometer.py
@@ -125,3 +125,75 @@ def test__curvature_matrix__interferometer_sparse_operator__delaunay__identical_
     assert inversion_sparse.curvature_matrix == pytest.approx(
         inversion_mapping.curvature_matrix, 1.0e-4
     )
+
+
+def test__curvature_matrix__interferometer_sparse_operator__delaunay__dft_and_nufft_match():
+    mask = aa.Mask2D(
+        mask=[
+            [True, True, True, True, True, True, True],
+            [True, True, True, True, True, True, True],
+            [True, True, True, False, True, True, True],
+            [True, True, False, False, False, True, True],
+            [True, True, True, False, True, True, True],
+            [True, True, True, True, True, True, True],
+            [True, True, True, True, True, True, True],
+        ],
+        pixel_scales=2.0,
+    )
+
+    grid = aa.Grid2D.from_mask(mask=mask, over_sample_size=1)
+
+    mesh = aa.mesh.Delaunay(pixels=9)
+    image_mesh = aa.image_mesh.Overlay(shape=(3, 3))
+    image_mesh_grid = image_mesh.image_plane_mesh_grid_from(
+        mask=mask, adapt_data=None
+    )
+
+    interpolator = mesh.interpolator_from(
+        source_plane_data_grid=grid,
+        source_plane_mesh_grid=image_mesh_grid,
+    )
+    mapper = aa.Mapper(interpolator=interpolator)
+
+    n_visibilities = 5
+    rng = np.random.default_rng(seed=0)
+    data = aa.Visibilities(
+        visibilities=rng.normal(size=(n_visibilities, 2)).astype(np.float64)
+    )
+    noise_map = aa.VisibilitiesNoiseMap(
+        visibilities=np.ones((n_visibilities, 2), dtype=np.float64)
+    )
+    uv_wavelengths = rng.normal(size=(n_visibilities, 2)).astype(np.float64)
+
+    dataset_dft = aa.Interferometer(
+        data=data,
+        noise_map=noise_map,
+        uv_wavelengths=uv_wavelengths,
+        real_space_mask=mask,
+        transformer_class=aa.TransformerDFT,
+    ).apply_sparse_operator(use_jax=False)
+
+    dataset_nufft = aa.Interferometer(
+        data=data,
+        noise_map=noise_map,
+        uv_wavelengths=uv_wavelengths,
+        real_space_mask=mask,
+        transformer_class=aa.TransformerNUFFT,
+    ).apply_sparse_operator(use_jax=False)
+
+    inversion_dft = aa.Inversion(
+        dataset=dataset_dft,
+        linear_obj_list=[mapper],
+    )
+
+    inversion_nufft = aa.Inversion(
+        dataset=dataset_nufft,
+        linear_obj_list=[mapper],
+    )
+
+    assert inversion_nufft.curvature_matrix == pytest.approx(
+        inversion_dft.curvature_matrix, 1.0e-4
+    )
+    assert inversion_nufft.data_vector == pytest.approx(
+        inversion_dft.data_vector, 1.0e-4
+    )


### PR DESCRIPTION
## Summary
- Delete the `apply_sparse_operator` NotImplementedError guard for `TransformerNUFFT`. The nufftax adjoint is numerically equivalent to `TransformerDFT.image_from`; the guard was overly conservative.
- Remove the `if use_adjoint_scaling: image *= self.adjoint_scaling` from `TransformerNUFFT.image_from`. That factor is a legacy pynufft Kaiser-Bessel compensation; the new nufftax-backed transformer is already the mathematical adjoint and needs no extra scaling. `use_adjoint_scaling` now matches `TransformerDFT.image_from` semantics (accepted for API parity, unused).
- Add parity tests: dirty image, curvature matrix, and data vector all match between DFT and NUFFT in the sparse-operator path at rtol=1e-4.

## Motivation
The HPC A100 profiling sweep (autolens_profiling A100 alma cells) was blocked by `TransformerDFT.image_from` OOMing at ALMA scale — the un-chunked outer product `np.outer(grid_radians, uv_wavelengths)` materialises ~123 GB at 1M visibilities × 15.4k unmasked pixels, and three concurrent intermediates push to ~370 GB (matched the 384 GB cgroup OOM exactly). Investigation showed the per-likelihood path with `sparse_operator` attached is entirely transformer-free (fast_chi_squared uses F, D, and raw data — see `fit_interferometer.py:151-158`); the OOM is from the single setup-time `image_from` call that produces the cached dirty image. Swapping that one call from DFT (O(N_pix · N_vis), un-chunked) to nufftax NUFFT (O((N_pix + N_vis) log N)) unblocks the sweep without any other library changes.

## Test plan
- [x] `python -m pytest test_autoarray/` (823 passed locally on this branch)
- [x] New parity test in `test_dataset.py` asserts NUFFT and DFT produce the same `sparse_operator.dirty_image` at rtol=1e-4
- [x] New parity test in `test_interferometer.py` asserts NUFFT and DFT produce the same Delaunay sparse-inversion `curvature_matrix` and `data_vector` at rtol=1e-4
- [ ] Follow-up: autolens_profiling PR switching `transformer_class=al.TransformerDFT` → `al.TransformerNUFFT` for alma cells, re-running the 4 blocked SLURM submits

🤖 Generated with [Claude Code](https://claude.com/claude-code)