### PR TITLE
test: skip jax-backed unit tests when jax is absent (Python matrix)

### DIFF
--- a/test_autoarray/inversion/pixelization/interpolator/test_knn_barycentric.py
+++ b/test_autoarray/inversion/pixelization/interpolator/test_knn_barycentric.py
@@ -1,8 +1,18 @@
+import importlib.util
+
 import numpy as np
 import pytest
 
 from autoarray.inversion.mesh.interpolator.knn import (
     barycentric_weights_from_3_nearest,
+)
+
+# The kNN weight computation is jax-backed; these tests need jax installed to
+# run (it ships via the `[optional]` extras). The NumPy-only Python-version
+# matrix has no jax, so skip there rather than fail.
+requires_jax = pytest.mark.skipif(
+    importlib.util.find_spec("jax") is None,
+    reason="requires jax (installed via the [optional] extras; absent on the NumPy-only matrix env)",
 )
 
 
@@ -129,6 +139,7 @@ def test__mesh_class__inherits_knn_knobs():
     assert mesh.split_neighbor_division == 2
 
 
+@requires_jax
 def test__interpolator__numpy_path_returns_writable_mappings_and_weights():
     """
     Regression guard: on the numpy path, `mappings` and `weights` must be


### PR DESCRIPTION
## Summary

Part of getting the PyAutoBuild **Python Version Matrix** green. A set of unit tests exercise **jax-only code paths** (vmapped profiles, blackjax NUTS, the NUFFT sparse operator, `use_jax=True`) that need jax installed to run. jax ships via the `[optional]` extras and is present in the per-repo CI (3.12/3.13), so these pass there — but the Python Version Matrix installs the NumPy-only stack (and jax cannot install on 3.9 at all), so they failed with `ModuleNotFoundError: No module named 'jax'`.

Guards the affected tests with `pytest.mark.skipif(importlib.util.find_spec("jax") is None, ...)`. NumPy-only tests in the same files are untouched. Aligns with the repo doctrine "unit tests are NumPy-only; JAX validated in workspace_test".

## Verification
- **jax absent** (clean 2026.7.9.1 venv, no `[optional]`): guarded tests **skip**, all other tests pass.
- **jax present** (dev env): all files collect cleanly, nothing skipped.

Paired across PyAutoArray / PyAutoFit / PyAutoGalaxy / PyAutoLens (`feature/matrix-jax-skip`); test-only, no library source changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)