### PR TITLE
fix: make the PYAUTO_SMALL_DATASETS fast-mode cap even (15×15 → 16×16)

### DIFF
--- a/autoarray/mask/mask_2d.py
+++ b/autoarray/mask/mask_2d.py
@@ -361,8 +361,8 @@ class Mask2D(Mask):
         """
 
         if os.environ.get("PYAUTO_SMALL_DATASETS") == "1":
-            if shape_native[0] > 15 or shape_native[1] > 15:
-                shape_native = (15, 15)
+            if shape_native[0] > 16 or shape_native[1] > 16:
+                shape_native = (16, 16)
                 pixel_scales = 0.6
             scale_scalar = (
                 pixel_scales

--- a/autoarray/structures/grids/uniform_2d.py
+++ b/autoarray/structures/grids/uniform_2d.py
@@ -491,14 +491,14 @@ class Grid2D(Structure):
         origin
             The origin of the grid's mask.
         respect_small_datasets
-            When ``PYAUTO_SMALL_DATASETS=1`` is set, grids larger than 15x15 are silently shrunk to
-            ``(15, 15)`` at ``pixel_scales=0.6`` to keep smoke runs fast. Pass ``False`` to opt out
+            When ``PYAUTO_SMALL_DATASETS=1`` is set, grids larger than 16x16 are silently shrunk to
+            ``(16, 16)`` at ``pixel_scales=0.6`` to keep smoke runs fast. Pass ``False`` to opt out
             of that shrink for grids whose spatial extent is load-bearing for the script (e.g. a
             visualization asserting cluster-scale critical curves at ~30-50").
         """
         if respect_small_datasets and os.environ.get("PYAUTO_SMALL_DATASETS") == "1":
-            if shape_native[0] > 15 or shape_native[1] > 15:
-                shape_native = (15, 15)
+            if shape_native[0] > 16 or shape_native[1] > 16:
+                shape_native = (16, 16)
                 pixel_scales = 0.6
 
         pixel_scales = geometry_util.convert_pixel_scales_2d(pixel_scales=pixel_scales)

--- a/autoarray/util/dataset_util.py
+++ b/autoarray/util/dataset_util.py
@@ -3,7 +3,7 @@ import shutil
 from pathlib import Path
 
 
-SMALL_DATASETS_SHAPE_NATIVE = (15, 15)
+SMALL_DATASETS_SHAPE_NATIVE = (16, 16)
 SMALL_DATASETS_PIXEL_SCALES = 0.6
 
 
@@ -15,10 +15,10 @@ def cap_array_2d_for_small_datasets(array_2d, pixel_scales):
     Returns ``(array_2d, pixel_scales)`` unchanged in any of these cases:
 
     - ``PYAUTO_SMALL_DATASETS`` is not set to ``"1"``.
-    - ``array_2d.shape_native`` is already at-or-below the cap (15, 15).
+    - ``array_2d.shape_native`` is already at-or-below the cap (16, 16).
 
-    When the env var is set and the input shape exceeds (15, 15), returns a
-    new ``Array2D`` center-cropped to (15, 15) with ``pixel_scales`` overridden
+    When the env var is set and the input shape exceeds (16, 16), returns a
+    new ``Array2D`` center-cropped to (16, 16) with ``pixel_scales`` overridden
     to 0.6 — matching the convention used by ``Mask2D.circular`` and
     ``Grid2D.uniform`` so the loaded dataset stays shape-consistent with masks
     and grids built under the same env var.

--- a/test_autoarray/dataset/imaging/test_dataset.py
+++ b/test_autoarray/dataset/imaging/test_dataset.py
@@ -196,8 +196,8 @@ def test__from_fits__small_datasets_env_caps_data_and_noise_map(
         noise_map_path=Path(test_data_path) / "noise_map_30x30.fits",
     )
 
-    assert dataset.data.shape_native == (15, 15)
-    assert dataset.noise_map.shape_native == (15, 15)
+    assert dataset.data.shape_native == (16, 16)
+    assert dataset.noise_map.shape_native == (16, 16)
     assert dataset.pixel_scales == (0.6, 0.6)
     assert dataset.psf.kernel.shape_native == (5, 5)
 

--- a/test_autoarray/mask/test_mask_2d.py
+++ b/test_autoarray/mask/test_mask_2d.py
@@ -134,11 +134,11 @@ def test__circular__small_datasets_env__oversized_radius_clamped_to_disc(monkeyp
 
     mask = aa.Mask2D.circular(shape_native=(100, 100), pixel_scales=0.1, radius=6.0)
 
-    assert mask.shape_native == (15, 15)
+    assert mask.shape_native == (16, 16)
     assert mask.pixel_scales == (0.6, 0.6)
     assert mask.is_circular
     n_unmasked = int((~mask.array).sum())
-    assert 100 < n_unmasked < 225
+    assert 100 < n_unmasked < 256
 
 
 def test__circular__small_datasets_env__in_bounds_radius_unchanged(monkeypatch):
@@ -161,7 +161,7 @@ def test__circular__small_datasets_env__tuple_pixel_scales_oversized_radius_clam
         shape_native=(200, 200), pixel_scales=(0.1, 0.1), radius=7.5
     )
 
-    assert mask.shape_native == (15, 15)
+    assert mask.shape_native == (16, 16)
     assert mask.is_circular
 
 

--- a/test_autoarray/util/test_dataset_util.py
+++ b/test_autoarray/util/test_dataset_util.py
@@ -59,12 +59,13 @@ def test__env_set__shape_above_cap__center_crops_and_overrides_pixel_scales(
     assert result.shape_native == SMALL_DATASETS_SHAPE_NATIVE
     assert pixel_scales == SMALL_DATASETS_PIXEL_SCALES
 
-    h0 = (150 - 15) // 2
-    expected = raw[h0:h0 + 15, h0:h0 + 15]
+    cap_h, cap_w = SMALL_DATASETS_SHAPE_NATIVE
+    h0, w0 = (150 - cap_h) // 2, (150 - cap_w) // 2
+    expected = raw[h0:h0 + cap_h, w0:w0 + cap_w]
     assert (result.native.array == expected).all()
 
 
-def test__env_set__non_square_above_cap__center_crops_to_15x15(monkeypatch):
+def test__env_set__non_square_above_cap__center_crops_to_16x16(monkeypatch):
     monkeypatch.setenv("PYAUTO_SMALL_DATASETS", "1")
 
     array = _array_2d((100, 50))


### PR DESCRIPTION
## Problem

The fast-mode cap (`PYAUTO_SMALL_DATASETS=1`) shrank masks/grids/arrays to an **odd** `15×15`. Any feature requiring even mask dimensions then failed under fast-mode — notably PyAutoLens' potential-correction dpsi mesh (`RegularDpsiMesh(factor=2)` → `PairRegularDpsiMesh`), which enforces:

```
raise ValueError("both mask dimensions must be divisible by dpsi_factor")
```

This failed the `interferometer/features/potential_correction/{start_here,likelihood_function}.py` scripts in **PyAutoHeart's release-fidelity validation** (and the nightly it feeds), even though they run fine at full resolution (their real-space mask is `72×72`, divisible by 2). Surfaced while auditing the nightly reds; it is **not** related to the autoconf→autonerves rename.

## Root cause

`(72,72)` real-space mask → capped to `(15,15)` → `15 % 2 != 0` → mesh rejects it. `cleaned_mask_from` preserves shape (it only toggles pixels to masked), so the odd shape reaches the divisibility check unchanged.

## Fix

Cap to an even **`16×16`** across all three cap sites and the shared constant:
- `Mask2D.circular` (`mask/mask_2d.py`)
- `Grid2D.uniform` (`structures/grids/uniform_2d.py`)
- `cap_array_2d_for_small_datasets` + `SMALL_DATASETS_SHAPE_NATIVE` (`util/dataset_util.py`)

Fast-mode is a CI-speed convenience only (`16×16` vs `15×15` is negligible) and **real runs are unaffected**. The potential-correction mesh keeps its strict even-divisibility invariant — the fast-mode cap simply no longer violates it.

## Validation

`python -m pytest test_autoarray/` → all small-datasets tests pass; full suite green apart from 3 pre-existing `nufft_pynufft` transformer tests that also fail on clean `main` in this env (unpinned pynufft), unrelated to this change. Cap-value assertions updated to `16×16`; `test_dataset_util.py` now derives the crop from the constant rather than hardcoding `15`.

## Downstream

Workspace smoke suites run with `PYAUTO_SMALL_DATASETS=1`, so they'll use `16×16` after this merges — the change that makes the potential-correction scripts pass. No API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN

---
_Generated by [Claude Code](https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN)_