### PR TITLE
fix: make the imaging simulator's @jax.jit path work (5 xp / pytree sites)

### DIFF
--- a/autoarray/abstract_ndarray.py
+++ b/autoarray/abstract_ndarray.py
@@ -164,7 +164,20 @@ class AbstractNDArray(ABC):
 
     @property
     def _xp(self):
-        if self.use_jax:
+        """The array module matching the array this instance actually holds.
+
+        ``use_jax`` records how the instance was *constructed*, and not every
+        construction site threads ``xp`` — an intermediate operation can hand
+        back an instance whose flag says NumPy while its backing array is a JAX
+        tracer. Consumers of ``_xp`` (notably ``Array2D.native``, which is a
+        property and so cannot be passed ``xp`` by its caller) would then route a
+        traced array through the NumPy path and raise
+        ``TracerArrayConversionError`` inside a ``jax.jit`` trace.
+
+        So the backing array is authoritative: if it is a JAX type, this is
+        ``jnp`` regardless of the flag. On the NumPy path nothing changes.
+        """
+        if self.use_jax or type(self._array).__module__.startswith(("jax", "jaxlib")):
             import jax.numpy as jnp
 
             return jnp

--- a/autoarray/dataset/imaging/simulator.py
+++ b/autoarray/dataset/imaging/simulator.py
@@ -12,6 +12,57 @@ from autoarray.dataset import preprocess
 
 logger = logging.getLogger(__name__)
 
+_IMAGING_PYTREES_REGISTERED = False
+
+
+def _register_imaging_pytrees() -> None:
+    """Register ``Imaging`` so ``jax.jit(via_image_from)`` can flatten its return.
+
+    Counterpart of ``AnalysisImaging._register_fit_imaging_pytrees``, which does
+    the same job for ``FitImaging``. Without it a jitted simulator call raises
+    ``TypeError: ... returned a value of type Imaging, which is not a valid JAX
+    type``.
+
+    ``data`` and ``noise_map`` are the only per-simulation dynamic values, so
+    everything else rides as aux: ``psf`` and ``grids`` are constants for a given
+    simulation, the over-sample sizes are static integer geometry, and the
+    remaining slots are ``None``.
+
+    Unlike pytree registration for a jitted function's *arguments* — which must
+    happen before the first call, because JAX flattens arguments at trace time —
+    registering here is in time, because the return value is flattened only after
+    the body has run. Idempotent via the module-level flag.
+    """
+    global _IMAGING_PYTREES_REGISTERED
+    if _IMAGING_PYTREES_REGISTERED:
+        return
+
+    from autoarray.abstract_ndarray import register_instance_pytree
+
+    # ``Array2D.instance_flatten`` emits every ``__dict__`` entry not opted out,
+    # so a flattened ``data`` exposes its ``mask`` as a child. ``Mask2D`` must
+    # therefore be a pytree itself, or it surfaces as a bare leaf and JAX
+    # rejects the return value. Registering it here rather than adding ``mask``
+    # to ``Array2D.__no_flatten__`` keeps ``Array2D``'s flatten semantics
+    # unchanged for every other jitted path in the stack.
+    register_instance_pytree(Mask2D)
+
+    register_instance_pytree(
+        Imaging,
+        no_flatten=(
+            "psf",
+            "grids",
+            "over_sample_size_lp",
+            "over_sample_size_pixelization",
+            "convolve_over_sample_size_lp",
+            "convolve_over_sample_size_pixelization",
+            "noise_covariance_matrix",
+            "sparse_operator",
+        ),
+    )
+
+    _IMAGING_PYTREES_REGISTERED = True
+
 
 class SimulatorImaging:
     def __init__(
@@ -162,6 +213,9 @@ class SimulatorImaging:
         if xp is None:
             xp = self._xp
 
+        if xp is not np:
+            _register_imaging_pytrees()
+
         exposure_time_map = Array2D.full(
             fill_value=self.exposure_time,
             shape_native=image.shape_native,
@@ -201,7 +255,9 @@ class SimulatorImaging:
 
         if self.include_poisson_noise_in_noise_map:
             noise_map = preprocess.noise_map_via_data_eps_and_exposure_time_map_from(
-                data_eps=image_with_poisson_noise, exposure_time_map=exposure_time_map
+                data_eps=image_with_poisson_noise,
+                exposure_time_map=exposure_time_map,
+                xp=xp,
             )
 
         else:

--- a/autoarray/dataset/preprocess.py
+++ b/autoarray/dataset/preprocess.py
@@ -132,7 +132,9 @@ def array_with_random_uniform_values_added(array, upper_limit=0.001):
     return array + upper_limit * np.random.uniform(size=array.shape_slim)
 
 
-def noise_map_via_data_eps_and_exposure_time_map_from(data_eps, exposure_time_map):
+def noise_map_via_data_eps_and_exposure_time_map_from(
+    data_eps, exposure_time_map, xp=np
+):
     """
     Estimate the noise-map value in every data-point, by converting the data to units of counts and taking the
     square root of these values.
@@ -148,9 +150,13 @@ def noise_map_via_data_eps_and_exposure_time_map_from(data_eps, exposure_time_ma
         The data in electrons second used to estimate the Poisson noise in every data point.
     exposure_time_map
         The exposure time at every data-point of the data.
+    xp
+        The array module (``numpy`` or ``jax.numpy``). Must be ``jnp`` when
+        ``data_eps`` carries a traced array, otherwise ``np.abs`` raises
+        ``TracerArrayConversionError`` inside a ``jax.jit`` trace.
     """
     return data_eps.with_new_array(
-        np.abs(data_eps.array * exposure_time_map.array) ** 0.5
+        xp.abs(data_eps.array * exposure_time_map.array) ** 0.5
         / exposure_time_map.array
     )
 

--- a/autoarray/structures/arrays/array_2d_util.py
+++ b/autoarray/structures/arrays/array_2d_util.py
@@ -509,8 +509,15 @@ def array_2d_native_from(
 
     shape = (mask_2d.shape[0], mask_2d.shape[1])
 
+    # Deliberately NumPy, not ``xp``: this index map is derived from the mask,
+    # which is concrete geometry and never traced. Its computation is a
+    # ``where(~mask)``, whose output shape depends on the *values* of the mask, so
+    # under ``jnp`` inside a ``jax.jit`` trace it raises
+    # ``ConcretizationTypeError``. Computing it in NumPy yields a concrete index
+    # array, which is a valid static operand for the scatter below — that is
+    # where ``xp`` genuinely belongs.
     native_index_for_slim_index_2d = mask_2d_util.native_index_for_slim_index_2d_from(
-        mask_2d=mask_2d, xp=xp
+        mask_2d=mask_2d
     ).astype("int")
 
     return array_2d_via_indexes_from(

--- a/autoarray/structures/arrays/uniform_2d.py
+++ b/autoarray/structures/arrays/uniform_2d.py
@@ -291,9 +291,18 @@ class AbstractArray2D(Structure):
 
         If it is already stored in its `native` representation it is return as it is. If not, it is mapped from
         `slim` to `native` and returned as a new `Array2D`.
+
+        ``xp`` is forwarded from ``self._xp`` rather than left at its ``numpy``
+        default. A property cannot take an argument, so without this a JAX-backed
+        array would be re-mapped slim -> native through the NumPy path and raise
+        ``TracerArrayConversionError`` inside a ``jax.jit`` trace.
         """
         return Array2D(
-            values=self, mask=self.mask, header=self.header, store_native=True
+            values=self,
+            mask=self.mask,
+            header=self.header,
+            store_native=True,
+            xp=self._xp,
         )
 
     @property


### PR DESCRIPTION
## Summary

The `@jax.jit` simulator recipe documented in both workspaces did not run. The
docs half is already corrected (PyAutoLabs/autolens_workspace#379 — registration
is the caller's responsibility and cannot be automated, since JAX flattens jitted
arguments at trace time). **This is the library half:** even *with* correct pytree
registration, the jitted call failed inside autoarray.

Five distinct sites, each a different kind of problem, found by iterating the
reproducer rather than by reading:

| # | Site | Cause |
|---|---|---|
| 1 | `dataset/preprocess.py:135` | `noise_map_via_data_eps_and_exposure_time_map_from` took **no `xp` parameter at all** and hardcoded `np.abs`, so its caller could not pass one. `include_poisson_noise_in_noise_map` defaults `True`, so the default path always hit it |
| 2 | `abstract_ndarray._xp` | `use_jax` records how an instance was *constructed*, and not every construction site threads `xp` — an intermediate op returned an instance whose flag said NumPy while its backing array was a **JAX tracer** (confirmed by instrumentation). So `_xp` returned `np` for a traced array |
| 3 | `structures/arrays/uniform_2d.py` `Array2D.native` | a property, so its caller cannot pass `xp`; now forwards `self._xp`, which site 2 made truthful |
| 4 | `structures/arrays/array_2d_util.py:512` | the **opposite** error — `xp` threaded *too far*, into `native_index_for_slim_index_2d_from`, whose `where(~mask)` has a value-dependent output shape → `ConcretizationTypeError` under `jnp` |
| 5 | `dataset/imaging/simulator.py` | `Imaging` was not a registered pytree, so it could not cross the jit **return** boundary |

### Two points worth a reviewer's attention

**Site 4 inverts the usual advice.** The fix was to thread `xp` *less*, not more.
The index map is derived from the mask — concrete geometry, never traced — so
computing it in NumPy yields a concrete index array, which is a valid static
operand for the scatter. `xp` genuinely belongs only in the scatter.

**Site 5 relies on a trace-time asymmetry.** Registration inside the callee is too
late for a jitted function's *arguments* (JAX flattens those at trace time — this
is why `PointSolver` documents registration as the user's job) but is in time for
its *return value*, which is flattened only after the body runs. That is the same
asymmetry that lets `AnalysisImaging.fit_from` register its own return types, and
`_register_imaging_pytrees` mirrors it directly.

Site 5 also registers `Mask2D`, because `Array2D.instance_flatten` emits `mask` as
a child and it would otherwise surface as a bare leaf (`TypeError: ... returned a
value of type Mask2D`). I chose that over adding `mask` to
`Array2D.__no_flatten__` so `Array2D`'s flatten semantics stay unchanged for every
other jitted path in the stack.

## Verified, not just "it runs"

- noiseless **NumPy-eager vs JAX-jitted** agree to `2.4e-13`
- **JAX-eager vs JAX-jitted** (fixed `noise_seed`) agree to `1.8e-15`
- the returned `Imaging` keeps its `psf` and `mask` and survives `np.asarray` — not a broken pytree husk
- **NumPy path byte-identical**, still `ndarray`-backed (no regression for non-JAX users)
- works for autogalaxy's `via_galaxies_from` too, via the shared autoarray fix
- `test_autoarray` **929 passed** · `test_autogalaxy` **1009 passed** · `test_autolens` **488 passed**

Sites 2 and 5 have stack-wide reach — `_xp` is consumed by every autoarray
structure and registering `Mask2D` changes flattening for any jitted path — which
is why all three suites were run rather than just autoarray's.

## Deliberately out of scope

**The interferometer is not fixed.** Measured on this branch: `TransformerDFT`
fails at the jit boundary (`Interferometer` needs its own pytree registration, the
analogue of site 5) and `TransformerNUFFT` fails at
`operators/transformer.py:660`, whose non-chunked branch ends
`np.array(np.asarray(out))`. That transformer already has a jittable `lax.scan`
branch, so it has partial JAX support and needs restructuring with its own
correctness surface (complex visibilities, two chunking branches). Filed as a
follow-up rather than grown into this PR.

Unit tests are NumPy-only by policy across the stack, so the JAX behaviour here is
covered by the parity checks above rather than by `test_autoarray/`.

## Docs follow-up (after this merges)

The imaging `__JAX Variant__` sections and both `guides/using_jax.py` currently say
the jitted wrap "does not currently work" and link here. Once this lands, restore
the recipe **and uncomment the call** so CI executes it — the governing lesson from
#368/#379 is that a documented JAX recipe no script executes will be wrong.

Generated by the PyAutoLabs agent workflow.
