### PR TITLE
fix: NaN-fill the reconstruction CSV noise-map column on a singular curvature_reg matrix

### DIFF
--- a/autoarray/inversion/plot/inversion_plots.py
+++ b/autoarray/inversion/plot/inversion_plots.py
@@ -369,6 +369,14 @@ def save_reconstruction_csv(
     One file is written per mapper: ``source_plane_reconstruction_{i}.csv``,
     with columns ``y``, ``x``, ``reconstruction``, ``noise_map``.
 
+    The reconstruction noise map inverts the curvature regularization matrix, which is
+    singular for rank-deficient inversions (e.g. the reduced-iteration searches used by
+    test profiles). The column schema is fixed, because consumers index the CSV by
+    column name, so in that case the ``noise_map`` column is written as ``nan`` (with a
+    logged warning) rather than omitted, and the file is still written: the
+    reconstruction is a science product in its own right and must not be lost, nor may
+    a failure here abort the enclosing model-fit.
+
     Parameters
     ----------
     inversion
@@ -383,10 +391,20 @@ def save_reconstruction_csv(
         y = mapper.source_plane_mesh_grid[:, 0]
         x = mapper.source_plane_mesh_grid[:, 1]
         reconstruction = inversion.reconstruction_dict[mapper]
-        noise_map = inversion.reconstruction_noise_map_dict[mapper]
+
+        try:
+            noise_map = inversion.reconstruction_noise_map_dict[mapper]
+        except np.linalg.LinAlgError:
+            logger.warning(
+                f"save_reconstruction_csv: could not compute the reconstruction noise map for "
+                f"mapper {i} (singular curvature_reg_matrix); writing the noise_map column of "
+                f"source_plane_reconstruction_{i}.csv as nan."
+            )
+            noise_map = None
 
         with open(output_path / f"source_plane_reconstruction_{i}.csv", mode="w", newline="") as f:
             writer = csv.writer(f)
             writer.writerow(["y", "x", "reconstruction", "noise_map"])
             for j in range(len(x)):
-                writer.writerow([float(y[j]), float(x[j]), float(reconstruction[j]), float(noise_map[j])])
+                noise_value = float("nan") if noise_map is None else float(noise_map[j])
+                writer.writerow([float(y[j]), float(x[j]), float(reconstruction[j]), noise_value])

--- a/test_autoarray/inversion/plot/test_inversion_plotters.py
+++ b/test_autoarray/inversion/plot/test_inversion_plotters.py
@@ -1,6 +1,8 @@
 import autoarray.plot as aplt
 from autoarray.inversion.mappers.abstract import Mapper
+from autoarray.inversion.plot.inversion_plots import save_reconstruction_csv
 
+import csv
 import numpy as np
 import pytest
 from pathlib import Path
@@ -92,3 +94,46 @@ def test__inversion_subplot_of_mapper__singular_curvature_reg_matrix(
     )
 
     assert str(Path(plot_path) / "inversion_0.png") in plot_patch.paths
+
+
+def test__save_reconstruction_csv__singular_curvature_reg_matrix(
+    rectangular_inversion_7x7_3x3,
+    tmp_path,
+    monkeypatch,
+):
+    inversion = rectangular_inversion_7x7_3x3
+
+    params = inversion.linear_obj_list[0].params
+
+    monkeypatch.setattr(
+        type(inversion),
+        "reconstruction_noise_map_with_covariance",
+        property(lambda self: np.sqrt(np.linalg.inv(np.zeros((params, params))))),
+    )
+
+    with pytest.raises(np.linalg.LinAlgError):
+        inversion.reconstruction_noise_map_dict
+
+    save_reconstruction_csv(inversion=inversion, output_path=tmp_path)
+
+    csv_path = tmp_path / "source_plane_reconstruction_0.csv"
+
+    assert csv_path.exists()
+
+    with open(csv_path, mode="r") as f:
+        reader = csv.reader(f)
+        header_list = next(reader)
+        row_list = [row for row in reader]
+
+    # The column schema is unchanged, because consumers index the CSV by column name.
+
+    assert header_list == ["y", "x", "reconstruction", "noise_map"]
+
+    mapper = inversion.cls_list_from(cls=Mapper)[0]
+
+    assert len(row_list) == len(mapper.source_plane_mesh_grid)
+
+    for row in row_list:
+        assert np.isfinite(float(row[0]))
+        assert np.isfinite(float(row[1]))
+        assert np.isnan(float(row[3]))


### PR DESCRIPTION
## What

Completes the #405 family: the CSV-export function in `inversion_plots.py` (line 386) read `reconstruction_noise_map_dict[mapper]` unguarded, so a rank-deficient `curvature_reg_matrix` (routine under reduced-iteration test profiles) raised `numpy.linalg.LinAlgError` and killed the enclosing model-fit — same mechanism #405 fixed for the subplot panel.

## Behaviour choice (from consumer analysis)

Every consumer of `source_plane_reconstruction_{i}.csv` reads by column name (workspace `source_science.py`/`galaxy_reconstruction.py` scripts, PyAutoGalaxy's plotter test, PyAutoFit's aggregator `extract_csv` via astropy Table) — so omitting the column is a schema break that would surface as downstream `KeyError`s, and silence hides real information loss. Chosen: **keep the 4-column schema, write `nan` for `noise_map`, log a warning, still write the file** — NaN parses cleanly through every reader and preserves row alignment so y/x/reconstruction (the primary product) survive.

`except` is scoped to `np.linalg.LinAlgError` only; `KeyError`/`TypeError` intentionally not swallowed here (unlike the panel, this function has no best-effort semantics).

## Verification

- New regression test `test__save_reconstruction_csv__singular_curvature_reg_matrix` (monkeypatched singular covariance; asserts header schema, full rows, finite y/x, NaN noise_map). Proven non-vacuous: fails with the fix reverted.
- `pytest test_autoarray/inversion/plot` → 7 passed; full `test_autoarray/` → 895 passed.

Consumer-visible effect: workspace scripts printing `reconstruction_dict["noise_map"]` show NaNs under a singular matrix instead of crashing — the intended signal.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzN9PZfG5zXMVku8ckSqkC)_