### PR TITLE
fix(test): degenerate-band sanity check asserts on BLAS rounding, not the library

### DIFF
--- a/test_autoarray/util/test_cholesky_degenerate.py
+++ b/test_autoarray/util/test_cholesky_degenerate.py
@@ -107,10 +107,15 @@ def test__fnnls_cholesky__never_returns_a_non_finite_solution(jitter):
     # The producer regression: across the whole near-degenerate band, the
     # solver must either return a finite solution or raise -- never hand back
     # NaN as though it were a valid reconstruction.
-    raised = 0
+    solved = 0
 
     for seed in range(40):
         ZTZ, ZTx = _normal_equations(n=12, n_data=40, jitter=jitter, seed=seed)
+
+        # The band really is degenerate. This is a property of the fixture, so it
+        # holds on every machine -- unlike *how the solver responds* to it, which
+        # is decided by floating-point summation order (see the module comment).
+        assert np.linalg.cond(ZTZ) > 1.0e12
 
         try:
             P_initial = np.linalg.solve(ZTZ, ZTx) > 0
@@ -120,14 +125,24 @@ def test__fnnls_cholesky__never_returns_a_non_finite_solution(jitter):
         try:
             reconstruction = fnnls_cholesky(ZTZ, ZTx.T, P_initial=P_initial)
         except np.linalg.LinAlgError:
-            raised += 1
             continue
+
+        solved += 1
 
         assert np.all(np.isfinite(reconstruction))
 
-    # Sanity: the degenerate band must actually be exercising the guard,
-    # otherwise the assertion above is passing vacuously.
-    assert raised > 0
+    # Sanity: at least one seed must have reached the finiteness assertion above,
+    # otherwise this test passes vacuously.
+    #
+    # NOT `raised > 0`. The invariant here is the same one
+    # `test__cholinsertlast__singular_insertion_never_yields_an_unusable_pivot`
+    # states: either raise, or return something finite. Raising is one *allowed*
+    # outcome, not a required one, so requiring it of some seed asserts on which
+    # side of zero the runner's BLAS happens to round the Schur complement. At
+    # `jitter=0.0` exactly one of these 40 seeds raises on a single-threaded local
+    # BLAS and none do on the CI runners, so `raised > 0` was a coin flip that
+    # failed CI on a green library.
+    assert solved > 0
 
 
 def test__fnnls_cholesky__well_conditioned_problem_is_unaffected():


### PR DESCRIPTION
`main` is red. `test__fnnls_cholesky__never_returns_a_non_finite_solution[0.0]` has been failing on the CI runners since at least `efaf3041` ([run 31219374045](https://github.com/PyAutoLabs/PyAutoArray/actions/runs/31219374045), 2026-08-07) while passing locally.

Nothing is wrong with the library. The failing line is the test's own vacuity guard:

```python
assert raised > 0
```

## Why that assertion cannot hold reliably

It requires `fnnls_cholesky` to raise `LinAlgError` for at least one of 40 seeds. But raising is an **allowed** outcome here, not a required one — and this file already says so, in `test__cholinsertlast__singular_insertion_never_yields_an_unusable_pivot`:

> The invariant is therefore NOT "always raise" (a small positive pivot is still a usable pivot, and rejecting it would change likelihood evaluations). It is: either raise, or return a strictly positive finite pivot.

The module comment goes further and identifies the exact mechanism:

> the Cholesky insertion's Schur complement is then zero up to rounding, and which side of zero it lands on depends only on floating-point summation order — i.e. on the BLAS thread count, which is why the original failure was reproducible on CI but not locally.

So `raised > 0` asserts on how the runner's BLAS rounds, not on library behaviour.

## Measurements

Across the 40 seeds, on a single-threaded local BLAS:

| jitter | raised | solved |
|---|---|---|
| 0.0 | **1** | 39 |
| 1e-15 | 16 | 24 |
| 1e-12 | 20 | 20 |
| 1e-9 | 14 | 26 |

`[0.0]` passes locally by a **single seed out of 40**, and zero seeds raise on the CI runners. That is precisely the one parametrisation CI fails — the other three have comfortable margins.

## The fix

The regression this test exists for — never hand back NaN as though it were a valid reconstruction — is untouched. Only the vacuity guard changes.

- **`solved > 0`** replaces `raised > 0`: at least one seed must actually have reached the finiteness assertion. That is what "not vacuous" means here, and it does not depend on rounding.
- **"The band really is degenerate" is pinned on the fixture instead**, via `cond(ZTZ) > 1e12`. Measured range is 1.07e16 – 3.71e18 across every seed and jitter value, so the margin is wide and the property is deterministic on any machine.

## Verification

Both directions checked by simulation, not just by the suite going green:

- With **no seed raising** (the CI condition): all four parametrisations pass.
- With **every seed raising** (genuine vacuity — the finiteness assertion never runs): the test still fails, so the guard keeps doing its job.

Full suite: **906 passed, 52 skipped**. The 3 `test_transformer.py` failures are pre-existing and unrelated (missing optional `pynufft`).

Opened so #437 can merge onto a green base.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KazMzMZYPLfaZoYQ79YQ8Q)_