### PR TITLE
test: skip default-nufftax interferometer tests when nufftax absent (py<3.12)

### DIFF
--- a/test_autoarray/conftest.py
+++ b/test_autoarray/conftest.py
@@ -280,3 +280,42 @@ def make_acs_ccd():
 @pytest.fixture(name="acs_quadrant")
 def make_acs_quadrant():
     return fixtures.make_acs_quadrant()
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip interferometer tests that need the default ``nufftax`` backend when
+    it is not installed.
+
+    The default ``Interferometer`` transformer is the JAX-native
+    ``TransformerNUFFT``, backed by ``nufftax`` — which is declared for Python
+    ``>= 3.12`` only (Python 3.9-3.11 are not officially supported). On those
+    interpreters the backend cannot be installed, so any test that builds a
+    default interferometer/transformer raises ``ModuleNotFoundError`` at
+    construction. Skip exactly those, while keeping the explicit ``DFT`` and
+    ``pynufft`` transformer tests, which have no ``nufftax`` dependency. On
+    3.12/3.13 (where ``nufftax`` is present) nothing is skipped.
+    """
+    try:
+        import nufftax  # noqa: F401
+
+        return
+    except ImportError:
+        pass
+
+    skip_nufftax = pytest.mark.skip(
+        reason="nufftax (default JAX interferometer backend) requires Python >= 3.12"
+    )
+    for item in items:
+        name = item.nodeid.rsplit("::", 1)[-1]
+        # Explicit DFT / pynufft backend tests do not use nufftax — keep them.
+        if "__dft__" in name or "pynufft" in name:
+            continue
+        nodeid = item.nodeid.replace("\\", "/")
+        needs_nufftax = (
+            "fit/test_fit_interferometer.py" in nodeid
+            or "dataset/interferometer/test_dataset.py" in nodeid
+            or "inversion/inversion/interferometer/test_interferometer.py" in nodeid
+            or ("operators/test_transformer.py" in nodeid and "__nufft__" in name)
+        )
+        if needs_nufftax:
+            item.add_marker(skip_nufftax)


### PR DESCRIPTION
## Summary

Part of fixing the **Python Version Matrix** red (PyAutoBuild weekly). The default `Interferometer` transformer is the JAX-native `TransformerNUFFT`, backed by **`nufftax`** — declared for **Python ≥ 3.12 only** (3.9–3.11 are not officially supported; `general.yaml`). On those interpreters the backend can't install, so every test that builds a default interferometer/transformer raised `ModuleNotFoundError` at construction.

Adds a `pytest_collection_modifyitems` hook in `test_autoarray/conftest.py` that, **only when `nufftax` is unavailable**, skips exactly the default-nufftax interferometer/transformer tests — keeping the explicit `DFT` and `pynufft` transformer tests running. On 3.12/3.13 (nufftax present) nothing is skipped.

## Test Plan (verified locally, Python 3.12.10)
- **nufftax present:** `test_transformer.py` 13 passed / 0 skipped; the 3 interferometer files 43 passed / 0 skipped — hook is inert.
- **nufftax blocked (simulating <3.12):** `test_transformer.py` → 5 passed (2 DFT + 3 pynufft), **8 skipped** (the `__nufft__` tests); interferometer files → 43 skipped cleanly, **no failures/errors**.

## Pairing
Lands with **PyAutoBuild** `feature/matrix-nufftax-py312` (adds `PyAutoArray[optional]` so nufftax/pynufft install on 3.12/3.13). Test-only change — no library source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)