### PR TITLE
Remove the dead use_adjoint_scaling parameter and adjoint_scaling attribute

### DIFF
--- a/autoarray/dataset/interferometer/dataset.py
+++ b/autoarray/dataset/interferometer/dataset.py
@@ -274,7 +274,6 @@ class Interferometer(AbstractDataset):
         dirty_image = self.transformer.image_from(
             visibilities=self.data.real * self.noise_map.real**-2.0
             + 1j * self.data.imag * self.noise_map.imag**-2.0,
-            use_adjoint_scaling=True,
         )
 
         sparse_operator = inversion_interferometer_util.InterferometerSparseOperator.from_nufft_precision_operator(

--- a/autoarray/operators/transformer.py
+++ b/autoarray/operators/transformer.py
@@ -143,8 +143,6 @@ class TransformerDFT:
             The precomputed sine terms used in the imaginary part of the DFT.
         real_space_pixels : int
             Alias for `total_image_pixels`.
-        adjoint_scaling : float
-            Scaling factor applied to the adjoint operator to normalize the inverse transform.
         """
         super().__init__()
 
@@ -154,11 +152,6 @@ class TransformerDFT:
 
         self.total_visibilities = uv_wavelengths.shape[0]
         self.total_image_pixels = self.real_space_mask.pixels_in_mask
-
-        # NOTE: This is the scaling factor that needs to be applied to the adjoint operator
-        self.adjoint_scaling = (2.0 * self.grid.shape_native[0]) * (
-            2.0 * self.grid.shape_native[1]
-        )
 
     def visibilities_from(self, image: Array2D, xp=np) -> Visibilities:
         """
@@ -187,9 +180,7 @@ class TransformerDFT:
 
         return Visibilities(visibilities=visibilities)
 
-    def image_from(
-        self, visibilities: Visibilities, use_adjoint_scaling: bool = False, xp=np
-    ) -> Array2D:
+    def image_from(self, visibilities: Visibilities, xp=np) -> Array2D:
         """
         Computes the real-space image from a set of visibilities using the adjoint of the DFT.
 
@@ -201,14 +192,6 @@ class TransformerDFT:
         ----------
         visibilities
             The complex visibilities to be transformed into a real-space image.
-        use_adjoint_scaling
-            If True, normalise the adjoint output onto the common scale shared by
-            every transformer (that of the plain mathematical adjoint). Both
-            remaining transformers already return the plain mathematical
-            adjoint, so this is a no-op for each of them; it is retained as a
-            stable part of the transformer interface. See `Interferometer.
-            apply_sparse_operator`, which passes `True` so the sparse-operator
-            dirty image is scale-consistent across both transformers.
 
         Returns
         -------
@@ -322,10 +305,6 @@ class TransformerNUFFT:
             Number of measured visibilities.
         total_image_pixels
             Number of unmasked pixels in the image grid.
-        adjoint_scaling
-            Scaling factor available for callers who want to apply an
-            optional normalisation to the adjoint output. Provided for
-            parity with the legacy class.
         """
         from astropy import units
 
@@ -362,7 +341,6 @@ class TransformerNUFFT:
 
         self.total_visibilities = uv_wavelengths.shape[0]
         self.total_image_pixels = real_space_mask.pixels_in_mask
-        self.adjoint_scaling = (2.0 * n_y) * (2.0 * n_x)
 
     def _forward_native(self, image_native_2d, xp=np):
         """Run nufft2d2 on a 2D native-shape image array, returning visibilities.
@@ -447,7 +425,6 @@ class TransformerNUFFT:
     def image_from(
         self,
         visibilities: Visibilities,
-        use_adjoint_scaling: bool = False,
         xp=np,
     ) -> Array2D:
         """
@@ -459,15 +436,9 @@ class TransformerNUFFT:
 
         Note that this is the **mathematical adjoint** of `visibilities_from`,
         with no kernel deconvolution applied. The values match
-        `TransformerDFT.image_from` exactly.
-
-        `use_adjoint_scaling` normalises the adjoint onto the common scale
-        shared by every transformer. It is a no-op here (and for
-        `TransformerDFT`) because both remaining adjoints are already the plain
-        mathematical adjoint; it is retained as a stable part of the
-        transformer interface. `Interferometer.apply_sparse_operator` passes
-        `True` so the sparse-operator dirty image is scale-consistent across
-        both transformers.
+        `TransformerDFT.image_from` exactly, which is what makes
+        `Interferometer.apply_sparse_operator` scale-consistent across both
+        transformers.
         """
         _load_nufftax()
 


### PR DESCRIPTION
## Summary

`use_adjoint_scaling` has **no effect on either remaining transformer**. Both `TransformerDFT.image_from` and `TransformerNUFFT.image_from` accepted it and never referenced it in any code path — including all four of `TransformerNUFFT`'s (jax one-shot, jax chunked, numpy one-shot, numpy chunked). Passing `True` silently did nothing.

Follow-up to #475, which flagged this but deliberately left it alone rather than widening a dependency removal.

### It was not always dead — where the work actually went

| Class | Applied `adjoint_scaling`? |
|---|---|
| `TransformerDFT` | **Never** |
| `TransformerNUFFTPyNUFFT` | **Yes** — `image *= self.adjoint_scaling`, the only real user. Removed in #475. |
| `TransformerNUFFT` | Until `bd18a769` (2026-05-22), then deliberately removed |

`bd18a769` states the reason: the `4·N_y·N_x` factor *"is a Kaiser-Bessel compensation that only the legacy pynufft variant needs; the nufftax adjoint is already the mathematical adjoint and needs no extra scaling."* With pynufft gone there is no backend that needs it.

### Why remove the attribute too, not just the parameter

`adjoint_scaling` was public and inert. Leaving it invites someone to apply it by hand and silently scale a dirty image by 4096× on a 32×32 grid. A caller still passing the keyword now gets a `TypeError` rather than a silent no-op — the safer failure, since the value was genuinely load-bearing for one now-deleted class.

Scale-consistency across the two transformers is unaffected: it comes from both returning the plain mathematical adjoint, not from this flag.

## API Changes

**Breaking:** the `use_adjoint_scaling` keyword is removed from `TransformerDFT.image_from` and `TransformerNUFFT.image_from`, and the `adjoint_scaling` attribute is removed from both classes. No migration is needed for correctness — the keyword had no effect on either class, so removing the call site changes no numbers. Anyone reading `transformer.adjoint_scaling` and applying it manually was introducing a 4096×-class error and should stop.

See full details below.

## Test Plan

- [x] `TransformerNUFFT.image_from` vs `TransformerDFT.image_from`: **1.562e-13** relative, *identical before and after* this change
- [x] `use_adjoint_scaling=True` vs `False` was **bit-identical** (`max|diff| = 0.000e+00`) on both classes before removal
- [x] Passing the removed keyword now raises `TypeError` (loud, not silent)
- [x] `pytest test_autoarray` — **1179 passed**, including `test__curvature_matrix__interferometer_sparse_operator__delaunay__dft_and_nufft_match`, the parity test `bd18a769` added for exactly this path
- [x] Downstream against this branch: PyAutoGalaxy **1103 passed, 1 skipped**; PyAutoLens **532 passed, 1 skipped**

<details>
<summary>Full API Changes (for automation &amp; release notes)</summary>

### Removed
- `TransformerDFT.image_from(..., use_adjoint_scaling=)` — keyword removed; it was never referenced
- `TransformerNUFFT.image_from(..., use_adjoint_scaling=)` — keyword removed; unreferenced since `bd18a769`
- `TransformerDFT.adjoint_scaling` — attribute removed
- `TransformerNUFFT.adjoint_scaling` — attribute removed

### Changed Signature
- `TransformerDFT.image_from(visibilities, xp=np)` — was `(visibilities, use_adjoint_scaling=False, xp=np)`
- `TransformerNUFFT.image_from(visibilities, xp=np)` — was `(visibilities, use_adjoint_scaling=False, xp=np)`

### Changed Behaviour
- None. Numerically identical output; the removed keyword had no effect on either class.

### Migration
- Before: `transformer.image_from(visibilities=vis, use_adjoint_scaling=True)`
- After: `transformer.image_from(visibilities=vis)`
- `Interferometer.apply_sparse_operator` was the only in-repo caller and is updated.

**Note for anyone with pre-2026-05-22 results:** if you used `TransformerNUFFT` with `use_adjoint_scaling=True` before `bd18a769`, the factor *was* applied then and is not applied now. Results generated before that commit differ from anything regenerated today by `4 * N_y * N_x`. That change landed in May and is not introduced here.

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6pH5eMAcAwjbfGUmCnwZF)_