### PR TITLE
Add ticks.minus_in_math config for math minus in arcsec labels

### DIFF
--- a/autoarray/config/visualize/general.yaml
+++ b/autoarray/config/visualize/general.yaml
@@ -22,6 +22,7 @@ ticks:
   extent_factor_2d: 0.75  # Fraction of half-extent used for 2D tick positions (< 1.0 pulls ticks inward from edges).
   number_of_ticks_2d: 3   # Number of ticks on each spatial axis of 2D plots.
   symbol_over_decimal: false  # If true, place the arcsec double-prime symbol over the decimal point, e.g. 3.″8, instead of after the value, e.g. 3.8".
+  minus_in_math: false  # If true, render negative tick labels with the Unicode/math minus sign (U+2212) instead of an ASCII hyphen (U+002D), e.g. −0.″05 instead of -0.″05.
 contour:
   total_contours: 10       # Number of contour levels drawn over log10 (and explicit linear) plots.
   include_values: true     # Whether to label each contour line with its value.

--- a/autoarray/plot/utils.py
+++ b/autoarray/plot/utils.py
@@ -911,6 +911,14 @@ def _arcsec_labels(ticks) -> List[str]:
     ``ticks.symbol_over_decimal`` is true, labels use the double-prime arcsecond
     symbol and decimal labels place it over the decimal point, e.g. ``3.″8``.
     """
+    minus_in_math = _conf_ticks_flag("minus_in_math", False)
+
+    def _fmt_minus(label: str) -> str:
+        # Replace the ASCII hyphen-minus (U+002D) with the Unicode/math minus
+        # (U+2212, matplotlib's own minus glyph) so negative arcsecond labels
+        # render with a proper minus sign rather than a hyphen.
+        return label.replace("-", "−") if minus_in_math else label
+
     labels = [f'{v:g}' for v in ticks]
     if any("." in label for label in labels):
         labels = [
@@ -922,11 +930,11 @@ def _arcsec_labels(ticks) -> List[str]:
         for label in labels:
             if "." in label:
                 int_part, frac_part = label.split(".", 1)
-                symbol_labels.append(f"{int_part}.″{frac_part}")
+                symbol_labels.append(_fmt_minus(f"{int_part}.″{frac_part}"))
             else:
-                symbol_labels.append(f"{label}″")
+                symbol_labels.append(_fmt_minus(f"{label}″"))
         return symbol_labels
-    return [f'{label}"' for label in labels]
+    return [_fmt_minus(f'{label}"') for label in labels]
 
 
 def apply_extent(

--- a/test_autoarray/plot/test_utils.py
+++ b/test_autoarray/plot/test_utils.py
@@ -50,3 +50,29 @@ def test_arcsec_labels_mixed_integer_and_decimal_default():
         assert _arcsec_labels([-2.1, -0.044, 2.0]) == ['-2.1"', '-0.044"', '2.0"']
     finally:
         ticks["symbol_over_decimal"] = original
+
+
+def test_arcsec_labels_minus_in_math():
+    ticks = conf.instance["visualize"]["general"]["ticks"]
+    original_symbol = ticks.get("symbol_over_decimal", False)
+    original_minus = ticks.get("minus_in_math", False)
+    try:
+        ticks["minus_in_math"] = True
+
+        # Suffix format: the ASCII hyphen (U+002D) becomes the math minus (U+2212).
+        ticks["symbol_over_decimal"] = False
+        assert _arcsec_labels([-2.1, -0.044, 2.0]) == ["−2.1\"", "−0.044\"", "2.0\""]
+
+        # Symbol-over-decimal format also uses the math minus.
+        ticks["symbol_over_decimal"] = True
+        assert _arcsec_labels([-2.1, -0.044, 2.0]) == ["−2.″1", "−0.″044", "2.″0"]
+
+        # Positive-only tick sets are unchanged.
+        assert _arcsec_labels([0.13, 1.95]) == ["0.″13", "1.″95"]
+
+        # The emitted minus really is U+2212, not the ASCII hyphen U+002D.
+        label = _arcsec_labels([-0.5])[0]
+        assert "−" in label and "-" not in label
+    finally:
+        ticks["symbol_over_decimal"] = original_symbol
+        ticks["minus_in_math"] = original_minus


### PR DESCRIPTION
## What

Adds a `ticks.minus_in_math` config flag (default `false`) to `visualize/general.yaml`. When true, `_arcsec_labels` renders negative tick values with the Unicode/math minus sign (U+2212, matplotlib's own minus glyph) instead of an ASCII hyphen (U+002D), e.g. `−0.″05` instead of `-0.″05`.

## Why

`_arcsec_labels` is the single tick-label chokepoint for all 2D plot panels (image-plane via `array.py`/`grid.py`, source-plane via `inversion.py`). It emitted an ASCII hyphen for negatives, inconsistent with matplotlib's own `axes.unicode_minus` behaviour and with astronomy/LaTeX typesetting. This makes the proper math minus available natively (as a config) rather than requiring per-figure custom label helpers.

## Scope / safety

- Additive and gated behind a default-off flag → zero behaviour change for existing users.
- Works with both label formats (suffix `3.8"` and symbol-over-decimal `3.″8`).

## Tests

`test_autoarray/plot/test_utils.py::test_arcsec_labels_minus_in_math` asserts U+2212 appears (and the ASCII hyphen does not) when the flag is on, for both label formats; existing tests unchanged and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)