### PR TITLE
fix: coerce fnnls_cholesky inputs to numpy — JAX ZTx broke the numba buffer kernels

### DIFF
--- a/autoarray/util/fnnls.py
+++ b/autoarray/util/fnnls.py
@@ -32,6 +32,20 @@ def fnnls_cholesky(
     """
     from scipy import linalg as slg
 
+    # The buffer kernels below (_cho_solve_buffer / cholinsertlast_inplace)
+    # overwrite their vector argument in place, so every slice handed to them
+    # must be a writeable numpy array. A JAX ZTZ / ZTx — the sparse-operator
+    # inversion path hands one over even when the fit itself runs the numba
+    # CPU path — breaks that contract: indexing a JAX array yields another
+    # JAX array, which numba maps to a *readonly* buffer and rejects at
+    # compile time ("Cannot modify readonly array"). Coerce once at the
+    # boundary — fancy indexing a numpy parent then hands the kernels fresh
+    # writeable arrays, exactly as the scipy solvers this replaced tolerated
+    # by copying internally.
+    ZTZ = np.asarray(ZTZ)
+    ZTx = np.asarray(ZTx)
+    P_initial = np.asarray(P_initial)
+
     lstsq = lambda A, x: slg.solve(
         A,
         x,

--- a/test_autoarray/util/test_cholesky_inplace.py
+++ b/test_autoarray/util/test_cholesky_inplace.py
@@ -167,3 +167,29 @@ def test__fnnls_cholesky__warm_start_matches_cold_start(seed):
     d_warm = fnnls_cholesky(ZTZ, ZTx, P_initial=P_initial)
 
     assert d_warm == pytest.approx(d_cold, rel=1e-8, abs=1e-10)
+
+
+@pytest.mark.parametrize("seed", [0, 1])
+def test__fnnls_cholesky__accepts_jax_arrays(seed):
+    """
+    The sparse-operator inversion path hands fnnls_cholesky JAX arrays even
+    when the fit runs the numba CPU path. Indexing a JAX array yields another
+    JAX array, which numba maps to a readonly buffer — before the boundary
+    coercion in fnnls_cholesky this failed kernel compilation with
+    "Cannot modify readonly array" (HowToLens smoke, 2026-08-20).
+    """
+    jnp = pytest.importorskip("jax.numpy")
+
+    rng = np.random.default_rng(seed)
+    n = 30
+    Z = rng.normal(size=(50, n))
+    x = Z @ rng.normal(size=n) + rng.normal(size=50)
+
+    ZTZ = Z.T @ Z
+    ZTx = Z.T @ x
+
+    d_np = fnnls_cholesky(ZTZ, ZTx)
+    d_jax = fnnls_cholesky(jnp.asarray(ZTZ), jnp.asarray(ZTx))
+
+    assert np.all(np.asarray(d_jax) >= 0.0)
+    assert np.asarray(d_jax) == pytest.approx(d_np, rel=1e-6, abs=1e-8)


### PR DESCRIPTION
## What

`fnnls_cholesky` now coerces `ZTZ` / `ZTx` / `P_initial` to numpy once at the function boundary, with a regression test that feeds it `jax.numpy` arrays.

## Why

The sparse-operator inversion path hands `fnnls_cholesky` JAX arrays even when the fit itself runs the numba CPU path (`PYAUTO_DISABLE_JAX=1`). Indexing a JAX array yields another JAX array, which numba maps to a **readonly** buffer — and the in-place buffer kernels introduced by #453 (`_cho_solve_buffer` → `_solve_upper_transposed_buffer`) overwrite their vector argument, so kernel compilation fails with `Cannot modify readonly array of type: readonly buffer(float64, 1d, C)` the first time the solver runs on such input. The scipy solvers #453 replaced tolerated JAX input by copying internally, which is why this never bit before.

**Visible failure:** HowToLens smoke on `main`, red since 2026-08-20 22:30 UTC — `tutorial_8_adaptive_pixelization` and `tutorial_11_brightness_adaption` (the two tutorials whose fits route through the sparse operator) failed with `During: Pass nopython_type_inference` on both CI Pythons, 21 minutes after #453 merged ([failing run](https://github.com/PyAutoLabs/HowToLens/actions/runs/32425255161)). This is the `HowToLens: Smoke Tests failure on main` RED that blocked the 2026-08-21 nightly release. Timeline pinned it to #453: no other library merge landed in the pass→fail window and both runs resolved identical dependency versions (numba 0.67.0 / numpy 2.5.2).

With numpy parents, fancy indexing hands every downstream kernel a fresh writeable array, so the in-place contract holds for all callers.

## Validation

- New `test__fnnls_cholesky__accepts_jax_arrays` (importorskip'd on jax) reproduces the failure without the coercion and passes with it; result cross-checked against the numpy-input solve.
- `test_autoarray/`: 1063 passed. (3 `test_transformer.py` pynufft failures reproduce identically on unmodified `main` in the validation env — missing `[optional]` extras — and are unrelated.)
- End-to-end: HowToLens `tutorial_8_adaptive_pixelization` + `tutorial_11_brightness_adaption` pass locally against current library mains with this fix (plus the HowToLens-side mesh-rename API update, PR'd separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GsUfbCwPd4XC8kpsiUJp7

---
_Generated by [Claude Code](https://claude.ai/code/session_015GsUfbCwPd4XC8kpsiUJp7)_