### PR TITLE
chore: sync __version__ to 2026.7.22.1

### DIFF
--- a/autoarray/__init__.py
+++ b/autoarray/__init__.py
@@ -106,7 +106,7 @@ from autonerves.fitsable import hdu_list_for_output_from
 
 conf.instance.register(__file__)
 
-__version__ = "2026.7.22.1"
+__version__ = "2026.7.23.1"
 
 # ---------------------------------------------------------------------------
 # Public re-export of the autonerves configuration / serialization surface.

--- a/autoarray/__init__.py
+++ b/autoarray/__init__.py
@@ -106,7 +106,7 @@ from autonerves.fitsable import hdu_list_for_output_from
 
 conf.instance.register(__file__)
 
-__version__ = "2026.7.9.1"
+__version__ = "2026.7.22.1"
 
 # ---------------------------------------------------------------------------
 # Public re-export of the autonerves configuration / serialization surface.


### PR DESCRIPTION
Syncs `__version__` to the released `2026.7.22.1`. Companion to PyAutoLens#642.