### PR TITLE
fix: repair ConstantZeroth dead code (eye(P) shape bug + missing neighbors_sizes)

### DIFF
--- a/autoarray/inversion/regularization/constant_zeroth.py
+++ b/autoarray/inversion/regularization/constant_zeroth.py
@@ -68,7 +68,7 @@ def constant_zeroth_regularization_matrix_from(
 
     reg_coeff = coefficient_zeroth**2.0
     # Identity matrix scaled by reg_coeff does exactly ∑_i reg_coeff * e_i e_i^T
-    zeroth = xp.eye(P) * reg_coeff
+    zeroth = xp.eye(S) * reg_coeff
 
     return const + zeroth
 
@@ -122,5 +122,6 @@ class ConstantZeroth(AbstractRegularization):
             coefficient=self.coefficient_neighbor,
             coefficient_zeroth=self.coefficient_zeroth,
             neighbors=linear_obj.neighbors,
+            neighbors_sizes=linear_obj.neighbors.sizes,
             xp=xp,
         )

--- a/test_autoarray/inversion/regularizations/test_constant_zeroth.py
+++ b/test_autoarray/inversion/regularizations/test_constant_zeroth.py
@@ -1,0 +1,97 @@
+import autoarray as aa
+import numpy as np
+import pytest
+
+from autoarray.inversion.regularization.constant_zeroth import (
+    constant_zeroth_regularization_matrix_from,
+)
+
+
+def test__regularization_matrix_from__shape_is_pixels_by_pixels():
+    # 3-pixel chain (0-1, 0-2) with P=2 neighbor columns, so S != P and the
+    # zeroth term must be built from S, not the neighbor count.
+    neighbors = np.array([[1, 2], [0, -1], [0, -1]])
+    neighbors_sizes = np.array([2, 1, 1])
+
+    regularization_matrix = constant_zeroth_regularization_matrix_from(
+        coefficient=1.0,
+        coefficient_zeroth=2.0,
+        neighbors=neighbors,
+        neighbors_sizes=neighbors_sizes,
+    )
+
+    assert regularization_matrix.shape == (3, 3)
+
+
+def test__regularization_matrix_from__no_null_mode__smallest_eigenvalue_at_least_coefficient_zeroth_squared():
+    neighbors = np.array(
+        [[1, 3, -1, -1], [0, 2, -1, -1], [1, 3, -1, -1], [0, 2, -1, -1]]
+    )
+    neighbors_sizes = np.array([2, 2, 2, 2])
+
+    coefficient_zeroth = 2.0
+
+    regularization_matrix = constant_zeroth_regularization_matrix_from(
+        coefficient=1.0,
+        coefficient_zeroth=coefficient_zeroth,
+        neighbors=neighbors,
+        neighbors_sizes=neighbors_sizes,
+    )
+
+    eigenvalues = np.linalg.eigvalsh(regularization_matrix)
+
+    assert np.min(eigenvalues) >= coefficient_zeroth**2.0
+
+
+def test__regularization_matrix_from__reduces_to_constant_matrix_plus_scaled_identity():
+    neighbors = np.array(
+        [[1, 3, -1, -1], [0, 2, -1, -1], [1, 3, -1, -1], [0, 2, -1, -1]]
+    )
+    neighbors_sizes = np.array([2, 2, 2, 2])
+
+    coefficient = 3.0
+    coefficient_zeroth = 2.0
+
+    constant_matrix = aa.util.regularization.constant_regularization_matrix_from(
+        coefficient=coefficient,
+        neighbors=neighbors,
+        neighbors_sizes=neighbors_sizes,
+    )
+
+    constant_zeroth_matrix = constant_zeroth_regularization_matrix_from(
+        coefficient=coefficient,
+        coefficient_zeroth=coefficient_zeroth,
+        neighbors=neighbors,
+        neighbors_sizes=neighbors_sizes,
+    )
+
+    assert constant_zeroth_matrix == pytest.approx(
+        constant_matrix + coefficient_zeroth**2.0 * np.identity(4), 1.0e-8
+    )
+
+
+def test__regularization_matrix_from__class_api_returns_without_raising():
+    reg = aa.reg.ConstantZeroth(coefficient_neighbor=2.0, coefficient_zeroth=3.0)
+
+    source_plane_mesh_grid = aa.Grid2D.no_mask(
+        values=[[0.1, 0.1], [1.1, 0.6], [2.1, 0.1], [0.4, 1.1], [1.1, 7.1], [2.1, 1.1]],
+        shape_native=(3, 2),
+        pixel_scales=1.0,
+    )
+
+    mesh_geometry = aa.MeshGeometryRectangular(
+        mesh=aa.mesh.RectangularUniform(shape=(3, 3)),
+        mesh_grid=source_plane_mesh_grid,
+        data_grid=None,
+    )
+
+    mapper = aa.m.MockMapper(
+        source_plane_mesh_grid=source_plane_mesh_grid, mesh_geometry=mesh_geometry
+    )
+
+    regularization_matrix = reg.regularization_matrix_from(linear_obj=mapper)
+
+    assert regularization_matrix.shape == (9, 9)
+    # Constant leg diagonal (8.0000001 for coefficient 2, see test_constant.py)
+    # plus the zeroth term coefficient_zeroth**2 = 9.
+    assert regularization_matrix[0, 0] == pytest.approx(17.0000001, 1.0e-4)


### PR DESCRIPTION
Closes #448. Phase 8C of the inference-methods programme (autolens_profiling#134, `results/notes/inference/PROGRAMME.md` on its PR #135).

## What was broken

`al.reg.ConstantZeroth` was dead code presenting as a feature — two independent defects, both reproduced on clean `main` (`7d1906e`) before any fix (tracebacks pasted on #448):

1. **`eye(P)` shape bug** — `constant_zeroth_regularization_matrix_from` built the zeroth-order term as `xp.eye(P)` where `P = neighbors.shape[1]` is the neighbor-column count (e.g. 4), not `S` the mesh pixel count, so `const + zeroth` raised `ValueError: operands could not be broadcast together with shapes (9,9) (4,4)` whenever `S != P`.
2. **Missing `neighbors_sizes` at the class API** — `ConstantZeroth.regularization_matrix_from` omitted the required argument, raising `TypeError` before the shape bug was even reached.

## The fix

- Zeroth term is now the full `S x S` scaled identity (`xp.eye(S) * coefficient_zeroth**2`), matching `zeroth.py`'s semantics (`eye(pixels)`).
- The class API threads `neighbors_sizes=linear_obj.neighbors.sizes`, mirroring `Constant.regularization_matrix_from`.
- **Sibling check:** `adapt_split_zeroth.py` and `brightness_zeroth.py` do *not* carry the copy-paste pattern — their zeroth terms are `xp.diag` over per-pixel weights; no change made there.
- **Untouched by design:** `Constant`/`Adapt`/`AdaptSplit` numerics, `autoarray/__init__.py` (version-stamp branch owns it). Nothing else bundled.

## Null-mode-lift verification (spectrum before/after)

On the 9-pixel rectangular MockMapper fixture with `lambda_neighbor = lambda_zeroth = 1.0`, through the class API:

| Scheme | min eigenvalue | max eigenvalue | condition number |
|---|---|---|---|
| `Constant` | 1.000e-08 (the jitter floor — graph-Laplacian null mode) | 6.000e+00 | 6.0e+08 |
| `ConstantZeroth` (fixed) | **1.000e+00 = lambda_z^2** | 7.000e+00 | 7.0e+00 |

The zeroth-order term lifts the null mode exactly as intended: `max |(CZ − C) − lambda_z^2·I| = 0.0` element-wise, and the smallest eigenvalue rises from the 1e-8 conditioning floor to `lambda_z^2`. **This fix makes the scheme WORK — it does not recommend it over AdaptSplit** (ConstantZeroth is an alternative regularization model; target-changing relative to AdaptSplit).

## Tests

New `test_autoarray/inversion/regularizations/test_constant_zeroth.py` (numpy-only per repo policy):

- matrix shape `(S, S)` on a fixture with `S != P` (the shape that previously raised),
- no null mode: `min(eigvalsh) >= lambda_z^2`,
- reduction to `Constant`'s matrix `+ lambda_z^2 * I` where the schemes overlap,
- class-API path returns without raising (diagonal = Constant's `8.0000001` + `lambda_z^2 = 9`).

Full suite: `pytest test_autoarray/` → **988 passed, 59 skipped, 3 failed** — the 3 failures are `test_transformer.py::test__nufft_pynufft__*` (`scipy.linalg.pinv2` removed in modern scipy, inside pynufft), identical on clean `main` in this environment and unrelated to this change.

Merge stays with @Jammy2211.

---
_Generated by [Claude Code](https://claude.ai/code/session_013frRFAHyKN1EpE8sQHTogB)_