### PR TITLE
fix: make the interferometer simulator's @jax.jit path work

### DIFF
--- a/autoarray/dataset/interferometer/simulator.py
+++ b/autoarray/dataset/interferometer/simulator.py
@@ -7,6 +7,58 @@ from autoarray.structures.visibilities import VisibilitiesNoiseMap
 from autoarray import exc
 from autoarray.dataset import preprocess
 
+_INTERFEROMETER_PYTREES_REGISTERED = False
+
+
+def _register_interferometer_pytrees() -> None:
+    """Register ``Interferometer`` so ``jax.jit(via_image_from)`` can flatten its return.
+
+    Counterpart of ``_register_imaging_pytrees`` in the imaging simulator (and of
+    ``AnalysisImaging._register_fit_imaging_pytrees``). Without it a jitted
+    interferometer call raises ``TypeError: ... returned a value of type
+    Interferometer, which is not a valid JAX type``.
+
+    ``data`` and ``noise_map`` are the only per-simulation dynamic values.
+    Everything else rides as aux: ``uv_wavelengths`` and ``real_space_mask`` are
+    the fixed observation geometry, ``transformer`` and ``grids`` are constants for
+    a given simulation, the over-sample sizes are static integer geometry, and the
+    remaining slots are ``None``.
+
+    Unlike registration for a jitted function's *arguments* — which must happen
+    before the first call, since JAX flattens arguments at trace time — this is in
+    time, because the return value is flattened only after the body has run.
+    Idempotent via the module-level flag.
+    """
+    global _INTERFEROMETER_PYTREES_REGISTERED
+    if _INTERFEROMETER_PYTREES_REGISTERED:
+        return
+
+    from autoarray.abstract_ndarray import register_instance_pytree
+    from autoarray.structures.visibilities import Visibilities
+
+    # The two dynamic children must themselves be pytrees, or they surface as
+    # bare leaves and JAX rejects the return value ("... returned a value of type
+    # Visibilities ... at output component [0]"). Unlike ``Array2D`` — which the
+    # imaging path gets auto-registered — these are not registered anywhere else.
+    register_instance_pytree(Visibilities)
+    register_instance_pytree(VisibilitiesNoiseMap)
+
+    register_instance_pytree(
+        Interferometer,
+        no_flatten=(
+            "uv_wavelengths",
+            "real_space_mask",
+            "transformer",
+            "grids",
+            "over_sample_size_lp",
+            "over_sample_size_pixelization",
+            "noise_covariance_matrix",
+            "sparse_operator",
+        ),
+    )
+
+    _INTERFEROMETER_PYTREES_REGISTERED = True
+
 
 class SimulatorInterferometer:
     def __init__(
@@ -115,11 +167,14 @@ class SimulatorInterferometer:
         if xp is None:
             xp = self._xp
 
+        if xp is not np:
+            _register_interferometer_pytrees()
+
         transformer = self.transformer_class(
             uv_wavelengths=self.uv_wavelengths, real_space_mask=image.mask
         )
 
-        visibilities = transformer.visibilities_from(image=image)
+        visibilities = transformer.visibilities_from(image=image, xp=xp)
 
         if self.noise_sigma is not None:
             visibilities = preprocess.data_with_complex_gaussian_noise_added(


### PR DESCRIPTION
## Summary

Follow-up to #420/#421, which fixed the **imaging** simulator's `@jax.jit` path and
deliberately excluded the interferometer. Two causes — and one of them was not what
#422 predicted.

**The whole change is one file, +56/-1.** `operators/transformer.py` is
deliberately untouched.

### 1. `Interferometer` was not a registered pytree

The analogue of #421's site 5: it could not cross the jit **return** boundary.
Added `_register_interferometer_pytrees`, mirroring `_register_imaging_pytrees` —
`data` and `noise_map` dynamic; `uv_wavelengths`, `real_space_mask`,
`transformer`, `grids`, the over-sample sizes and the `None`s as aux. The split was
taken from `vars(dataset)`, not the `__init__` signature, which is what got the
`Imaging` split right in #421.

It must also register `Visibilities` and `VisibilitiesNoiseMap`. On the imaging
path `Array2D` is already registered elsewhere; nothing registers these, so they
surfaced as bare leaves:
`returned a value of type Visibilities ... at output component [0]`.

### 2. A caller that never threaded `xp` — one line

`via_image_from` called `transformer.visibilities_from(image=image)` with no
`xp=xp`.

**#422 got this wrong, and it is worth correcting explicitly.** That issue said
`TransformerNUFFT._forward_native` "hard-converts to NumPy" and needs
"restructuring with its own correctness surface". It does not.
`_forward_native` already has a complete, jittable JAX branch (`lax.scan` +
`dynamic_slice`). The failure reported at `transformer.py:660` was in the
**NumPy** branch — the traceback pointed at the symptom while the cause sat one
frame up, in a caller that never passed `xp`. Exactly the root shape as site 1 of
#421.

Had I edited the transformer as the issue proposed, I would have restructured
working code to fix a bug that was somewhere else.

`TransformerDFT` had been passing by luck: its arithmetic flows through tracers, so
the missing `xp` never showed. Only NUFFT, which calls into `_nufftax` and then
converts, exposed it.

## Verified

- **DFT and NUFFT**, numpy-eager vs jax-jit, agree to **~1e-11** on real *and* imaginary parts (complex visibilities, so both are checked)
- **Both NUFFT chunk branches** under jit match NumPy to **~5e-13** — single-shot and the `lax.scan` path. `chunk_size` is a `TransformerNUFFT.__init__` arg the simulator never sets, so that branch is unreachable via the simulator and was exercised on the transformer directly rather than skipped
- the returned `Interferometer` keeps `uv_wavelengths`, `real_space_mask` and its noise map — not a broken pytree husk
- NumPy path still `ndarray`-backed
- `test_autoarray` **929** · `test_autogalaxy` **1009** · `test_autolens` **488** — all identical to pre-change counts

Unit tests are NumPy-only by policy across the stack, so the JAX behaviour is
covered by the parity checks above rather than by `test_autoarray/`.

## Out of scope

`TransformerNUFFTPyNUFFT` — the legacy pynufft backend is not JAX-traceable and is
not expected to be.

## Docs follow-up (after this merges)

The interferometer `__JAX Variant__` sections in both workspaces still say the
jitted wrap "does not currently work" (autolens_workspace#379), and the
`TransformerNUFFT` "supports `jax.jit`" claim in
`autolens_workspace/scripts/interferometer/simulator.py` is currently unqualified.
Once this lands, do for interferometer what autolens_workspace#381 did for
imaging: restore the recipe, uncomment the call, and add the script to
`smoke_tests.txt` so CI executes it.

Generated by the PyAutoLabs agent workflow.
