### PR TITLE
Document the DFT/NUFFT trade-off on the sparse-operator setup path

### DIFF
--- a/autoarray/dataset/interferometer/dataset.py
+++ b/autoarray/dataset/interferometer/dataset.py
@@ -232,6 +232,21 @@ class Interferometer(AbstractDataset):
         the number of visibilities and the real-space mask resolution — potentially hours for large
         datasets). The result can be cached to disk and reloaded to avoid recomputation.
 
+        Both `TransformerDFT` and `TransformerNUFFT` are supported here and agree to ~3e-13 relative.
+        Which is faster is governed by the product `N_vis * N_pix`, because the DFT setup cost scales
+        as `O(N_vis * N_pix)` whereas the NUFFT scales as `O((N_vis + N_pix) log N)` on top of a fixed
+        ~2s overhead:
+
+        - below `N_vis * N_pix ~ 1e7`, `TransformerDFT` is faster (measured 0.2-0.7x the NUFFT time)
+        - above it, `TransformerNUFFT` is faster (1.2-1.9x at 1e7-1e8)
+        - above `~1e8`, the DFT's `O(N_vis * N_pix)` allocation makes it infeasible rather than merely
+          slow — extrapolating a measured 446 MB at N_vis=4e3 / N_pix=1e4 gives ~109 GB at 1M
+          visibilities, whereas the NUFFT path allocates nothing beyond its working buffers.
+
+        As a rule of thumb at a typical 64x64 mask the crossover sits near 5,000 visibilities, but on a
+        coarser mask the DFT stays ahead well beyond that — it is the product that matters, not the
+        visibility count alone.
+
         Parameters
         ----------
         nufft_precision_operator
@@ -263,6 +278,20 @@ class Interferometer(AbstractDataset):
             logger.info(
                 "INTERFEROMETER - Computing NUFFT Precision Operator; runtime scales with visibility count and mask resolution, CPU run times may exceed hours."
             )
+
+            n_vis = self.uv_wavelengths.shape[0]
+            n_pix = self.real_space_mask.pixels_in_mask
+
+            if n_vis * n_pix < 10**7 and not isinstance(
+                self.transformer, TransformerDFT
+            ):
+                logger.info(
+                    f"INTERFEROMETER - This dataset is small for the NUFFT setup path "
+                    f"(N_vis x N_pix = {n_vis * n_pix:.1e}, below the ~1e7 crossover). "
+                    f"`TransformerDFT` computes this operator faster below that point; "
+                    f"`TransformerNUFFT` wins above it, and above ~1e8 it is the only "
+                    f"option that fits in memory. Both are supported here."
+                )
 
             nufft_precision_operator = self.psf_precision_operator_from(
                 chunk_k=chunk_k,


### PR DESCRIPTION
## Summary

Closes the last open item from the pynufft removal (#475): whether `apply_sparse_operator` is still incompatible with `TransformerNUFFT`.

**It is not, and has not been since May.** The `NotImplementedError` guard was removed by #329 (`bd18a769`, 2026-05-22); only a stale workspace comment still claimed otherwise. Verified directly: `apply_sparse_operator` runs with `TransformerNUFFT` at every scale tried, and its dirty image matches `TransformerDFT` to **~3e-13 relative**.

Both paths are supported. What was undocumented is which one you should actually pick — and the answer isn't the visibility count.

### The crossover is the product, not the visibility count

The DFT setup costs `O(N_vis × N_pix)`; the NUFFT costs `O((N_vis + N_pix) log N)` plus a fixed ~2 s overhead. So the product decides it. Measured on CPU (`use_jax=False`), seven points agree on a crossover near **1e7**:

| N_vis × N_pix | DFT / NUFFT time |
|---:|---:|
| 1.3e6 | 0.21× |
| 2.6e6 | 0.27× |
| 5.2e6 | 0.70× |
| **1.0e7** | **1.16×** |
| 2.1e7 | 1.50× |
| 2.3e7 | 1.41× |
| 8.3e7 | 1.92× |

At a typical 64×64 mask that's ~5,000 visibilities — but on a 32×32 mask the DFT still wins at 4,000. Quoting a visibility count alone would be wrong on half the grids.

### Memory is the decisive axis

At fixed `N_vis=4000`, growing the grid:

| grid | N_pix | DFT ΔMB | NUFFT ΔMB |
|---|---:|---:|---:|
| 32² | 648 | 60 | 81 |
| 64² | 2 608 | 239 | **0** |
| 96² | 5 860 | 293 | **0** |
| 128² | 10 428 | 446 | **0** |

The DFT allocates with `N_vis × N_pix`; the NUFFT allocates nothing measurable beyond its working buffers. At 10.7 bytes/element that extrapolates to **~109 GB at 1M visibilities** — independently corroborating the ~123 GB figure `bd18a769` recorded by a different route, and confirming the NUFFT is the only feasible ALMA-scale path.

## Why an INFO and not a warning

`Interferometer` defaults to `TransformerNUFFT` (`dataset.py:34`). A "NUFFT below the crossover" **warning** would therefore fire on the default path for every small dataset — every tutorial, test and workspace example. That's warning fatigue for a ~2 s cost.

So the guidance is an INFO on the existing setup log, emitted only when a NUFFT-backed transformer is used below the crossover: an explicit, expensive, opt-in call, never fired when the advice would be moot. The genuinely dangerous direction is already a hard `DatasetException` above 10,000 visibilities with an opt-out, so nothing is left unguarded.

## API Changes

None — internal changes only. One added INFO log and docstring text; no signature, symbol or behaviour changes.

## Test Plan

- [x] Advisory fires for small+NUFFT; stays silent for small+DFT and for large+NUFFT (all three checked explicitly)
- [x] `pytest test_autoarray` — **1179 passed**
- [x] Diff is purely additive (29 insertions, 0 deletions) — the repo's black version wants to reformat an unrelated `DatasetException` block, and that churn was deliberately kept out

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6pH5eMAcAwjbfGUmCnwZF)_