### PR TITLE
docs(should_simulate): the point-source "not in this gap" note is repo-specific

### DIFF
--- a/autoarray/util/dataset_util.py
+++ b/autoarray/util/dataset_util.py
@@ -354,10 +354,28 @@ def should_simulate(dataset_path):
     the reach of a destructive predicate is its own change, with its own review,
     not a rider on the one that changes where its input comes from.
 
-    Note that point-source datasets are **not** in this gap: they write a
-    top-level ``data.fits`` alongside their JSON and are covered normally. The
-    original issue text grouped them with weak lensing as "JSON with no FITS";
-    that is true of weak lensing only.
+    Note that point-source datasets are **not** in this gap *in
+    ``autolens_workspace``*: there they write a top-level ``data.fits`` alongside
+    their JSON and are covered normally. The original issue text grouped them
+    with weak lensing as "JSON with no FITS"; that is true of weak lensing only
+    in that repo.
+
+    It is **not** true everywhere, and the exception is not hypothetical.
+    Whether a dataset family is reachable by the stamp is decided per repository
+    by that repo's ``.gitignore``, never by the family name.
+    ``autolens_workspace_test`` lists ``data.fits`` under "Generated artifacts —
+    never check in", so its ``dataset/point_source/simple`` is three tracked JSON
+    files and nothing else -- no stamp can exist there under any placement, and
+    the capped branch deleted that committed, allowlist-protected directory on
+    every smoke run (PyAutoArray#470, fixed workspace-side in
+    autolens_workspace_test#264).
+
+    So do not read this paragraph as "point-source is safe". Read it as "point
+    source is safe wherever a top-level ``data.fits`` is actually written".
+    ``PyAutoHands``' ``check_dataset_allowlist`` guard now fails a ``pre_build``
+    run when a ``should_simulate`` call site that has not released
+    ``PYAUTO_SMALL_DATASETS`` would delete git-tracked files, which is the
+    check this docstring cannot itself enforce.
     """
     if os.environ.get("PYAUTO_SMALL_DATASETS") == "1":
         if Path(dataset_path).exists() and not _is_capped_at_the_current_cap(


### PR DESCRIPTION
Docstring only — no behaviour change. Refs #470. Paired with PyAutoHands#253, which adds the guard that enforces what a docstring cannot.

## The wrong sentence

`should_simulate`'s "Known gap" section currently ends:

> Note that point-source datasets are **not** in this gap: they write a top-level `data.fits` alongside their JSON and are covered normally. The original issue text grouped them with weak lensing as "JSON with no FITS"; that is true of weak lensing only.

That holds in `autolens_workspace`. It is **false in `autolens_workspace_test`**, whose `.gitignore` lists `data.fits` under "Generated artifacts — never check in":

```
$ git -C autolens_workspace_test ls-files dataset/point_source/simple
dataset/point_source/simple/point_dataset_positions_only.json
dataset/point_source/simple/point_dataset_with_fluxes_and_time_delays.json
dataset/point_source/simple/tracer.json
```

No `data.fits` ⇒ no `SMALLDAT` stamp ⇒ `_is_capped_at_the_current_cap` returns False ⇒ the capped branch deletes the directory.

That is precisely the directory #470 was about, so as written the paragraph reassures the reader about the one case that actually bit us — a committed, allowlist-protected dataset destroyed on every smoke run and replaced with degenerate output (`PointSolver.solve` short-circuits to a fixed position pair under the cap).

## What it says now

The generalisation is replaced with the rule that actually governs: **whether a dataset family is reachable by the stamp is decided per repository by that repo's `.gitignore`, never by the family name.** "Point-source is safe" becomes "point-source is safe wherever a top-level `data.fits` is actually written", with the counter-example named.

It also points at `PyAutoHands`' `check_dataset_allowlist` guard (PyAutoHands#253), which fails a `pre_build` run when a `should_simulate` call site that has not released `PYAUTO_SMALL_DATASETS` would delete git-tracked files.

## Verification

`test_autoarray/util` — 88 passed. `-k "should_simulate or small_datasets"` — 8 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F11sMzmaVWfU6NCz1PKVVb