### PR TITLE
fix: bounds-guard the kernel gather in psf_weighted_data_from

### DIFF
--- a/autoarray/inversion/inversion/imaging_numba/inversion_imaging_numba_util.py
+++ b/autoarray/inversion/inversion/imaging_numba/inversion_imaging_numba_util.py
@@ -61,9 +61,28 @@ def psf_weighted_data_from(
 
         for k0_y in range(kernel_native.shape[0]):
             for k0_x in range(kernel_native.shape[1]):
-                weight_value = weight_map_native[
-                    ip0_y + k0_y + kernel_shift_y, ip0_x + k0_x + kernel_shift_x
-                ]
+                iy = ip0_y + k0_y + kernel_shift_y
+                ix = ip0_x + k0_x + kernel_shift_x
+
+                # numba @jit() does not bounds-check array reads. Without this
+                # guard, a kernel position that lands off the weight-map array
+                # (e.g. a mask pixel within `kernel_shift` of the array edge)
+                # silently reads uninitialized memory, producing astronomical
+                # or non-finite contributions that poison `psf_weighted_data`
+                # and the data vector computed from it. A negative index is
+                # just as unsafe: it wraps to the opposite edge and quietly
+                # convolves in unrelated pixels. Positions off the array
+                # contribute zero, matching the zero-padded reference in
+                # `inversion_imaging_util.psf_weighted_data_from`.
+                if (
+                    iy < 0
+                    or iy >= weight_map_native.shape[0]
+                    or ix < 0
+                    or ix >= weight_map_native.shape[1]
+                ):
+                    continue
+
+                weight_value = weight_map_native[iy, ix]
 
                 if not np.isnan(weight_value):
                     value += kernel_native[k0_y, k0_x] * weight_value

--- a/test_autoarray/inversion/inversion/imaging/test_inversion_imaging_util.py
+++ b/test_autoarray/inversion/inversion/imaging/test_inversion_imaging_util.py
@@ -36,6 +36,51 @@ def test__psf_weighted_noise_imaging_from():
     )
 
 
+def test__psf_weighted_data_from__unmasked_pixels_on_array_edge():
+    """
+    Regression test: an unmasked pixel within `kernel_shape // 2` of the array
+    edge drives the kernel off the weight map.
+
+    numba `@jit()` does not bounds-check array reads, so those positions
+    silently returned uninitialized memory (values of order 1e299) rather than
+    raising, poisoning `psf_weighted_data` and the data vector built from it.
+    Because the values read depend on whatever the allocator left next to the
+    weight map, the corruption was heap-state dependent: deterministic on the
+    first call after a cold-cache compile, and intermittent in forked
+    multiprocessing workers.
+
+    The zero-padded numpy implementation is the reference — kernel positions
+    off the array contribute zero. Every other test in this module masks a
+    one-pixel border, so none of them exercise this path.
+    """
+
+    image = np.arange(1.0, 26.0).reshape(5, 5)
+    noise_map = np.ones((5, 5))
+
+    kernel = np.array([[0.0, 1.0, 2.0], [3.0, 4.0, 1.0], [2.0, 0.0, 1.0]])
+
+    # Every pixel unmasked, so the border pixels push the kernel off the array.
+    native_index_for_slim_index = np.array(
+        [[y, x] for y in range(5) for x in range(5)]
+    )
+
+    psf_weighted_data = aa.util.inversion_imaging_numba.psf_weighted_data_from(
+        image_native=image,
+        noise_map_native=noise_map,
+        kernel_native=kernel,
+        native_index_for_slim_index=native_index_for_slim_index,
+    )
+
+    psf_weighted_data_numpy = aa.util.inversion_imaging.psf_weighted_data_from(
+        weight_map_native=image / noise_map**2.0,
+        kernel_native=kernel,
+        native_index_for_slim_index=native_index_for_slim_index,
+    )
+
+    assert np.all(np.isfinite(psf_weighted_data))
+    assert psf_weighted_data == pytest.approx(psf_weighted_data_numpy, 1.0e-8)
+
+
 def test__psf_weighted_data_from():
 
     mask = aa.Mask2D(


### PR DESCRIPTION
Fixes the numba sparse-operator likelihood returning garbage / NaN (PyAutoMind `draft/bug/autoarray/numba_first_call_garbage_psf_weighted_data.md`).

## Root cause — not a numba caching bug

The prompt's leading suspect was numba codegen/caching (first-call-after-compile executing wrong code). It isn't.

`psf_weighted_data_from` gathers the weight map at `[ip0_y + k0_y + kernel_shift_y, ...]` with **no bounds check**. numba `@jit()` does not bounds-check array reads, so for any unmasked pixel within `kernel_shape // 2` of the array edge the gather reads uninitialized heap memory instead of raising `IndexError`.

Proof: compiling the **shipped source unchanged** under `boundscheck=True` raises `IndexError: index is out of bounds` for a mask reaching the array edge, and is clean for an interior-only mask.

This is also why the inputs were verified identical between call 1 and call 2 — they were. The function reads memory *outside* its inputs. Both reported symptoms follow:

- **Cold-cache first call** runs right after numba's compilation churned the heap, so the memory next to the freshly allocated weight map holds compiler garbage (~1e299). Warm cache: no compile, benign neighbour.
- **Forked workers** each have a different heap layout, so whether the neighbouring memory is poisonous varies per worker and per run (2/8 corrupted in one map, 0/24 in the next).

The sibling `psf_precision_value_from` was already hardened against exactly this, with a comment describing the failure mode almost verbatim; `psf_weighted_data_from` was missed. It was the only unguarded native-array read left in the module.

## The fix

The same guard as the sibling: kernel positions off the array contribute zero, matching the zero-padded numpy reference in `inversion_imaging_util.psf_weighted_data_from`.

## Numerics impact

The guard only ever changes what an **off-array** position contributes, so behaviour splits into four cases:

| Case | Old | New | Changed? |
|---|---|---|---|
| Read in bounds | correct | correct | **no — bit-identical** |
| Negative index wrapping onto a *masked* pixel | NaN, skipped → 0 | 0 | **no** |
| Negative index wrapping onto an *unmasked* pixel | adds an unrelated pixel | 0 | yes — old was wrong |
| Index past the array end | reads uninitialized memory (UB) | 0 | yes — old was undefined |

Only the two broken cases change. Verified old-vs-new by extracting both versions of the function and compiling each:

- **Interior masks (the production case): bit-identical.** 8 array/kernel geometries (7x7 up to 31x31, kernels 3x3–9x9), 3 random trials each, compared with `np.array_equal` and raw-byte equality — not `approx`. Zero difference.
- **Edge-touching masks:** old disagrees with the zero-padded numpy reference on 19–342 pixels per case; new matches it exactly (`rtol=1e-9`).
- **Change is confined to border pixels:** with an edge-touching mask, interior pixels are still bit-identical; only pixels within `kernel//2` of the edge move.

End-to-end at the inversion level (`Inversion` over the standard 7x7 fixture, pre-fix vs post-fix), every quantity is bit-identical by SHA over raw bytes — `psf_weighted_data`, `data_vector`, `curvature_matrix`, `reconstruction`, `mapped_reconstructed_operated_data`, `log_det_curvature_reg_matrix_term`, `regularization_term`. The sparse-operator inversion also still agrees with the independent mapping-matrix formalism to 6.7e-16 (that formalism never touches this code path).

Edge-touching masks are constructible — nothing upstream forbids them — and with the fix such an inversion agrees with the mapping-matrix formalism to 2.2e-16.

## Tests

Regression test compares the numba and numpy implementations on a mask whose unmasked pixels reach the array edge. It fails without the fix (13/25 border pixels wrong) and passes with it. Every existing test in that module masks a one-pixel border, which is why this survived.

Full `test_autoarray`: **1034 passed**. The 3 `test_transformer.py` pynufft failures are pre-existing — identical on a clean tree, from the optional `pynufft` dep not being installed.

One caveat on test design: the out-of-bounds read is undefined behaviour, so the *garbage* cannot be reproduced deterministically at unit scale — on small in-process arrays the neighbouring heap is usually benign. The test therefore asserts the correctness property (agreement with the zero-padded reference), which is deterministic, rather than trying to catch a specific garbage value.

## Not verified here

The `parallel_scaling/pixelization_numba.py` corruption counters named as the acceptance probe need the profiling workspace and its datasets, which aren't available in this environment. The case that this fix covers the forked-worker symptom is mechanistic, not measured — worth re-running that probe against this branch before closing the prompt.

## Found alongside, filed separately

Both numba gathers derive their kernel shifts from the **transposed** kernel axes (`kernel_shift_y` from `shape[1]`). Harmless for square kernels; kernels are validated as *odd*, not square, so a 3x5 PSF mis-centres the gather. Filed as PyAutoMind `draft/bug/autoarray/numba_kernel_shift_axes_swapped.md` rather than fixed here — `psf_precision_value_from` has the identical swap, and correcting one without the other would make the two paths disagree about kernel orientation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013unzp382r79c4BN8g4ckb2

---
_Generated by [Claude Code](https://claude.ai/code/session_013unzp382r79c4BN8g4ckb2)_