### PR TITLE
chore: rename PyAutoConf → PyAutoNerves in docs/prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Shared utilities (e.g. `test_mode`, `jax_wrapper`) belong in autonerves.
 
 ## Related repos
 
-- **Source siblings:** PyAutoConf (upstream). PyAutoGalaxy / PyAutoLens build
+- **Source siblings:** PyAutoNerves (upstream). PyAutoGalaxy / PyAutoLens build
   directly on autoarray.
 - No `_workspace`, `_workspace_test`, or HowTo of its own. The JAX/`xp` path is
   exercised by the parity scripts in **autogalaxy_workspace_test** and

--- a/llms.txt
+++ b/llms.txt
@@ -12,4 +12,4 @@
 
 ## Ecosystem
 
-- Built on PyAutoConf (config); used by PyAutoGalaxy and PyAutoLens, which inherit its grid decorators and JAX `xp` backend.
+- Built on PyAutoNerves (config); used by PyAutoGalaxy and PyAutoLens, which inherit its grid decorators and JAX `xp` backend.


### PR DESCRIPTION
## What

Update the "source siblings / related repos" references from PyAutoConf to PyAutoNerves following the GitHub repo rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN

---
_Generated by [Claude Code](https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN)_