### PR TITLE
build: bump intra-family floors to >=2026.8.22.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     # Floor, not a pin (PyAutoLens#687) — bump to the first release with JAX
     # in autonerves' base dependencies once it exists (PyAutoLens#702), so
     # backtracking cannot pair this autoarray with a jax-optional autonerves.
-    "autonerves>=2026.7.29.2",
+    "autonerves>=2026.8.22.1",
     "astropy>=5.0",
     "decorator>=4.0.0",
     "dill>=0.3.1.1",


### PR DESCRIPTION
Release `2026.8.22.1` promoted all five libraries together (nightly run 50), so the committed source floor moves from the previous promoted set `2026.7.29.2` to the first version carrying the JAX-default dependency handshake, the fnnls JAX fix (#463) and the rectangular mesh split. Step (1) of the `jax-default-dependency` follow-ups recorded in PyAutoMind `active.md`; sibling PRs bump PyAutoFit, PyAutoGalaxy and PyAutoLens.

One line: `autonerves>=2026.7.29.2` → `>=2026.8.22.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GsUfbCwPd4XC8kpsiUJp7

---
_Generated by [Claude Code](https://claude.ai/code/session_015GsUfbCwPd4XC8kpsiUJp7)_