### PR TITLE
fix: guard weighted image-mesh weight map against a blank adapt image

### DIFF
--- a/autoarray/inversion/mesh/image_mesh/abstract_weighted.py
+++ b/autoarray/inversion/mesh/image_mesh/abstract_weighted.py
@@ -57,7 +57,19 @@ class AbstractImageMeshWeighted(AbstractImageMesh):
         The weight map which is used to adapt the Delaunay pixels in the image-plane to components in the data.
         """
 
-        weight_map = np.abs(adapt_data) / np.max(adapt_data)
+        max_value = np.max(adapt_data)
+
+        if max_value <= 0.0:
+            # A blank adapt image (all-zero, or with no positive signal) carries
+            # no structure to adapt the mesh to. Normalising by ``np.max`` would
+            # divide by zero (or a non-positive peak), producing NaN/negative
+            # weights that propagate into NaN mesh coordinates and crash the
+            # downstream Delaunay/Voronoi triangulation ("Points cannot contain
+            # NaN"). Fall back to a uniform weight map so the mesh degrades to
+            # uniform sampling instead of failing.
+            return np.ones_like(adapt_data, dtype=float)
+
+        weight_map = np.abs(adapt_data) / max_value
         weight_map = weight_map**self.weight_power
 
         weight_map[weight_map < self.weight_floor] = self.weight_floor

--- a/test_autoarray/inversion/pixelization/image_mesh/test_abstract_weighted.py
+++ b/test_autoarray/inversion/pixelization/image_mesh/test_abstract_weighted.py
@@ -24,3 +24,24 @@ def test__weight_map_from():
     weight_map = pixelization.weight_map_from(adapt_data=adapt_data)
 
     assert weight_map == pytest.approx([1.0, 1.0, 1.0], 1.0e-4)
+
+
+def test__weight_map_from__blank_adapt_image_returns_uniform_not_nan():
+    # A blank (all-zero) adapt image has ``np.max == 0``; the normalisation must
+    # not divide by zero and produce NaN weights, which would propagate into NaN
+    # mesh coordinates and crash the downstream Delaunay triangulation.
+    pixelization = aa.image_mesh.Hilbert(
+        pixels=5, weight_floor=0.01, weight_power=3.5
+    )
+
+    weight_map = pixelization.weight_map_from(adapt_data=np.zeros(4))
+
+    assert np.all(np.isfinite(weight_map))
+    assert weight_map == pytest.approx([1.0, 1.0, 1.0, 1.0], 1.0e-4)
+
+    # An adapt image with no positive signal (non-positive peak) is equally
+    # degenerate and must also fall back to a finite, uniform weight map.
+    weight_map = pixelization.weight_map_from(adapt_data=np.array([-2.0, -1.0, -3.0]))
+
+    assert np.all(np.isfinite(weight_map))
+    assert weight_map == pytest.approx([1.0, 1.0, 1.0], 1.0e-4)


### PR DESCRIPTION
## What

`AbstractImageMeshWeighted.weight_map_from` normalises by `np.max(adapt_data)`. When the adapt image is blank (all-zero, or no positive signal) this divides by zero, producing NaN weights that propagate into NaN Hilbert mesh coordinates and crash the downstream Delaunay triangulation with `ValueError: Points cannot contain NaN` inside the vmapped likelihood.

This is what failed the nightly release-fidelity validation on `autolens_workspace/scripts/interferometer/features/pixelization/delaunay.py` (PyAutoHeart run 30069528162): under the release profile (`PYAUTO_TEST_MODE=1` + `PYAUTO_SMALL_DATASETS=1`, 16×16 capped mask) the SLaM `source_pix_2` step receives a degenerate `source_pix_result_1` model image (max 0).

The rectangular-mesh consolidation (#403) was investigated and definitively ruled out: the identical failure reproduces with PyAutoArray checked out at the pre-#403 tip. This is a pre-existing robustness bug, not a regression from #403.

## Fix

- `autoarray/inversion/mesh/image_mesh/abstract_weighted.py`: if the adapt-image peak is non-positive, return a uniform weight map (graceful degradation to uniform sampling). The normal `max > 0` path is byte-identical.
- Regression test in `test_autoarray/inversion/pixelization/image_mesh/test_abstract_weighted.py` covering the all-zero and no-positive-signal cases.

## Verification

- The failing workspace script now runs end-to-end (exit 0) under the faithful CI environment (Python 3.12, jax 0.10.2, nufftax 0.4.0, release profile env).
- `test_autoarray/inversion/` → 209 passed, including the existing exact-value `weight_map_from` test (confirms the normal path is unchanged).

Shared by the Hilbert and KMeans image-meshes; no public API change. Downstream repos unaffected on non-degenerate inputs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzN9PZfG5zXMVku8ckSqkC)_