### PR TITLE
Arcsec ticks: consistent decimal for mixed integer/decimal ticks; centre rotated y-labels

### DIFF
--- a/autoarray/plot/utils.py
+++ b/autoarray/plot/utils.py
@@ -902,16 +902,21 @@ def _round_ticks(values: np.ndarray, sig: int = 2) -> np.ndarray:
 def _arcsec_labels(ticks) -> List[str]:
     """Format tick values as arcsecond coordinate strings.
 
-    Values that all end in ``.0`` are stripped of the decimal point before the
-    ``"`` suffix is appended, so ``[-1.0, 0.0, 1.0]`` becomes
-    ``['-1"', '0"', '1"']``.  By default decimal labels keep the suffix form
-    ``3.8"``.  When ``ticks.symbol_over_decimal`` is true, labels use the
-    double-prime arcsecond symbol and decimal labels place it over the decimal
-    point, e.g. ``3.″8``.
+    Whole-number tick sets render without a decimal point, so
+    ``[-1.0, 0.0, 1.0]`` becomes ``['-1"', '0"', '1"']``.  When whole-number and
+    decimal ticks are mixed, the whole-number ticks gain a single decimal place
+    (e.g. ``2`` -> ``2.0``) so a lone integer tick reads consistently with its
+    neighbours (``2.″0`` rather than ``2″`` beside ``-0.″044``).  By default
+    decimal labels keep the suffix form ``3.8"``.  When
+    ``ticks.symbol_over_decimal`` is true, labels use the double-prime arcsecond
+    symbol and decimal labels place it over the decimal point, e.g. ``3.″8``.
     """
     labels = [f'{v:g}' for v in ticks]
-    if all(label.endswith(".0") for label in labels):
-        labels = [label[:-2] for label in labels]
+    if any("." in label for label in labels):
+        labels = [
+            label if "." in label else f"{float(v):.1f}"
+            for label, v in zip(labels, ticks)
+        ]
     if _conf_ticks_flag("symbol_over_decimal", False):
         symbol_labels = []
         for label in labels:
@@ -948,3 +953,9 @@ def apply_extent(
     ax.set_yticks(yticks)
     ax.set_xticklabels(_arcsec_labels(xticks))
     ax.set_yticklabels(_arcsec_labels(yticks))
+
+    # The y-tick labels are rotated 90 degrees elsewhere; without an explicit
+    # centre alignment a rotated label anchors at its right edge and visually
+    # drops below the tick line. Centre them on the tick.
+    for label in ax.get_yticklabels():
+        label.set_verticalalignment("center")

--- a/test_autoarray/plot/test_utils.py
+++ b/test_autoarray/plot/test_utils.py
@@ -27,5 +27,26 @@ def test_arcsec_labels_symbol_over_decimal():
             "1.″95",
         ]
         assert _arcsec_labels([3.0]) == ["3″"]
+
+        # Mixed whole-number and decimal ticks: the whole-number tick gains a
+        # single decimal so it reads as 2.″0 rather than a bare 2″.
+        assert _arcsec_labels([-2.1, -0.044, 2.0]) == [
+            "-2.″1",
+            "-0.″044",
+            "2.″0",
+        ]
+    finally:
+        ticks["symbol_over_decimal"] = original
+
+
+def test_arcsec_labels_mixed_integer_and_decimal_default():
+    ticks = conf.instance["visualize"]["general"]["ticks"]
+    original = ticks.get("symbol_over_decimal", False)
+    try:
+        ticks["symbol_over_decimal"] = False
+
+        # All-integer sets stay integer; a mixed set pads the whole number.
+        assert _arcsec_labels([-1.0, 0.0, 1.0]) == ['-1"', '0"', '1"']
+        assert _arcsec_labels([-2.1, -0.044, 2.0]) == ['-2.1"', '-0.044"', '2.0"']
     finally:
         ticks["symbol_over_decimal"] = original


### PR DESCRIPTION
## Summary

Refines the arcsecond tick labelling introduced in #350 to fix two rendering issues seen in the Euclid DR1 lens-catalogue paper figures.

1. **Mixed integer/decimal ticks** — `_arcsec_labels` rendered a tick value of exactly `2.0` as `2` (via `%g`), producing `2″` next to decimal neighbours like `-0.″044`. It now pads whole-number ticks to a single decimal place (`2` → `2.0`, rendered `2.″0`) **only when** the tick set is a mix of whole numbers and decimals. All-integer sets (e.g. `[-1, 0, 1]` → `-1"`, `0"`, `1"`) and lone integers (`[3.0]` → `3″`) are unchanged.
2. **Off-centre y-labels** — `apply_extent` sets rotated (90°) y-tick labels; without an explicit vertical alignment they anchor at the right edge and visually drop below the tick. They are now `verticalalignment="center"`.

## Tests

- Existing `_arcsec_labels` tests unchanged and passing.
- Added a mixed integer/decimal case (`[-2.1, -0.044, 2.0]`) for both the default and symbol-over-decimal modes.

All 3 tests in `test_autoarray/plot/test_utils.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)