### PR TITLE
fix: form the reconstruction covariance via Cholesky, not an elementwise sqrt

### DIFF
--- a/autoarray/inversion/inversion/abstract.py
+++ b/autoarray/inversion/inversion/abstract.py
@@ -1,4 +1,5 @@
 import copy
+import warnings
 
 import numpy as np
 from typing import Dict, List, Optional, Type, Union
@@ -836,27 +837,78 @@ class AbstractInversion:
         return self._log_det_symmetric_from(self.regularization_matrix_reduced)
 
     @property
-    def reconstruction_noise_map_with_covariance(self) -> np.ndarray:
+    def reconstruction_covariance_matrix(self) -> np.ndarray:
         """
-        Returns the noise-map of the reconstruction as a two dimension matrix which accounts for the covariance
-        of the noise between pixels.
+        Returns the covariance matrix of the reconstruction, ``C = [F + reg_coeff*H]^-1``.
 
-        The diagonal of this matrix is the noise-map of the reconstruction, which can be used for analysing the
-        reconstruction with noise properties that are representative of the fit and therefore should be used
-        for any scientific analysis (e.g. source reconstructions of strong lenses).
+        This is the inverse of the curvature matrix with regularization -- the same matrix used to solve for the
+        reconstruction via the linear inversion. Its diagonal holds the variance of each reconstructed pixel and
+        its off-diagonal entries the covariances between pixels; the off-diagonals are routinely negative, which is
+        a property of the covariance and not an error.
 
-        This noise-map is defined as the RMS standard deviation of the noise in every pixel of the reconstruction.
-        This definition is identical to the `noise_map` attributes of dataset objects.
+        For the RMS standard deviation of each pixel (the quantity used for scientific analysis) use
+        `reconstruction_noise_map`, which takes the square root of this matrix's diagonal.
 
-        It is computed as the square root of the inverse of the curvature matrix with regularization, which is the
-        same matrix used to solve for the reconstruction via the linear inversion.
+        The inverse is formed from a Cholesky factorization rather than `np.linalg.inv`, for two reasons:
+
+        - `cho_factor` raises `LinAlgError` when the matrix is not positive-definite. `np.linalg.inv` raises only
+          on an exactly singular matrix, so an indefinite `curvature_reg_matrix` -- which the inversion does
+          encounter, hence `Settings.no_regularization_add_to_curvature_diag_value` -- previously returned a
+          plausible-looking covariance with no error and no warning. A covariance is only defined for a
+          positive-definite matrix, so failing here is correct and is handled by the callers in
+          `inversion/plot/inversion_plots.py`.
+        - `np.linalg.inv` is LU-based and exploits neither the symmetry nor the positive-definiteness this matrix
+          has. Its output drifts out of symmetry as conditioning worsens (measured at ~5e-7 absolute at
+          `cond ~ 1e12`, against ~3e-16 for the Cholesky solve), while a covariance matrix is symmetric by
+          definition.
+
+        This property is NumPy-only: the input is coerced with `np.asarray`, so a JAX `curvature_reg_matrix`
+        forces a device-to-host transfer. It is a post-fit diagnostic, not part of the likelihood, so it is not on
+        the JIT path.
 
         Returns
         -------
-        The noise-map of the reconstruction as a two dimension matrix which accounts for the covariance of the noise
-        between pixels.
+        The covariance matrix of the reconstruction, of shape [total_params, total_params].
         """
-        return np.sqrt(np.linalg.inv(self.curvature_reg_matrix))
+        from scipy.linalg import cho_factor, cho_solve
+
+        matrix = np.asarray(self.curvature_reg_matrix)
+
+        covariance = cho_solve(
+            cho_factor(matrix), np.eye(matrix.shape[0], dtype=matrix.dtype)
+        )
+
+        # cho_solve is accurate but not bitwise symmetric; a covariance matrix is symmetric by definition.
+        return 0.5 * (covariance + covariance.T)
+
+    @property
+    def reconstruction_noise_map_with_covariance(self) -> np.ndarray:
+        """
+        Deprecated alias of `reconstruction_covariance_matrix`.
+
+        This property previously returned ``np.sqrt(np.linalg.inv(curvature_reg_matrix))`` -- an elementwise square
+        root of the whole covariance matrix. Because the off-diagonal entries of a covariance matrix are routinely
+        negative, every such entry was `NaN` by construction, for any input matrix however well-conditioned, and
+        each call emitted `RuntimeWarning: invalid value encountered in sqrt`.
+
+        It now returns the covariance matrix itself, so the values differ: the diagonal holds variances rather
+        than standard deviations, and the off-diagonals hold covariances rather than `NaN`.
+
+        Returns
+        -------
+        The covariance matrix of the reconstruction (see `reconstruction_covariance_matrix`).
+        """
+        warnings.warn(
+            "`reconstruction_noise_map_with_covariance` is deprecated; use "
+            "`reconstruction_covariance_matrix` instead. Note the values have changed: it now returns the "
+            "covariance matrix, so its diagonal holds variances rather than standard deviations (the previous "
+            "elementwise square root made every off-diagonal NaN). For the RMS noise of each pixel use "
+            "`reconstruction_noise_map`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return self.reconstruction_covariance_matrix
 
     @property
     def reconstruction_noise_map(self):
@@ -870,15 +922,15 @@ class AbstractInversion:
         The noise-map of the reconstruction is the RMS standard deviation of the noise in every pixel of the
         reconstruction. This definition is identical to the `noise_map` attributes of dataset objects.
 
-        It is computed as the square root of the diagonal of the `reconstruction_noise_map_with_covariance` matrix,
-        which is the same matrix used to solve for the reconstruction via the linear inversion.
+        It is computed as the square root of the diagonal of `reconstruction_covariance_matrix`, which is the
+        inverse of the same matrix used to solve for the reconstruction via the linear inversion.
 
         Returns
         -------
         The noise-map of the reconstruction as a one dimensional ndarray, which does not account for the covariance
         of the noise between pixels.
         """
-        return np.diagonal(self.reconstruction_noise_map_with_covariance)
+        return np.sqrt(np.diag(self.reconstruction_covariance_matrix))
 
     @property
     def reconstruction_noise_map_dict(self) -> Dict[LinearObj, np.ndarray]:

--- a/autoarray/inversion/inversion/abstract.py
+++ b/autoarray/inversion/inversion/abstract.py
@@ -862,6 +862,14 @@ class AbstractInversion:
           `cond ~ 1e12`, against ~3e-16 for the Cholesky solve), while a covariance matrix is symmetric by
           definition.
 
+        Every failure mode raises `LinAlgError`, including a non-finite `curvature_reg_matrix`. That case is
+        checked explicitly because scipy would otherwise raise `ValueError`, which the callers -- here and
+        downstream -- do not catch; the previous implementation returned a silently all-`NaN` matrix instead.
+
+        The matrix is symmetrized on input. `cho_factor` reads only the upper triangle, so an asymmetric input
+        would otherwise be inverted as though its lower triangle matched, silently and with no diagnostic.
+        `curvature_reg_matrix` is `F + H` and symmetric by construction, so this is defensive only.
+
         This property is NumPy-only: the input is coerced with `np.asarray`, so a JAX `curvature_reg_matrix`
         forces a device-to-host transfer. It is a post-fit diagnostic, not part of the likelihood, so it is not on
         the JIT path.
@@ -874,8 +882,21 @@ class AbstractInversion:
 
         matrix = np.asarray(self.curvature_reg_matrix)
 
+        if not np.isfinite(matrix).all():
+            raise np.linalg.LinAlgError(
+                "The curvature_reg_matrix contains non-finite entries (NaN or inf), so the reconstruction "
+                "covariance is undefined. Raised as LinAlgError so the plotting and CSV callers, which guard "
+                "on LinAlgError, degrade gracefully rather than aborting the model-fit."
+            )
+
+        # cho_factor reads only the upper triangle; symmetrize so an asymmetric input cannot be silently
+        # inverted as though its lower triangle matched its upper.
+        matrix = 0.5 * (matrix + matrix.T)
+
         covariance = cho_solve(
-            cho_factor(matrix), np.eye(matrix.shape[0], dtype=matrix.dtype)
+            cho_factor(matrix, check_finite=False),
+            np.eye(matrix.shape[0], dtype=matrix.dtype),
+            check_finite=False,
         )
 
         # cho_solve is accurate but not bitwise symmetric; a covariance matrix is symmetric by definition.
@@ -924,6 +945,12 @@ class AbstractInversion:
 
         It is computed as the square root of the diagonal of `reconstruction_covariance_matrix`, which is the
         inverse of the same matrix used to solve for the reconstruction via the linear inversion.
+
+        This previously took the diagonal of an elementwise-square-rooted matrix. The two are algebraically
+        identical -- `np.sqrt` is elementwise, so it commutes with taking the diagonal -- but only numerically
+        equivalent, since the covariance is now formed by Cholesky rather than LU. The difference is
+        conditioning-limited roundoff, measured at ~7e-15 relative at `cond ~ 1e3` rising to ~4e-5 at
+        `cond ~ 1e13`; neither result is the more correct one.
 
         Returns
         -------

--- a/test_autoarray/inversion/inversion/test_abstract.py
+++ b/test_autoarray/inversion/inversion/test_abstract.py
@@ -678,7 +678,7 @@ def test__log_det_method__slogdet_is_finite_where_cholesky_fails_on_non_positive
     assert result == pytest.approx(np.linalg.slogdet(matrix)[1], 1.0e-8)
 
 
-def test__reconstruction_noise_map__asymmetric_curvature_reg_matrix__correct_diagonal_noise_values():
+def test__reconstruction_noise_map__correct_diagonal_noise_values():
     curvature_reg_matrix = np.array([[1.0, 1.0, 1.0], [1.0, 2.0, 1.0], [1.0, 1.0, 3.0]])
 
     inversion = aa.m.MockInversion(curvature_reg_matrix=curvature_reg_matrix)
@@ -713,18 +713,59 @@ def test__reconstruction_covariance_matrix__off_diagonals_are_finite_and_negativ
     assert covariance == pytest.approx(np.linalg.inv(curvature_reg_matrix), 1.0e-8)
 
 
-def test__reconstruction_covariance_matrix__is_exactly_symmetric():
-    """A covariance matrix is symmetric by definition; `np.linalg.inv` drifts out of symmetry."""
+def test__reconstruction_covariance_matrix__is_accurate_and_symmetric_when_ill_conditioned():
+    """
+    Ground truth is exact by construction: for `A = Q diag(w) Q.T` the inverse is `Q diag(1/w) Q.T`.
+
+    The symmetry half only guards the symmetrization line -- `0.5 * (C + C.T)` is bitwise symmetric for any C --
+    so the accuracy assertion against the constructed truth is what tests the factorization itself.
+    """
     rng = np.random.default_rng(1234)
     q, _ = np.linalg.qr(rng.standard_normal((25, 25)))
-    curvature_reg_matrix = (q * np.logspace(0, 9, 25)) @ q.T
+    eigenvalues = np.logspace(0, 9, 25)
+
+    curvature_reg_matrix = (q * eigenvalues) @ q.T
     curvature_reg_matrix = 0.5 * (curvature_reg_matrix + curvature_reg_matrix.T)
+
+    covariance_true = (q * (1.0 / eigenvalues)) @ q.T
 
     inversion = aa.m.MockInversion(curvature_reg_matrix=curvature_reg_matrix)
 
     covariance = inversion.reconstruction_covariance_matrix
 
+    # cond ~ 1e9, so the achievable accuracy is eps * cond ~ 2e-7; the measured error is ~3e-9. This is not a
+    # claim that Cholesky beats LU here -- it does not, `np.linalg.inv` measures ~7e-10 on this matrix.
+    assert covariance == pytest.approx(covariance_true, abs=1.0e-7)
     assert covariance == pytest.approx(covariance.T, abs=1.0e-15)
+
+
+def test__reconstruction_covariance_matrix__asymmetric_input_is_symmetrized_not_silently_upper_triangle():
+    """
+    `cho_factor` reads only the upper triangle, so an asymmetric input would be inverted as though its lower
+    triangle matched its upper -- silently, and differing from the true inverse.
+    """
+    curvature_reg_matrix = np.array([[2.0, 0.5], [0.1, 2.0]])
+    symmetrized = 0.5 * (curvature_reg_matrix + curvature_reg_matrix.T)
+
+    inversion = aa.m.MockInversion(curvature_reg_matrix=curvature_reg_matrix)
+
+    assert inversion.reconstruction_covariance_matrix == pytest.approx(
+        np.linalg.inv(symmetrized), 1.0e-8
+    )
+
+
+def test__reconstruction_covariance_matrix__non_finite_matrix_raises_lin_alg_error():
+    """
+    scipy raises `ValueError` on a non-finite matrix, which the plotting and CSV callers do not catch -- they
+    guard on `LinAlgError`. The CSV writer explicitly promises not to abort the enclosing model-fit, so the
+    non-finite case is converted rather than allowed to escape.
+    """
+    curvature_reg_matrix = np.array([[1.0, np.nan], [np.nan, 2.0]])
+
+    inversion = aa.m.MockInversion(curvature_reg_matrix=curvature_reg_matrix)
+
+    with pytest.raises(np.linalg.LinAlgError, match="non-finite"):
+        inversion.reconstruction_covariance_matrix
 
 
 def test__reconstruction_noise_map__is_sqrt_of_covariance_diagonal():

--- a/test_autoarray/inversion/inversion/test_abstract.py
+++ b/test_autoarray/inversion/inversion/test_abstract.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pytest
 
@@ -681,12 +683,95 @@ def test__reconstruction_noise_map__asymmetric_curvature_reg_matrix__correct_dia
 
     inversion = aa.m.MockInversion(curvature_reg_matrix=curvature_reg_matrix)
 
-    assert inversion.reconstruction_noise_map_with_covariance[0, 0] == pytest.approx(
-        np.sqrt(2.5), 1.0e-2
-    )
+    assert inversion.reconstruction_covariance_matrix[0, 0] == pytest.approx(2.5, 1.0e-2)
     assert inversion.reconstruction_noise_map == pytest.approx(
         np.sqrt(np.array([2.5, 1.0, 0.5])), 1.0e-3
     )
+
+
+def test__reconstruction_covariance_matrix__off_diagonals_are_finite_and_negative():
+    """
+    The off-diagonal entries of a covariance matrix are covariances and are routinely negative.
+
+    `reconstruction_covariance_matrix` previously applied `np.sqrt` elementwise to the whole inverse, so every
+    negative off-diagonal became NaN by construction -- for any matrix, however well-conditioned -- while
+    emitting `RuntimeWarning: invalid value encountered in sqrt`. Only the [0, 0] diagonal element was asserted,
+    so nothing caught it.
+    """
+    curvature_reg_matrix = np.array([[1.0, 1.0, 1.0], [1.0, 2.0, 1.0], [1.0, 1.0, 3.0]])
+
+    inversion = aa.m.MockInversion(curvature_reg_matrix=curvature_reg_matrix)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        covariance = inversion.reconstruction_covariance_matrix
+
+    assert np.all(np.isfinite(covariance))
+
+    # this matrix has anti-correlated pixels, so the off-diagonals are genuinely negative
+    assert covariance[0, 1] < 0.0
+    assert covariance == pytest.approx(np.linalg.inv(curvature_reg_matrix), 1.0e-8)
+
+
+def test__reconstruction_covariance_matrix__is_exactly_symmetric():
+    """A covariance matrix is symmetric by definition; `np.linalg.inv` drifts out of symmetry."""
+    rng = np.random.default_rng(1234)
+    q, _ = np.linalg.qr(rng.standard_normal((25, 25)))
+    curvature_reg_matrix = (q * np.logspace(0, 9, 25)) @ q.T
+    curvature_reg_matrix = 0.5 * (curvature_reg_matrix + curvature_reg_matrix.T)
+
+    inversion = aa.m.MockInversion(curvature_reg_matrix=curvature_reg_matrix)
+
+    covariance = inversion.reconstruction_covariance_matrix
+
+    assert covariance == pytest.approx(covariance.T, abs=1.0e-15)
+
+
+def test__reconstruction_noise_map__is_sqrt_of_covariance_diagonal():
+    """
+    The invariant, asserted directly rather than via hand-computed values.
+
+    `reconstruction_noise_map` used to be `np.diagonal(...)` of an already-square-rooted matrix, which was
+    correct only incidentally -- because `np.sqrt` is elementwise. It now takes the square root of the
+    covariance diagonal itself, so the relationship is stated rather than emergent.
+    """
+    curvature_reg_matrix = np.array([[1.0, 1.0, 1.0], [1.0, 2.0, 1.0], [1.0, 1.0, 3.0]])
+
+    inversion = aa.m.MockInversion(curvature_reg_matrix=curvature_reg_matrix)
+
+    assert inversion.reconstruction_noise_map == pytest.approx(
+        np.sqrt(np.diag(inversion.reconstruction_covariance_matrix)), 1.0e-12
+    )
+
+
+def test__reconstruction_covariance_matrix__raises_on_a_non_positive_definite_matrix():
+    """
+    A covariance is only defined for a positive-definite matrix.
+
+    `np.linalg.inv` raises only on an exactly singular matrix, so an indefinite `curvature_reg_matrix` returned
+    a plausible-looking covariance with no error and no warning. The Cholesky factorization rejects it, and the
+    plotting and CSV callers already catch `LinAlgError`.
+    """
+    # symmetric, non-singular, but indefinite (eigenvalues +1 and -1)
+    curvature_reg_matrix = np.array([[0.0, 1.0], [1.0, 0.0]])
+
+    inversion = aa.m.MockInversion(curvature_reg_matrix=curvature_reg_matrix)
+
+    assert np.isfinite(np.linalg.inv(curvature_reg_matrix)).all()  # inv is silent here
+
+    with pytest.raises(np.linalg.LinAlgError):
+        inversion.reconstruction_covariance_matrix
+
+
+def test__reconstruction_noise_map_with_covariance__is_deprecated_alias():
+    curvature_reg_matrix = np.array([[1.0, 1.0, 1.0], [1.0, 2.0, 1.0], [1.0, 1.0, 3.0]])
+
+    inversion = aa.m.MockInversion(curvature_reg_matrix=curvature_reg_matrix)
+
+    with pytest.warns(DeprecationWarning, match="reconstruction_covariance_matrix"):
+        covariance = inversion.reconstruction_noise_map_with_covariance
+
+    assert covariance == pytest.approx(inversion.reconstruction_covariance_matrix, 1.0e-12)
 
 
 def test__max_pixel_list_from_and_centre__returns_top_pixels_and_brightest_centre():

--- a/test_autoarray/inversion/plot/test_inversion_plotters.py
+++ b/test_autoarray/inversion/plot/test_inversion_plotters.py
@@ -79,8 +79,8 @@ def test__inversion_subplot_of_mapper__singular_curvature_reg_matrix(
 
     monkeypatch.setattr(
         type(inversion),
-        "reconstruction_noise_map_with_covariance",
-        property(lambda self: np.sqrt(np.linalg.inv(np.zeros((params, params))))),
+        "reconstruction_covariance_matrix",
+        property(lambda self: np.linalg.inv(np.zeros((params, params)))),
     )
 
     with pytest.raises(np.linalg.LinAlgError):
@@ -107,8 +107,8 @@ def test__save_reconstruction_csv__singular_curvature_reg_matrix(
 
     monkeypatch.setattr(
         type(inversion),
-        "reconstruction_noise_map_with_covariance",
-        property(lambda self: np.sqrt(np.linalg.inv(np.zeros((params, params))))),
+        "reconstruction_covariance_matrix",
+        property(lambda self: np.linalg.inv(np.zeros((params, params)))),
     )
 
     with pytest.raises(np.linalg.LinAlgError):


### PR DESCRIPTION
Closes #468.

## The defect

`AbstractInversion.reconstruction_noise_map_with_covariance` was:

```python
return np.sqrt(np.linalg.inv(self.curvature_reg_matrix))
```

`np.sqrt` is applied **elementwise to the whole inverse**. That inverse is the reconstruction covariance matrix, whose off-diagonals are covariances and are routinely negative — so every one was `NaN` by construction, for any input matrix however well-conditioned, with a `RuntimeWarning` on every call. The docstring promised a matrix that "accounts for the covariance of the noise between pixels"; the entries carrying that covariance were exactly the broken ones.

Found during the reproduction gate for #467.

**This did not affect the 1D `reconstruction_noise_map`.** `np.sqrt` is elementwise, so it commutes with taking the diagonal (`diagonal(sqrt(C))[i] == sqrt(C[i,i])`). Only the covariance-aware consumer and the warning spam were hit.

## Changes

- **new `reconstruction_covariance_matrix`** — returns `C` itself, formed by Cholesky (`cho_factor`/`cho_solve`), input and output symmetrized, with an explicit finiteness guard.
- **`reconstruction_noise_map`** — decoupled, now `sqrt(diag(C))` directly. It was previously correct only *incidentally*, via the elementwise sqrt; the invariant is now stated, so it cannot silently become a variance if the matrix changes.
- **`reconstruction_noise_map_with_covariance`** — deprecated alias whose warning states the value change explicitly.

## Why Cholesky — on measured evidence, not assumption

An A/B was run before writing the fix, and it **refuted two of the arguments** originally made for this change:

| Claim | Verdict |
|---|---|
| `inv` gives negative diagonals on well-formed SPD | **Refuted** — 0 across cond 1e3–1e15, n=400, 20 trials each |
| `inv` is materially less accurate on the diagonal | **Refuted** — matches `cho_solve`; at cond 1e15 `inv` was marginally *better* |
| Near-coincident mesh vertices degrade the inverse | **Refuted** — with regularization the matrix stays PD (cond ~6.8e7 even at exactly duplicated columns) |
| `inv` returns asymmetric output | **Confirmed** — 5.2e-7 at cond 1e12, vs 2.6e-16 |
| `inv` silently succeeds on indefinite matrices | **Confirmed** |

**The case for Cholesky is detection, not accuracy.** `cho_factor` raises `LinAlgError` on a negative eigenvalue; `np.linalg.inv` raises only on an *exactly* singular matrix and otherwise returns a plausible-looking covariance. At eigenvalue `-1e-8` all 300 diagonals came back negative (whole noise map `NaN`); at `-1.0`, **zero** did — no `NaN`, no warning, no error, and wrong numbers. A covariance is only defined for a positive-definite matrix, so this adds a definiteness check the code lacked entirely.

Not established: that a real `curvature_reg_matrix` *is* indefinite in a converged fit. `Settings.no_regularization_add_to_curvature_diag_value` and the `curvature_matrix_with_added_to_diag_from` docstring say non-PD matrices happen, but no fit was instrumented to confirm it.

## Review fixes (second commit)

An adversarial review of the first commit found a **regression it had introduced**:

- **Non-finite input raised `ValueError`, not `LinAlgError`.** scipy defaults to `check_finite=True`. Both callers (`inversion_plots.py:169`, `:397`) catch only `LinAlgError`, and the CSV writer's docstring explicitly promises a failure there may not abort the enclosing model-fit. Verified: old code returned `[nan, nan]`; first fix raised `ValueError` past the guards. Now raises `LinAlgError` with a message naming the cause, so the contract holds for downstream callers too. `check_finite=False` is then passed to scipy, so the explicit check costs nothing net.
- **`cho_factor` reads only the upper triangle**, so an asymmetric input was silently inverted as though its lower triangle matched — `[[2.0, 0.5], [0.1, 2.0]]` gave diag `0.5333` vs the true inverse's `0.5063`. Output symmetrization does not address this; the input is now symmetrized too.

## API and behaviour changes

**`reconstruction_noise_map_with_covariance` values change** — diagonal from std-dev to variance, off-diagonals from `NaN` to covariances. Grepped rather than assumed safe:

| Repo | `with_covariance` | `reconstruction_noise_map` |
|---|---|---|
| PyAutoGalaxy `3ca31bf` | none | none |
| PyAutoLens `87e5827` | none | none |
| autolens_workspace | none | **4 scripts + notebooks** |

Control greps confirm the checkouts are real (394 / 237 / 465 `.py` files), so the nulls are genuine. No consumer of the alias exists in the stack. `reconstruction_noise_map` *is* used — `source_science.py` computes `signal_to_noise_map = reconstruction / reconstruction_noise_map` — and its values are unchanged. Not checked: `autogalaxy_workspace`, HowTo repos, external user code.

**`reconstruction_noise_map` is numerically, not bitwise, equivalent.** Algebraically identical, but the covariance is now formed by Cholesky rather than LU: ~7e-15 relative at cond 1e3 rising to ~4e-5 at cond 1e13. Neither result is the more correct one.

**`reconstruction_covariance_matrix` now raises on indefinite/non-finite input** where `inv` silently returned numbers. Both existing call sites already catch `LinAlgError` — verified, not assumed.

## Tests

The only prior assertion on this property checked `[0, 0]`, a **diagonal** element — which is why the off-diagonal `NaN`s shipped. Added:

- off-diagonals finite and genuinely negative, under `-W error::RuntimeWarning` (fails on the old implementation)
- accuracy against an exactly-constructed ground truth `A = Q diag(w) Q.T`, plus symmetry
- `reconstruction_noise_map == sqrt(diag(C))` as an explicit invariant
- raises on an indefinite matrix, asserting `inv` is silent on the same input
- raises `LinAlgError` (not `ValueError`) on a non-finite matrix
- asymmetric input is symmetrized rather than silently upper-triangled
- the deprecated alias warns and matches the new property

Two plotter monkeypatch sites repointed to the new property. Fixed a stale test name asserting `asymmetric_curvature_reg_matrix` over a symmetric matrix.

**Local run:** 1152 passed, 1 skipped. Three `test_transformer.py` pynufft failures are pre-existing on `a6b07cd` (verified by stashing) and unrelated — a sandbox dependency issue, expected to be green in CI.

## Out of scope

The estimator-level defects are tracked separately and deliberately excluded: the covariance describes the *unconstrained* Warren & Dye solve while `use_positive_only_solver: true` (NNLS) is the shipped default; the noise map ignores `zeroed_ids_to_keep` under `use_edge_zeroed_pixels: true`; and that setting is silently ignored when the positive-only solver is off. Those need a statistical decision, not a code repair.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133X4XhMV91SFjzV2mK4Ejh

---
_Generated by [Claude Code](https://claude.ai/code/session_0133X4XhMV91SFjzV2mK4Ejh)_