### PR TITLE
fix(transformer): tell Python <3.12 users to upgrade, not to pip install nufftax

### DIFF
--- a/autoarray/operators/transformer.py
+++ b/autoarray/operators/transformer.py
@@ -1,5 +1,6 @@
 import copy
 import numpy as np
+import sys
 import warnings
 from typing import Optional, Tuple
 
@@ -41,6 +42,32 @@ def pynufft_exception():
 
 
 def nufftax_exception():
+    # On Python 3.11 `pip install nufftax` is actively bad advice. The releases
+    # that work with our JAX stack (0.4.x) require Python >= 3.12, so pip resolves
+    # 0.6.x instead — and 0.6.0/0.6.1 both break the interferometer inversion
+    # (0.6.0 uses `jax.interpreters.batching.not_mapped`, removed in JAX 0.10;
+    # 0.6.1 cannot handle the rank-4 input `transform_mapping_matrix` produces
+    # under vmap). There is currently no nufftax release that both installs on
+    # 3.11 and works, so send 3.11 users to 3.12+ or to the pynufft backend.
+    if sys.version_info < (3, 12):
+        raise ModuleNotFoundError(
+            "\n--------------------\n"
+            "You are attempting to perform interferometer analysis with the default "
+            f"JAX-native `TransformerNUFFT`, on Python {sys.version_info.major}.{sys.version_info.minor}.\n\n"
+            "The optional library nufftax (https://github.com/GragasLab/nufftax) is not installed, "
+            "and on this Python version it CANNOT be usefully installed:\n\n"
+            "  - nufftax releases that work with PyAutoArray require Python >= 3.12.\n"
+            "  - The releases that do install here (0.6.x) are incompatible with the "
+            "JAX version PyAutoArray requires, and fail partway through a fit.\n\n"
+            "Do NOT `pip install nufftax` on this Python version. Instead either:\n\n"
+            "  1. Upgrade to Python 3.12 or newer (recommended), then "
+            "`pip install 'autoarray[optional]'`; or\n"
+            "  2. Use the legacy pynufft backend, by passing "
+            "`transformer_class=TransformerNUFFTPyNUFFT` and running "
+            "`pip install pynufft==2022.2.2`.\n\n"
+            "----------------------"
+        )
+
     raise ModuleNotFoundError(
         "\n--------------------\n"
         "You are attempting to perform interferometer analysis with the default "

--- a/test_autoarray/operators/test_transformer.py
+++ b/test_autoarray/operators/test_transformer.py
@@ -306,3 +306,50 @@ def test__nufft__chunk_size__jax_jit_traces_with_scan():
     assert np.asarray(result) == pytest.approx(
         np.asarray(expected), rel=1.0e-6, abs=1.0e-10
     )
+
+
+def test__nufftax_exception__pre_3_12_tells_user_to_upgrade_not_to_pip_install():
+    """
+    On Python < 3.12 there is no usable nufftax release: the versions that work
+    require >= 3.12, and the ones that do install (0.6.x) break mid-fit. The
+    error must therefore steer the user away from `pip install nufftax`.
+    """
+    import collections
+    from unittest import mock
+    from autoarray.operators import transformer
+
+    version_info = collections.namedtuple(
+        "version_info", "major minor micro releaselevel serial"
+    )
+
+    with mock.patch.object(
+        transformer.sys, "version_info", version_info(3, 11, 0, "final", 0)
+    ):
+        with pytest.raises(ModuleNotFoundError) as exc:
+            transformer.nufftax_exception()
+
+    message = str(exc.value)
+    assert "Python 3.11" in message
+    assert "Do NOT `pip install nufftax`" in message
+    assert "Python 3.12 or newer" in message
+    assert "TransformerNUFFTPyNUFFT" in message
+
+
+def test__nufftax_exception__3_12_and_later_keeps_the_plain_install_instruction():
+    import collections
+    from unittest import mock
+    from autoarray.operators import transformer
+
+    version_info = collections.namedtuple(
+        "version_info", "major minor micro releaselevel serial"
+    )
+
+    with mock.patch.object(
+        transformer.sys, "version_info", version_info(3, 12, 0, "final", 0)
+    ):
+        with pytest.raises(ModuleNotFoundError) as exc:
+            transformer.nufftax_exception()
+
+    message = str(exc.value)
+    assert "Install it via the command `pip install nufftax`" in message
+    assert "Do NOT" not in message


### PR DESCRIPTION
## Problem

The `nufftax` missing-dependency error tells the user:

> Install it via the command `pip install nufftax`.

On **Python 3.11 that is actively bad advice** — following it makes things worse.

`nufftax>=0.4.0,<0.5.0` (what `autoarray[optional]` pins) declares `requires_python >= 3.12`, so it is never installed on 3.11. A user who runs `pip install nufftax` there gets **0.6.x**, and both 0.6.x releases break the interferometer inversion:

| Version | Installs on 3.11? | Works with our JAX 0.10 stack? |
|---|---|---|
| 0.4.0 (our pin) | ✗ requires 3.12 | ✓ |
| 0.6.0 | ✓ | ✗ `AttributeError: jax.interpreters.batching has no attribute 'not_mapped'` (removed in JAX 0.10) |
| 0.6.1 | ✓ | ✗ `ValueError: too many values to unpack (expected 3)` |

The 0.6.1 failure is upstream: `_aval_2d2` advertises `f.shape[:-2]` (any leading dims) but `transforms/nufft2.py` unpacks exactly `n_trans, n_modes2, n_modes1 = f.shape`, so anything rank > 3 dies. `transform_mapping_matrix` produces exactly that under vmap. Minimal repro:

```python
jax.vmap(lambda ff: nufftax.nufft2d2(x, y, ff, 1e-12, -1))(f4)   # f4.ndim == 4
```

So the old message converts a clean import-time failure into a **failure partway through a fit** — strictly worse. There is currently no nufftax release that both installs on 3.11 and works.

## Change

`nufftax_exception()` branches on `sys.version_info`:

- **< 3.12** — states that nufftax cannot be usefully installed here, says explicitly *not* to `pip install nufftax`, and offers the two real options: upgrade to 3.12+ (recommended), or use `TransformerNUFFTPyNUFFT` with `pynufft==2022.2.2`.
- **>= 3.12** — unchanged text.

Only the error string changes. No behaviour change on 3.12+.

## Verification

- both branches rendered and asserted by two new tests
- `test_autoarray/operators/test_transformer.py` — 15 passed
- full `test_autoarray/` — **904 passed**

## Not included

Bumping the pin to 0.6.x was tried and **reverted** — it is blocked by the upstream regression above. Worth noting for anyone who retries: forward output is *bit-identical* between 0.4.0 and 0.6.1 for plain 2-D/3-D calls, so a numerical-equivalence check passes and the signature is backward compatible. The break only appears under vmap, i.e. only when you run a real fit.

The CI side (Python 3.11 interferometer smoke scripts) is handled separately in PyAutoHands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EZTtyLUAyKWuATyk4mkcm