### PR TITLE
refactor!: depend on and import `autonerves` (renamed from autoconf)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,9 @@ numerical-utility layer: masks, arrays, (y,x) grids, imaging/interferometer
 datasets, inversions/pixelizations, convolution/over-sampling operators, and
 the grid decorators used throughout PyAutoGalaxy and PyAutoLens.
 
-Dependency direction: autoarray depends on **autoconf** only. It does **not**
+Dependency direction: autoarray depends on **autonerves** only. It does **not**
 import `autofit`, `autogalaxy`, or `autolens` — never add such an import.
-Shared utilities (e.g. `test_mode`, `jax_wrapper`) belong in autoconf.
+Shared utilities (e.g. `test_mode`, `jax_wrapper`) belong in autonerves.
 
 ## Related repos
 
@@ -55,7 +55,7 @@ is no black/ruff/flake8 gate — formatting is advisory. (`requires-python` in
 
 ## Configuration & defaults
 
-autoconf supplies the packaged defaults under `autoarray/config/`. Workspaces
+autonerves supplies the packaged defaults under `autoarray/config/`. Workspaces
 override them via their own `config/` directory; the test suite pushes a local
 config dir via `conf.instance.push(...)` in `test_autoarray/conftest.py`. When
 a change adds a new config key, mirror it into the packaged defaults so
@@ -97,7 +97,7 @@ from `AbstractNDArray`; `.array` returns the raw `numpy.ndarray` / `jax.Array`.
 
 ## Key rules / footguns
 
-- Import direction: autoconf only — never `autofit` / `autogalaxy` / `autolens`.
+- Import direction: autonerves only — never `autofit` / `autogalaxy` / `autolens`.
 - Grid-consuming functions decorated with `@aa.decorators.to_array` / `to_grid`
   / `to_vector_yx` must return a **raw array** — the decorator wraps it. (Write
   `aa.decorators.*`; `aa.grid_dec` is a deprecated alias.)

--- a/autoarray/__init__.py
+++ b/autoarray/__init__.py
@@ -1,6 +1,6 @@
-from autoconf import jax_wrapper
-from autoconf.dictable import register_parser
-from autoconf import conf
+from autonerves import jax_wrapper
+from autonerves.dictable import register_parser
+from autonerves import conf
 
 conf.instance.register(__file__)
 
@@ -97,40 +97,40 @@ from .layout.region import Region2D
 from .structures.visibilities import Visibilities
 from .structures.visibilities import VisibilitiesNoiseMap
 
-from autoconf import conf
-from autoconf.fitsable import ndarray_via_hdu_from
-from autoconf.fitsable import ndarray_via_fits_from
-from autoconf.fitsable import header_obj_from
-from autoconf.fitsable import output_to_fits
-from autoconf.fitsable import hdu_list_for_output_from
+from autonerves import conf
+from autonerves.fitsable import ndarray_via_hdu_from
+from autonerves.fitsable import ndarray_via_fits_from
+from autonerves.fitsable import header_obj_from
+from autonerves.fitsable import output_to_fits
+from autonerves.fitsable import hdu_list_for_output_from
 
 conf.instance.register(__file__)
 
 __version__ = "2026.7.9.1"
 
 # ---------------------------------------------------------------------------
-# Public re-export of the autoconf configuration / serialization surface.
+# Public re-export of the autonerves configuration / serialization surface.
 #
 # Workspaces, tutorials and downstream code import these names from the science
 # library (e.g. ``from autolens import conf``) rather than depending on the
-# ``autoconf`` package directly, so the underlying configuration / serialization
+# ``autonerves`` package directly, so the underlying configuration / serialization
 # layer stays an implementation detail of the library.
 # ---------------------------------------------------------------------------
-from autoconf import conf
-from autoconf import jax_wrapper
-from autoconf import fitsable
-from autoconf import setup_colab
-from autoconf import setup_notebook
-from autoconf.conf import with_config
-from autoconf.dictable import from_dict, from_json, to_dict, output_to_json
-from autoconf.fitsable import (
+from autonerves import conf
+from autonerves import jax_wrapper
+from autonerves import fitsable
+from autonerves import setup_colab
+from autonerves import setup_notebook
+from autonerves.conf import with_config
+from autonerves.dictable import from_dict, from_json, to_dict, output_to_json
+from autonerves.fitsable import (
     output_to_fits,
     hdu_list_for_output_from,
     ndarray_via_fits_from,
     ndarray_via_hdu_from,
     header_obj_from,
 )
-from autoconf.test_mode import (
+from autonerves.test_mode import (
     with_test_mode_segment,
     skip_visualization,
     skip_fit_output,

--- a/autoarray/abstract_ndarray.py
+++ b/autoarray/abstract_ndarray.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from autoarray.structures.abstract_structure import Structure
 
-from autoconf import conf
+from autonerves import conf
 
 
 def to_new_array(func):
@@ -66,7 +66,7 @@ _pytree_registered_classes: set = set()
 
 
 def _register_as_pytree(cls):
-    """Register ``cls`` with ``jax.tree_util`` via the lazy autoconf wrapper.
+    """Register ``cls`` with ``jax.tree_util`` via the lazy autonerves wrapper.
 
     Gated: only called when a subclass instance is constructed on the JAX path
     (``xp is not np``). The registration is class-scoped via
@@ -75,7 +75,7 @@ def _register_as_pytree(cls):
     """
     if cls in _pytree_registered_classes:
         return
-    from autoconf.jax_wrapper import register_pytree_node
+    from autonerves.jax_wrapper import register_pytree_node
 
     register_pytree_node(cls, cls.instance_flatten, cls.instance_unflatten)
     _pytree_registered_classes.add(cls)
@@ -101,8 +101,8 @@ def register_instance_pytree(cls, no_flatten=()):
     """
     if cls in _pytree_registered_classes:
         return
-    from autoconf.jax_wrapper import register_pytree_node
-    from autoconf.tools.decorators import cached_property_names
+    from autonerves.jax_wrapper import register_pytree_node
+    from autonerves.tools.decorators import cached_property_names
 
     # Extend the caller-supplied no_flatten set with every
     # ``cached_property``-style descriptor on ``cls`` so derived caches
@@ -180,7 +180,7 @@ class AbstractNDArray(ABC):
         """
         Flatten an instance of an autoarray class into a tuple of its attributes (i.e.. a pytree)
         """
-        from autoconf.tools.decorators import cached_property_names
+        from autonerves.tools.decorators import cached_property_names
 
         # Union the class-level ``__no_flatten__`` opt-out with any
         # ``cached_property`` descriptor names so derived caches don't

--- a/autoarray/dataset/interferometer/dataset.py
+++ b/autoarray/dataset/interferometer/dataset.py
@@ -2,8 +2,8 @@ import logging
 import numpy as np
 from typing import Optional
 
-from autoconf.fitsable import ndarray_via_fits_from
-from autoconf import cached_property
+from autonerves.fitsable import ndarray_via_fits_from
+from autonerves import cached_property
 
 from autoarray.dataset.abstract.dataset import AbstractDataset
 from autoarray.dataset.grids import GridsDataset

--- a/autoarray/dataset/plot/imaging_plots.py
+++ b/autoarray/dataset/plot/imaging_plots.py
@@ -219,7 +219,7 @@ def fits_imaging(
     overwrite : bool
         If ``True`` existing files are replaced.
     """
-    from autoconf.fitsable import output_to_fits, hdu_list_for_output_from, write_hdu_list
+    from autonerves.fitsable import output_to_fits, hdu_list_for_output_from, write_hdu_list
 
     header_dict = dataset.data.mask.header_dict if hasattr(dataset.data.mask, "header_dict") else None
 

--- a/autoarray/dataset/plot/interferometer_plots.py
+++ b/autoarray/dataset/plot/interferometer_plots.py
@@ -177,7 +177,7 @@ def fits_interferometer(
     overwrite : bool
         If ``True`` existing files are replaced.
     """
-    from autoconf.fitsable import output_to_fits, hdu_list_for_output_from, write_hdu_list
+    from autonerves.fitsable import output_to_fits, hdu_list_for_output_from, write_hdu_list
 
     if file_path is not None:
         values_list = []

--- a/autoarray/inversion/inversion/abstract.py
+++ b/autoarray/inversion/inversion/abstract.py
@@ -3,7 +3,7 @@ import copy
 import numpy as np
 from typing import Dict, List, Optional, Type, Union
 
-from autoconf import cached_property, is_test_mode
+from autonerves import cached_property, is_test_mode
 
 from autoarray.dataset.imaging.dataset import Imaging
 from autoarray.dataset.interferometer.dataset import Interferometer

--- a/autoarray/inversion/inversion/imaging/mapping.py
+++ b/autoarray/inversion/inversion/imaging/mapping.py
@@ -1,7 +1,7 @@
 import numpy as np
 from typing import Dict, List, Optional, Union
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 from autoarray.dataset.imaging.dataset import Imaging
 from autoarray.inversion.inversion.dataset_interface import DatasetInterface

--- a/autoarray/inversion/inversion/imaging/sparse.py
+++ b/autoarray/inversion/inversion/imaging/sparse.py
@@ -1,7 +1,7 @@
 import numpy as np
 from typing import Dict, List, Optional, Union
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 from autoarray.dataset.imaging.dataset import Imaging
 from autoarray.inversion.inversion.dataset_interface import DatasetInterface

--- a/autoarray/inversion/inversion/imaging_numba/sparse.py
+++ b/autoarray/inversion/inversion/imaging_numba/sparse.py
@@ -1,7 +1,7 @@
 import numpy as np
 from typing import Dict, List, Optional, Union
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 from autoarray.dataset.imaging.dataset import Imaging
 from autoarray.inversion.inversion.dataset_interface import DatasetInterface

--- a/autoarray/inversion/inversion/inversion_util.py
+++ b/autoarray/inversion/inversion/inversion_util.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from typing import List, Optional, Type
 
-from autoconf import is_test_mode
+from autonerves import is_test_mode
 
 from autoarray.settings import Settings
 
@@ -288,7 +288,7 @@ def reconstruction_positive_only_from(
     """
     if xp.__name__.startswith("jax"):
 
-        from autoconf import conf
+        from autonerves import conf
 
         from autoarray.util.jax_nnls import solve_nnls_primal
 

--- a/autoarray/inversion/linear_obj/func_list.py
+++ b/autoarray/inversion/linear_obj/func_list.py
@@ -1,7 +1,7 @@
 import numpy as np
 from typing import Optional
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 from autoarray.inversion.linear_obj.linear_obj import LinearObj
 from autoarray.inversion.linear_obj.neighbors import Neighbors

--- a/autoarray/inversion/mappers/abstract.py
+++ b/autoarray/inversion/mappers/abstract.py
@@ -2,8 +2,8 @@ import itertools
 import numpy as np
 from typing import List, Optional, Tuple
 
-from autoconf import conf
-from autoconf import cached_property
+from autonerves import conf
+from autonerves import cached_property
 
 from autoarray.inversion.linear_obj.linear_obj import LinearObj
 from autoarray.inversion.linear_obj.func_list import UniqueMappings

--- a/autoarray/inversion/mesh/border_relocator.py
+++ b/autoarray/inversion/mesh/border_relocator.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import numpy as np
 from typing import Tuple, Union
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 from autoarray.mask.mask_2d import Mask2D
 from autoarray.structures.arrays.uniform_2d import Array2D

--- a/autoarray/inversion/mesh/image_mesh/hilbert.py
+++ b/autoarray/inversion/mesh/image_mesh/hilbert.py
@@ -12,7 +12,7 @@ from autoarray.inversion.mesh.image_mesh.abstract_weighted import (
 from autoarray.structures.grids.irregular_2d import Grid2DIrregular
 
 from autoarray import exc
-from autoconf.test_mode import skip_checks
+from autonerves.test_mode import skip_checks
 
 
 def gilbert2d(width, height):

--- a/autoarray/inversion/mesh/interpolator/delaunay.py
+++ b/autoarray/inversion/mesh/interpolator/delaunay.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 from autoarray.inversion.mesh.interpolator.abstract import AbstractInterpolator
 from autoarray.inversion.regularization.regularization_util import (

--- a/autoarray/inversion/mesh/interpolator/knn.py
+++ b/autoarray/inversion/mesh/interpolator/knn.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 from autoarray.inversion.mesh.interpolator.delaunay import InterpolatorDelaunay
 

--- a/autoarray/inversion/mesh/interpolator/rectangular.py
+++ b/autoarray/inversion/mesh/interpolator/rectangular.py
@@ -1,7 +1,7 @@
 import numpy as np
 from functools import partial
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 from autoarray.inversion.mesh.interpolator.abstract import AbstractInterpolator
 

--- a/autoarray/inversion/mesh/interpolator/rectangular_kernel.py
+++ b/autoarray/inversion/mesh/interpolator/rectangular_kernel.py
@@ -45,7 +45,7 @@ import numpy as np
 from functools import partial
 from typing import Optional
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 from autoarray.inversion.mesh.interpolator.rectangular import (
     InterpolatorRectangular,

--- a/autoarray/inversion/mesh/interpolator/rectangular_rotated_spline.py
+++ b/autoarray/inversion/mesh/interpolator/rectangular_rotated_spline.py
@@ -14,7 +14,7 @@ from typing import Optional
 
 import numpy as np
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 from autoarray.inversion.mesh.interpolator.rectangular_spline import (
     SPLINE_CDF_DEFAULT_DEG,

--- a/autoarray/inversion/mesh/interpolator/rectangular_spline.py
+++ b/autoarray/inversion/mesh/interpolator/rectangular_spline.py
@@ -33,7 +33,7 @@ from typing import Callable, Optional, Tuple
 
 import numpy as np
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 from autoarray.inversion.mesh.interpolator.abstract import AbstractInterpolator
 from autoarray.inversion.mesh.interpolator.rectangular import InterpolatorRectangular

--- a/autoarray/inversion/mesh/interpolator/rectangular_uniform.py
+++ b/autoarray/inversion/mesh/interpolator/rectangular_uniform.py
@@ -1,7 +1,7 @@
 from typing import Tuple
 import numpy as np
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 from autoarray.inversion.mesh.interpolator.abstract import AbstractInterpolator
 from autoarray.geometry.geometry_2d import Geometry2D

--- a/autoarray/inversion/mesh/mesh_geometry/delaunay.py
+++ b/autoarray/inversion/mesh/mesh_geometry/delaunay.py
@@ -2,7 +2,7 @@ import numpy as np
 import scipy.spatial
 from typing import Tuple
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 from autoarray.geometry.geometry_2d_irregular import Geometry2DIrregular
 from autoarray.inversion.linear_obj.neighbors import Neighbors

--- a/autoarray/inversion/plot/inversion_plots.py
+++ b/autoarray/inversion/plot/inversion_plots.py
@@ -4,7 +4,7 @@ import numpy as np
 from pathlib import Path
 from typing import Optional, Union
 
-from autoconf import conf
+from autonerves import conf
 
 from autoarray.inversion.mappers.abstract import Mapper
 from autoarray.plot.array import plot_array

--- a/autoarray/mask/mask_2d.py
+++ b/autoarray/mask/mask_2d.py
@@ -6,7 +6,7 @@ import numpy as np
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Tuple, Union
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 from autoarray.structures.abstract_structure import Structure
 
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from autoarray.structures.arrays.uniform_2d import Array2D
 
 
-from autoconf.fitsable import ndarray_via_fits_from
+from autonerves.fitsable import ndarray_via_fits_from
 
 from autoarray.mask.abstract_mask import Mask
 

--- a/autoarray/numba_util.py
+++ b/autoarray/numba_util.py
@@ -1,6 +1,6 @@
 import logging
 
-from autoconf import conf
+from autonerves import conf
 
 
 logger = logging.getLogger(__name__)

--- a/autoarray/operators/convolver.py
+++ b/autoarray/operators/convolver.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Optional, Tuple, Union
 import warnings
 
-from autoconf import conf
+from autonerves import conf
 from autoarray.structures.arrays.uniform_2d import Array2D
 from autoarray.structures.grids.uniform_2d import Grid2D
 

--- a/autoarray/operators/over_sampling/over_sampler.py
+++ b/autoarray/operators/over_sampling/over_sampler.py
@@ -2,8 +2,8 @@ import numpy as np
 
 from typing import Union
 
-from autoconf import conf
-from autoconf import cached_property
+from autonerves import conf
+from autonerves import cached_property
 
 from autoarray.mask.mask_2d import Mask2D
 from autoarray.structures.arrays.uniform_2d import Array2D

--- a/autoarray/plot/__init__.py
+++ b/autoarray/plot/__init__.py
@@ -1,7 +1,7 @@
 def _set_backend():
     try:
         import matplotlib
-        from autoconf import conf
+        from autonerves import conf
 
         backend = conf.get_matplotlib_backend()
         if backend != "default":

--- a/autoarray/plot/array.py
+++ b/autoarray/plot/array.py
@@ -163,7 +163,7 @@ def plot_array(
     # --- colour normalisation --------------------------------------------------
     if use_log10:
         try:
-            from autoconf import conf as _conf
+            from autonerves import conf as _conf
 
             log10_min = _conf.instance["visualize"]["general"]["general"][
                 "log10_min_value"

--- a/autoarray/plot/utils.py
+++ b/autoarray/plot/utils.py
@@ -79,7 +79,7 @@ def auto_mask_edge(array) -> Optional[np.ndarray]:
 def zoom_array(array):
     """Crop *array* around its mask when ``zoom_around_mask`` is enabled in config.
 
-    Reads ``visualize/general/general/zoom_around_mask`` from the autoconf
+    Reads ``visualize/general/general/zoom_around_mask`` from the autonerves
     configuration.  When the flag is ``True`` and *array* carries a non-trivial
     mask the array is cropped via ``Zoom2D`` so that downstream ``imshow``
     calls fill the axes without empty black borders.
@@ -98,7 +98,7 @@ def zoom_array(array):
         unmodified.
     """
     try:
-        from autoconf import conf
+        from autonerves import conf
 
         zoom_around_mask = conf.instance["visualize"]["general"]["general"][
             "zoom_around_mask"
@@ -400,7 +400,7 @@ def conf_mat_plot_fontsize(section: str, default: int) -> int:
         The configured font size.
     """
     try:
-        from autoconf import conf
+        from autonerves import conf
 
         return int(
             conf.instance["visualize"]["general"]["mat_plot"][section]["fontsize"]
@@ -432,7 +432,7 @@ def conf_figsize(context: str = "figures") -> Tuple[int, int]:
         ``"figures"`` (single-panel) or ``"subplots"`` (multi-panel).
     """
     try:
-        from autoconf import conf
+        from autonerves import conf
 
         if context == "figures":
             raw = conf.instance["visualize"]["general"]["mat_plot"]["figure"]["figsize"]
@@ -450,7 +450,7 @@ def conf_subplot_figsize(rows: int, cols: int) -> Tuple[int, int]:
     ``(cols * fx, rows * fy)``.
     """
     try:
-        from autoconf import conf
+        from autonerves import conf
 
         raw = conf.instance["visualize"]["general"]["mat_plot"]["figure"][
             "subplot_shape_to_figsize_factor"
@@ -532,7 +532,7 @@ def save_figure(
         format = _conf_output_format()
 
     if dpi is None:
-        from autoconf import conf
+        from autonerves import conf
         dpi = int(conf.instance["visualize"]["general"]["general"]["dpi"])
 
     if _output_mode_save(fig, filename):
@@ -595,7 +595,7 @@ def plot_visibilities_1d(vis, ax, title: str = "") -> None:
 
 def _conf_colorbar(key: str, default):
     try:
-        from autoconf import conf
+        from autonerves import conf
         return conf.instance["visualize"]["general"]["colorbar"][key]
     except Exception:
         return default
@@ -663,7 +663,7 @@ def _colorbar_tick_labels(tick_values: List[float], cb_unit: Optional[str] = Non
     """
     if cb_unit is None:
         try:
-            from autoconf import conf
+            from autonerves import conf
             cb_unit = conf.instance["visualize"]["general"]["units"]["cb_unit"]
         except Exception:
             cb_unit = ""
@@ -763,7 +763,7 @@ def _apply_contours(
         the config value is used.
     """
     try:
-        from autoconf import conf
+        from autonerves import conf
         _c = conf.instance["visualize"]["general"]["contour"]
         total = int(n if n is not None else _c.get("total_contours", 10))
         include_values = bool(_c.get("include_values", True))
@@ -774,7 +774,7 @@ def _apply_contours(
     try:
         if use_log10:
             try:
-                from autoconf import conf
+                from autonerves import conf
                 log10_min = float(conf.instance["visualize"]["general"]["general"]["log10_min_value"])
             except Exception:
                 log10_min = 1.0e-4
@@ -828,7 +828,7 @@ def hide_unused_axes(axes) -> None:
 def _default_colormap() -> str:
     """Return the colormap name from config, registering the custom one if needed."""
     try:
-        from autoconf import conf
+        from autonerves import conf
         name = conf.instance["visualize"]["general"]["colormap"]
     except Exception:
         name = "autoarray"
@@ -841,7 +841,7 @@ def _default_colormap() -> str:
 def _conf_imshow_origin() -> str:
     """Return the imshow origin from config (``"upper"`` or ``"lower"``)."""
     try:
-        from autoconf import conf
+        from autonerves import conf
         return conf.instance["visualize"]["general"]["general"]["imshow_origin"]
     except Exception:
         return "upper"
@@ -850,7 +850,7 @@ def _conf_imshow_origin() -> str:
 def _conf_output_format() -> str:
     """Return the default output_format from config (``"show"``, ``"png"``, etc.)."""
     try:
-        from autoconf import conf
+        from autonerves import conf
         return conf.instance["visualize"]["general"]["general"]["output_format"]
     except Exception:
         return "show"
@@ -858,7 +858,7 @@ def _conf_output_format() -> str:
 
 def _conf_ticks(key: str, default: float) -> float:
     try:
-        from autoconf import conf
+        from autonerves import conf
         return float(conf.instance["visualize"]["general"]["ticks"][key])
     except Exception:
         return default
@@ -866,7 +866,7 @@ def _conf_ticks(key: str, default: float) -> float:
 
 def _conf_ticks_flag(key: str, default: bool) -> bool:
     try:
-        from autoconf import conf
+        from autonerves import conf
         return bool(conf.instance["visualize"]["general"]["ticks"][key])
     except Exception:
         return default

--- a/autoarray/settings.py
+++ b/autoarray/settings.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional
 
-from autoconf import conf
+from autonerves import conf
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)

--- a/autoarray/structures/arrays/uniform_1d.py
+++ b/autoarray/structures/arrays/uniform_1d.py
@@ -2,7 +2,7 @@ import numpy as np
 from pathlib import Path
 from typing import Optional, Union, Tuple, List
 
-from autoconf.fitsable import ndarray_via_fits_from, header_obj_from
+from autonerves.fitsable import ndarray_via_fits_from, header_obj_from
 
 from autoarray.structures.header import Header
 

--- a/autoarray/structures/arrays/uniform_2d.py
+++ b/autoarray/structures/arrays/uniform_2d.py
@@ -3,8 +3,8 @@ import numpy as np
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
 
-from autoconf import conf
-from autoconf.fitsable import ndarray_via_fits_from, header_obj_from
+from autonerves import conf
+from autonerves.fitsable import ndarray_via_fits_from, header_obj_from
 
 from autoarray.mask.mask_2d import Mask2D
 from autoarray.mask.derive.zoom_2d import Zoom2D

--- a/autoarray/structures/grids/uniform_2d.py
+++ b/autoarray/structures/grids/uniform_2d.py
@@ -4,8 +4,8 @@ import numpy as np
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
 
-from autoconf import conf
-from autoconf.fitsable import ndarray_via_fits_from
+from autonerves import conf
+from autonerves.fitsable import ndarray_via_fits_from
 
 from autoarray.mask.mask_2d import Mask2D
 from autoarray.structures.abstract_structure import Structure

--- a/autoarray/structures/triangles/coordinate_array_np.py
+++ b/autoarray/structures/triangles/coordinate_array_np.py
@@ -4,7 +4,7 @@ from autoarray.structures.triangles.abstract import HEIGHT_FACTOR
 from autoarray.structures.triangles.abstract import AbstractTriangles
 from autoarray.structures.triangles.array_np import ArrayTrianglesNp
 from autoarray.structures.triangles.shape import Shape
-from autoconf import cached_property
+from autonerves import cached_property
 
 
 class CoordinateArrayTrianglesNp(AbstractTriangles):

--- a/autoarray/structures/visibilities.py
+++ b/autoarray/structures/visibilities.py
@@ -5,7 +5,7 @@ import numpy as np
 from pathlib import Path
 from typing import List, Tuple, Union
 
-from autoconf.fitsable import ndarray_via_fits_from, output_to_fits
+from autonerves.fitsable import ndarray_via_fits_from, output_to_fits
 
 from autoarray.structures.abstract_structure import Structure
 from autoarray.structures.grids.irregular_2d import Grid2DIrregular

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 keywords = ["cli"]
 dependencies = [
-    "autoconf",
+    "autonerves",
     "astropy>=5.0,<=7.2.0",
     "decorator>=4.0.0",
     "dill>=0.3.1.1",
@@ -52,7 +52,7 @@ local_scheme = "no-local-version"
 
 
 [project.optional-dependencies]
-jax = ["autoconf[jax]"]
+jax = ["autonerves[jax]"]
 optional = [
     "autoarray[jax]",
     "numba",
@@ -62,7 +62,7 @@ optional = [
     # regularization path (autoarray/inversion/regularization/matern_kernel.py).
     # The last *stable* release (tensorflow-probability==0.25.0) targets a JAX where
     # `jax.interpreters.xla.pytype_aval_mappings` still existed; it crashes at import
-    # under the resolved `jax>=0.7` stack (autoconf[jax]). The nightly restores
+    # under the resolved `jax>=0.7` stack (autonerves[jax]). The nightly restores
     # compatibility. Durable fix (vendor bessel_kve, drop tfp) tracked separately.
     "tfp-nightly==0.26.0.dev20260713"
 ]

--- a/test_autoarray/conftest.py
+++ b/test_autoarray/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from matplotlib import pyplot
 
 from autoarray import fixtures
-from autoconf import conf
+from autonerves import conf
 
 
 class PlotPatch:

--- a/test_autoarray/inversion/inversion/test_settings_dict.py
+++ b/test_autoarray/inversion/inversion/test_settings_dict.py
@@ -4,7 +4,7 @@ import pytest
 from pathlib import Path
 
 import autoarray as aa
-from autoconf.dictable import from_dict, output_to_json, from_json
+from autonerves.dictable import from_dict, output_to_json, from_json
 
 
 @pytest.fixture(name="settings_dict")

--- a/test_autoarray/mask/test_mask_2d.py
+++ b/test_autoarray/mask/test_mask_2d.py
@@ -421,7 +421,7 @@ def test__from_fits__output_to_fits__roundtrip_preserves_values_pixel_scales_and
 
     os.makedirs(output_path)
 
-    from autoconf.fitsable import output_to_fits
+    from autonerves.fitsable import output_to_fits
     output_to_fits(
         values=mask.astype("float"),
         file_path=Path(output_path) / "mask.fits",

--- a/test_autoarray/plot/test_utils.py
+++ b/test_autoarray/plot/test_utils.py
@@ -1,4 +1,4 @@
-from autoconf import conf
+from autonerves import conf
 
 from autoarray.plot.utils import _arcsec_labels
 

--- a/test_autoarray/structures/arrays/test_uniform_1d.py
+++ b/test_autoarray/structures/arrays/test_uniform_1d.py
@@ -162,7 +162,7 @@ def test__output_to_fits__ones_array__fits_file_has_correct_values_and_header():
 
     os.makedirs(test_data_path)
 
-    from autoconf.fitsable import output_to_fits
+    from autonerves.fitsable import output_to_fits
     output_to_fits(values=arr.native.array.astype("float"), file_path=test_data_path / "array.fits", header_dict=arr.mask.header_dict)
 
     array_from_out = aa.Array1D.from_fits(

--- a/test_autoarray/structures/arrays/test_uniform_2d.py
+++ b/test_autoarray/structures/arrays/test_uniform_2d.py
@@ -204,7 +204,7 @@ def test__output_to_fits__3x3_ones__fits_file_has_ones_and_correct_pixel_scale_h
 
     os.makedirs(output_test_path)
 
-    from autoconf.fitsable import output_to_fits
+    from autonerves.fitsable import output_to_fits
     output_to_fits(values=array_2d.native.array.astype("float"), file_path=output_test_path / "array.fits", header_dict=array_2d.mask.header_dict)
 
     array_from_fits = aa.Array2D.from_fits(

--- a/test_autoarray/structures/grids/test_uniform_2d.py
+++ b/test_autoarray/structures/grids/test_uniform_2d.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from autoconf import conf
+from autonerves import conf
 import autoarray as aa
 from autoarray import exc
 
@@ -488,7 +488,7 @@ def test__to_and_from_fits_methods():
 
     file_path = test_grid_dir / "grid_2d.fits"
 
-    from autoconf.fitsable import output_to_fits
+    from autonerves.fitsable import output_to_fits
     output_to_fits(values=grid_2d.native.array.astype("float"), file_path=file_path, overwrite=True, header_dict=grid_2d.mask.header_dict)
 
     grid_from_fits = aa.Grid2D.from_fits(file_path=file_path, pixel_scales=2.0)

--- a/test_autoarray/structures/test_visibilities.py
+++ b/test_autoarray/structures/test_visibilities.py
@@ -100,7 +100,7 @@ def test__output_to_fits():
 
     os.makedirs(output_test_path)
 
-    from autoconf.fitsable import output_to_fits
+    from autonerves.fitsable import output_to_fits
     output_to_fits(values=visibilities.in_array, file_path=output_test_path / "data.fits")
 
     visibilities_from_out = aa.Visibilities.from_fits(

--- a/test_autoarray/structures/vectors/test_vectors_irregular.py
+++ b/test_autoarray/structures/vectors/test_vectors_irregular.py
@@ -99,7 +99,7 @@ def test__vectors_within_radius():
 
 
 def test__json_round_trip(tmp_path):
-    from autoconf.dictable import output_to_json, from_json
+    from autonerves.dictable import output_to_json, from_json
 
     vectors = aa.VectorYX2DIrregular(
         values=[(0.1, 0.2), (0.3, 0.4)],

--- a/test_autoarray/test_abstract_ndarray_pytree_guard.py
+++ b/test_autoarray/test_abstract_ndarray_pytree_guard.py
@@ -42,7 +42,7 @@ class _FakeArray(AbstractNDArray):
 def test_instance_flatten_excludes_cached_property_names():
     """``AbstractNDArray.instance_flatten`` unions the class-level
     ``__no_flatten__`` with the result of
-    ``autoconf.tools.decorators.cached_property_names`` so derived
+    ``autonerves.tools.decorators.cached_property_names`` so derived
     cached strings stay out of the pytree leaves.
 
     This pins the structural defense that follows PyAutoFit#1300: the


### PR DESCRIPTION
## What

Switch the `autoconf` dependency to its renamed form **`autonerves`**: pyproject pins and every `import autoconf` / `from autoconf` (including the config re-export block). Repo-name references (`PyAutoConf`) are unchanged — they flip with the GitHub repo rename.

⚠️ **Breaking / coordinated**: pairs with PyAutoConf#135 and the other library PRs on the **same-named branch**. CI resolves `autonerves` from the same-named PyAutoConf branch. Merge together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN

---
_Generated by [Claude Code](https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN)_