### PR TITLE
fix: catch LinAlgError in the inversion noise-map diagnostic panel

### DIFF
--- a/autoarray/inversion/plot/inversion_plots.py
+++ b/autoarray/inversion/plot/inversion_plots.py
@@ -166,7 +166,7 @@ def subplot_of_mapper(
             mesh_grid=mesh_grid,
             lines=lines,
         )
-    except (KeyError, TypeError):
+    except (KeyError, TypeError, np.linalg.LinAlgError):
         pass
 
     # panel 7: regularization weights

--- a/test_autoarray/inversion/plot/test_inversion_plotters.py
+++ b/test_autoarray/inversion/plot/test_inversion_plotters.py
@@ -1,6 +1,7 @@
 import autoarray.plot as aplt
 from autoarray.inversion.mappers.abstract import Mapper
 
+import numpy as np
 import pytest
 from pathlib import Path
 
@@ -62,3 +63,32 @@ def test__inversion_subplot_of_mapper__is_output_for_all_inversions(
         output_format="png",
     )
     assert str(Path(plot_path) / "mappings_0.png") in plot_patch.paths
+
+
+def test__inversion_subplot_of_mapper__singular_curvature_reg_matrix(
+    rectangular_inversion_7x7_3x3,
+    plot_path,
+    plot_patch,
+    monkeypatch,
+):
+    inversion = rectangular_inversion_7x7_3x3
+
+    params = inversion.linear_obj_list[0].params
+
+    monkeypatch.setattr(
+        type(inversion),
+        "reconstruction_noise_map_with_covariance",
+        property(lambda self: np.sqrt(np.linalg.inv(np.zeros((params, params))))),
+    )
+
+    with pytest.raises(np.linalg.LinAlgError):
+        inversion.reconstruction_noise_map_dict
+
+    aplt.subplot_of_mapper(
+        inversion=inversion,
+        mapper_index=0,
+        output_path=plot_path,
+        output_format="png",
+    )
+
+    assert str(Path(plot_path) / "inversion_0.png") in plot_patch.paths


### PR DESCRIPTION
## What

Fixes the ~50% flaky `numpy.linalg.LinAlgError: Singular matrix` failure that killed `autolens_workspace/scripts/interferometer/features/subhalo/detect/start_here.py` in the nightly release validation (run 30113021881), and likely a whole class of intermittent nightly failures since 07-11.

## Root cause

`subplot_of_mapper`'s panel 6 reads `inversion.reconstruction_noise_map_dict[mapper]`, which computes `np.sqrt(np.linalg.inv(curvature_reg_matrix))`. Under reduced-iteration test profiles (`PYAUTO_TEST_MODE=1` + `PYAUTO_SMALL_DATASETS=1`) the sampler routinely evaluates near-random lens models whose source pixels get no support, leaving `curvature_reg` rank-deficient (measured 784×784, rank 426) — whether `inv` raises is numerically borderline, hence the coin flip. The call site already has a best-effort `except (KeyError, TypeError)` — the author intended this optional diagnostic panel to be skippable — but `LinAlgError` subclasses `ValueError`, so it escapes the guard and takes down the entire model-fit.

Diagnosis notes: the recent NaN-guard change (#404) was explicitly exonerated — instrumentation showed its branch never fires on this script (rectangular meshes don't touch the weighted image-mesh path), and reverting it reproduced the identical failure. Baseline pass rate 4/8; with this fix 4/4 (script) / structural guarantee (the error can no longer escape the panel).

## Change

One line: add `np.linalg.LinAlgError` to the panel's except tuple. Plus a regression test that monkeypatches a genuinely singular covariance input, asserts the property raises, and asserts the subplot still renders (verified non-vacuous: fails with the fix reverted).

## Verification

- `pytest test_autoarray/inversion/plot -q` → 6 passed
- Flaky script passes end-to-end under the CI-exact env (Python 3.12, nufftax 0.4.0, release profile), zero LinAlgError in log

## Follow-ups flagged (not in this PR)

- `inversion_plots.py:386` (CSV export) reads the same dict unguarded — deserves a deliberate decision, not a silent skip.
- The underlying rank-deficiency under test profiles is expected behaviour; this patch only stops it killing fits via an optional plot.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzN9PZfG5zXMVku8ckSqkC)_